### PR TITLE
Added limits to data & summaries pulled from postgres.

### DIFF
--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -270,7 +270,7 @@ func (s *Storage) fetchNumericalResultHistogram(resultURI string, dataset string
 
 func (s *Storage) fetchCategoricalResultHistogram(resultURI string, dataset string, variable *model.Variable) (*model.Histogram, error) {
 	// Get count by category.
-	query := fmt.Sprintf("SELECT value, COUNT(*) AS count FROM %s WHERE result_id = $1 and target = $2 GROUP BY value;", dataset)
+	query := fmt.Sprintf("SELECT value, COUNT(*) AS count FROM %s WHERE result_id = $1 and target = $2 GROUP BY value ORDER BY count desc, value LIMIT %d;", dataset, catResultLimit)
 
 	// execute the postgres query
 	res, err := s.client.Query(query, resultURI, variable.Name)

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -10,6 +10,10 @@ import (
 	"github.com/unchartedsoftware/distil/api/model"
 )
 
+const (
+	catResultLimit = 10
+)
+
 func (s *Storage) getHistogramAggQuery(extrema *model.Extrema) (string, string) {
 	// compute the bucket interval for the histogram
 	interval := (extrema.Max - extrema.Min) / model.MaxNumBuckets
@@ -160,7 +164,7 @@ func (s *Storage) fetchNumericalHistogram(dataset string, variable *model.Variab
 
 func (s *Storage) fetchCategoricalHistogram(dataset string, variable *model.Variable) (*model.Histogram, error) {
 	// Get count by category.
-	query := fmt.Sprintf("SELECT \"%s\", COUNT(*) AS count FROM %s GROUP BY \"%s\";", variable.Name, dataset, variable.Name)
+	query := fmt.Sprintf("SELECT \"%s\", COUNT(*) AS count FROM %s GROUP BY \"%s\" ORDER BY count desc, \"%s\" LIMIT %d;", variable.Name, dataset, variable.Name, variable.Name, catResultLimit)
 
 	// execute the postgres query
 	res, err := s.client.Query(query)

--- a/api/model/variable.go
+++ b/api/model/variable.go
@@ -16,6 +16,8 @@ const (
 	VarNameField = "varName"
 	// VarTypeField is the field name for the variable type.
 	VarTypeField = "varType"
+	// VarTypeIndex is the variable type of the index field.
+	VarTypeIndex = "index"
 )
 
 // Variable represents a single variable description within a dataset.

--- a/api/routes/variable_summaries_test.go
+++ b/api/routes/variable_summaries_test.go
@@ -138,7 +138,7 @@ func TestVariableSummaryHandlerCategoricalPostgres(t *testing.T) {
 
 	// setup the expected query
 	mockDB.EXPECT().Query(
-		"SELECT \"Position\", COUNT(*) AS count FROM o_185 GROUP BY \"Position\";").Return(nil, nil)
+		"SELECT \"Position\", COUNT(*) AS count FROM o_185 GROUP BY \"Position\" ORDER BY count desc, \"Position\" LIMIT 10;").Return(nil, nil)
 
 	// execute the test request
 	res := mock.HTTPResponse(t, req, VariableSummaryHandler(storageCtor, ctorES))


### PR DESCRIPTION
When pulling back variable & result summaries & filtered data, limit the data returned. Specifically, categorical summaries return the top 10 sorted by count (descending) and then alphanumerically. The filtered data is limited to the first 500 rows ordered by the index field.

Should fix #68 