### PR TITLE
splits data table into two tables and adds parent component to manage

### DIFF
--- a/public/components/ResultsComparison.vue
+++ b/public/components/ResultsComparison.vue
@@ -1,0 +1,56 @@
+<template>
+	<div class="results-tables">
+		<results-data-table
+			class="results-data-table"
+			title="Correct Predictions"
+			:filterFunc="classificationMatchFilter"
+			:decorateFunc="classificationMatchDecorate"
+		></results-data-table>
+		<results-data-table class="results-data-table" title="Incorrect Predictions"
+			:filterFunc="classificationNoMatchFilter"
+			:decorateFunc="classificationNoMatchDecorate"
+		></results-data-table>
+	</div>
+</template>
+
+<script>
+import ResultsDataTable from '../components/ResultsDataTable';
+
+export default {
+	name: 'results-comparison',
+
+	components: {
+		ResultsDataTable,
+	},
+
+	methods: {
+		// Methods passed to result table instances to filter their displays.
+		classificationMatchFilter(dataItem) {
+			return dataItem[dataItem._target.truth] === dataItem[dataItem._target.predicted];
+		},
+		classificationNoMatchFilter(dataItem) {
+			return dataItem[dataItem._target.truth] !== dataItem[dataItem._target.predicted];
+		},
+		// Methods passed to result table instance to update their row visuals post-filter
+		classificationMatchDecorate(dataItem) {
+			dataItem._cellVariants = { [dataItem._target.predicted]: 'success' };
+			return dataItem;
+		},
+		classificationNoMatchDecorate(dataItem) {
+			dataItem._cellVariants = { [dataItem._target.predicted]: 'danger' };
+			return dataItem;
+		}
+	}
+};
+</script>
+
+<style>
+.results-tables {
+	display: flex;
+	flex-direction: column;
+}
+.results-data-table {
+	display: flex;
+	flex-direction: column;
+}
+</style>

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="results-data-table">
 		<div class="bg-faded rounded-top">
-			<h6 class="nav-link">Values</h6>
+			<h6 class="nav-link">{{title}}</h6>
 		</div>
 		<div class="results-data-table-container">
 			<div v-if="items.length===0">
@@ -26,10 +26,16 @@
 export default {
 	name: 'results-data-table',
 
+	props: [
+		'title',
+		'filterFunc',
+		'decorateFunc'
+	],
+
 	data() {
 		return {
 			perPage: 10,
-			currentPage: 1
+			currentPage: 1,
 		};
 	},
 
@@ -61,7 +67,9 @@ export default {
 		},
 		// extracts the table data from the store
 		items() {
-			return this.$store.getters.getResultDataItems();
+			const items = this.$store.getters.getResultDataItems();
+			return items.filter(this.filterFunc)
+				.map(this.decorateFunc);
 		},
 		// extract the table field header from the store
 		fields() {

--- a/public/store/actions.js
+++ b/public/store/actions.js
@@ -213,7 +213,7 @@ export function getResultsSummaries(context, args) {
 	// dispatch a request to fetch the results for each pipeline
 	for (var result of results) {
 		const name = result.name;
-		const pipelineId = result.pipelineId; 
+		const pipelineId = result.pipelineId;
 		const res = encodeURIComponent(result.pipeline.resultUri);
 		axios.get(`/distil/results-summary/${ES_INDEX}/${dataset}/${res}`)
 		.then(response => {
@@ -232,7 +232,7 @@ export function getResultsSummaries(context, args) {
 			// ensure buckets is not nil
 			histogram.buckets = histogram.buckets ? histogram.buckets : [];
 			histogram.name = name;
-			histogram.pipelineId = 
+			histogram.pipelineId =
 			context.commit('updateResultsSummaries', histogram);
 		})
 		.catch(error => {
@@ -250,7 +250,7 @@ export function getResultsSummaries(context, args) {
 
 // fetches result data for created pipeline
 export function updateResults(context, args) {
-	const encodedUri = encodeURIComponent(args.resultId); 
+	const encodedUri = encodeURIComponent(args.resultId);
 	axios.get(`/distil/results/${ES_INDEX}/${args.dataset}/${encodedUri}`)
 	.then(response => {
 		context.commit('setResultData', response.data);

--- a/public/store/getters.js
+++ b/public/store/getters.js
@@ -186,9 +186,7 @@ export function getResultDataItems(state, getters) {
 				for (const [j, colName] of resultData.columns.entries()) {
 					const label = `Predicted ${colName}`;
 					dataObj[label] = resultData.values[i][j];
-					if (dataObj[colName] !== resultData.values[i][j]) {
-						dataObj._cellVariants = { [label]: 'danger'};
-					}
+					dataObj._target = {truth: colName, predicted: label};
 				}
 			}
 			return dataRows;

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -1,20 +1,20 @@
 <template>
 	<div class="results">
 		<variable-summaries class="results-variable-summaries"></variable-summaries>
-		<results-data-table class="results-data-table"></results-data-table>
+		<results-comparison class="results-result-comparison"></results-comparison>
 		<result-summaries class="results-result-summaries"></result-summaries>
 	</div>
 </template>
 
 <script>
-import ResultsDataTable from '../components/ResultsDataTable';
+import ResultsComparison from '../components/ResultsComparison';
 import VariableSummaries from '../components/VariableSummaries';
 import ResultSummaries from '../components/ResultSummaries';
 
 export default {
 	name: 'results',
 	components: {
-		ResultsDataTable,
+		ResultsComparison,
 		VariableSummaries,
 		ResultSummaries
 	},
@@ -59,9 +59,7 @@ export default {
 .results-result-summaries {
 	width: 20%;
 }
-.results-data-table {
-	display: flex;
-	flex-direction: column;
+.results-result-comparison {
 	width: 60%;
 }
 </style>


### PR DESCRIPTION
First portion of result table split that focuses on classification results.  Splits results table into 2 parts- one for correct predictions, one for incorrect, and  creates new parent component to manage them.  This fixes #104, and will be refined to better handle regression as part of #105.