### PR TITLE
aligns pipeline values with latest d3m schema version

### DIFF
--- a/public/components/CreatePipelinesForm.vue
+++ b/public/components/CreatePipelinesForm.vue
@@ -92,7 +92,7 @@ export default {
 
 			const taskData = getTask(variable.type);
 			const task = taskData.schemaName;
-			const output = getOutputSchemaNames(taskData)[0];
+			const output = _.values(getOutputSchemaNames(taskData))[0];
 			const metric = getMetricSchemaName(this.metric);
 
 			// dispatch action that triggers request send to server

--- a/public/util/pipelines.js
+++ b/public/util/pipelines.js
@@ -96,7 +96,7 @@ const regressionMetrics = {
 	},
 	meanAbsoluteErr: {
 		displayName: 'Mean Absolute Error',
-		schemaName: 'mean_abs_err'
+		schemaName: 'mean_absolute_error'
 	},
 	rSquared: {
 		displayName: 'R Squared',
@@ -112,26 +112,14 @@ const classificationOutputs = {
 		displayName: 'Label',
 		schemaName: 'class_label'
 	}
-	// multilabel: {
-	// 	displayName: 'Multi Label',
-	// 	schemaName: 'multilabel'
-	// }
 };
 
 // output types used in regression tasks
 const regressionOutputs = {
 	regressionValue: {
-		displayName: 'Regression Value',
-		schemaName: 'regression_value'
+		displayName: 'Real',
+		schemaName: 'real'
 	}
-	// probability: {
-	// 	displayName: 'Probability',
-	// 	schemaName: 'probability'
-	// },
-	// generalScore: {
-	// 	displayName: 'General Score',
-	// 	schemaName: 'general_score'
-	// }
 };
 
 // classification task info


### PR DESCRIPTION
Some of the d3m schema names were changed in the TA3TA2 API proto def.  Those needed to be reflected in the client side code.

fixes #116 
