### PR TITLE
adds export and abort buttons

### DIFF
--- a/api/pipeline/client.go
+++ b/api/pipeline/client.go
@@ -117,6 +117,25 @@ func (c *Client) EndSession(ctx context.Context, id string) error {
 	return nil
 }
 
+// ExportPipeline will issue an export pipeline call to the pipeline compute server
+func (c *Client) ExportPipeline(ctx context.Context, sessionID string, pipelineID string, pipelineURI string) error {
+	// check for session
+	c.mu.Lock()
+	_, ok := c.sessions[sessionID]
+	c.mu.Unlock()
+	if !ok {
+		return errors.Errorf("session id `%s` is not recognized", sessionID)
+	}
+	// create start session request
+	req := GenerateExportPipelineRequest(sessionID, pipelineID, pipelineURI)
+	// execute the request
+	_, err := c.dispatchRequestSync(ctx, req.RequestFunc)
+	if err != nil {
+		return errors.Wrap(err, "failed to export pipeline")
+	}
+	return nil
+}
+
 func (c *Client) dispatchRequestSync(ctx context.Context, request RequestFunc) ([]*proto.Message, error) {
 	// execute the start session request
 	req := request(&ctx, &c.client)

--- a/api/pipeline/request.go
+++ b/api/pipeline/request.go
@@ -210,6 +210,22 @@ func GenerateEndSessionRequest(sessionID string) *RequestInfo {
 	return generateRequest(&sessionCtx, grpcFunc, msgHash)
 }
 
+// GenerateExportPipelineRequest creates a request that signals the pipeline compute server to export the
+// pipeline indicated by caller supplied pipeline ID.
+func GenerateExportPipelineRequest(sessionID string, pipelineID string, pipelineURI string) *RequestInfo {
+	exportRequest := PipelineExportRequest{
+		Context:         &SessionContext{sessionID},
+		PipelineId:      pipelineID,
+		PipelineExecUri: pipelineURI,
+	}
+	grpcFunc := func(client *CoreClient, ctx *context.Context, request proto.Message) (proto.Message, error) {
+		// execute the export pipeline request
+		return (*client).ExportPipeline(*ctx, &exportRequest)
+	}
+	hashFunc := func(msg proto.Message, id uuid.UUID) uint64 { return hash(id.Bytes()) }
+	return generateRequest(&exportRequest, grpcFunc, hashFunc)
+}
+
 // HashInclude satisifies the Includable interface from hashstructure package, and  allows
 // for the context field to be skipped when generating a hash for the PiplineCreateRequest
 // struct.

--- a/api/routes/abort.go
+++ b/api/routes/abort.go
@@ -1,0 +1,18 @@
+package routes
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/unchartedsoftware/plog"
+)
+
+// AbortHandler terminates the server.  Yes, this is intentional.  Its part of the
+// eval protocol.  Don't look at me like that.
+func AbortHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Info("Received abort request - shutting down")
+		os.Exit(0)
+		return
+	}
+}

--- a/api/routes/export.go
+++ b/api/routes/export.go
@@ -1,0 +1,33 @@
+package routes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"goji.io/pat"
+
+	"github.com/unchartedsoftware/distil/api/pipeline"
+	"github.com/unchartedsoftware/plog"
+)
+
+// ExportHandler exports the caller supplied pipeline by calling through to the compute
+// server export functionality.
+func ExportHandler(client *pipeline.Client) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// extract route parameters
+		pipelineID := pat.Param(r, "pipeline-id")
+		sessionID := pat.Param(r, "session")
+		exportURI := fmt.Sprintf("file:///%s.d3m", pipelineID)
+
+		err := client.ExportPipeline(context.Background(), sessionID, pipelineID, exportURI)
+		if err != nil {
+			log.Info("Failed pipeline export request to %s", exportURI)
+		} else {
+			log.Info("Completed export request to %s", exportURI)
+		}
+		os.Exit(0)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -140,6 +140,9 @@ func main() {
 	registerRoute(mux, "/distil/results/:index/:dataset/:results-uuid", routes.ResultsHandler(dataStorageCtor))
 	registerRoute(mux, "/distil/results-summary/:index/:dataset/:results-uuid", routes.ResultsSummaryHandler(dataStorageCtor))
 	registerRoute(mux, "/distil/session/:session", routes.SessionHandler(dataStorageCtor))
+	registerRoute(mux, "/distil/abort", routes.AbortHandler())
+	registerRoute(mux, "/distil/export/:session/:pipeline-id", routes.ExportHandler(pipelineClient))
+
 	registerRoute(mux, "/ws", ws.PipelineHandler(pipelineClient, esClientCtor, dataStorageCtor))
 	registerRoute(mux, "/*", routes.FileHandler("./dist"))
 

--- a/public/components/NavBar.vue
+++ b/public/components/NavBar.vue
@@ -3,7 +3,8 @@
 
 		<b-nav-toggle target="nav_collapse"></b-nav-toggle>
 
-		<i class="fa fa-rebel navbar-brand app-icon"></i>
+		<!-- <i class="fa fa-empire navbar-brand app-icon"></i> -->
+		<img src="/favicons/favicon-32x32.png" class="app-icon"></img>
 		<span class="navbar-brand">Distil</span>
 
 		<b-collapse is-nav id="nav_collapse">
@@ -15,21 +16,15 @@
 				<b-nav-item @click="onPipelines" :active="activeView===PIPELINES" :disabled="!hasDataset()">Pipelines</b-nav-item>
 				<b-nav-item @click="onResults" :active="activeView===RESULTS">Results</b-nav-item>
 			</b-nav>
-			<!--
 			<b-nav is-nav-bar class="ml-auto">
-				<b-nav-text class="session-label">Session:</b-nav-text>
-				<b-nav-text v-if="sessionID===null" class="session-not-ready">
-					<i class="fa fa-close"></i>Unavailable
-				</b-nav-text>
-				<b-nav-text v-if="sessionID!==null" class="session-ready">
-					<i class="fa fa-check"></i>{{sessionID}}
-				</b-nav-text>
-			</b-nav>
-			-->
-			<b-nav is-nav-bar class="ml-auto">
-				<b-nav is-nav-bar>
-					<b-nav-item href="/help">Help</b-nav-item>
-				</b-nav>
+				<b-nav-item href="/help">Help</b-nav-item>
+				<b-btn v-b-modal.abort size="sm" variant="outline-danger" class="abort-button">Abort</b-btn>
+				<b-modal id="abort" title="Abort" @ok="onAbort">
+					<div>
+						<i class="fa fa-exclamation-triangle fa-3x abort-icon"></i>
+						This action will terminate the session.
+					</div>
+				</b-modal>
 			</b-nav>
 		</b-collapse>
 	</b-navbar>
@@ -74,12 +69,6 @@ export default {
 		this.$store.dispatch('getPipelineSession');
 	},
 
-	computed: {
-		sessionID() {
-			return this.$store.getters.getPipelineSessionID();
-		}
-	},
-
 	methods: {
 		onHome() {
 			gotoHome(this.$store, this.$router);
@@ -98,6 +87,10 @@ export default {
 		},
 		onResults() {
 			gotoResults(this.$store, this.$router);
+		},
+		onAbort() {
+			this.$router.replace('/');
+			this.$store.dispatch('abort');
 		},
 		hasDataset() {
 			return !!this.$store.getters.getRouteDataset();
@@ -123,7 +116,14 @@ export default {
 	color: #00c07f !important;
 }
 .app-icon {
-	color: #cf3835 !important;
+	padding-right: 5px;
+}
+.abort-icon {
+	vertical-align: middle;
+	color:#cf3835;
+}
+.abort-button {
+	margin-left: 20px;
 }
 .session-label {
 	padding-right: 4px

--- a/public/components/ResultFacets.vue
+++ b/public/components/ResultFacets.vue
@@ -74,6 +74,7 @@ export default {
 								enabled: true
 							}
 						}, activeResult.pipeline.resultUri);
+						this.$emit('activePipelineChange', { name: activeResult.name, id: activeResult.pipelineId });
 					}
 				});
 			}
@@ -130,6 +131,8 @@ export default {
 					enabled: true
 				}
 			}, completedReq.pipeline.resultUri);
+			// let listening components know the acitive pipeline changed
+			this.$emit('activePipelineChange', { name: completedReq.name, id: completedReq.pipelineId });
 		},
 
 		onCollapse() {

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -5,26 +5,28 @@
 			<div class="result-summaries-label">
 				Error:
 			</div>
-			<div  class="result-summaries-slider">
-				<vue-slider
-					ref="slider"
-					:v-model="value"
-					:min="0"
-					:max="maxVal"
-					:lazy="true"
-					width=100%
-					tooltip-dir="bottom"
-					@callback="onSlide"/>
+			<div class="result-summaries-slider">
+				<vue-slider ref="slider" :v-model="value" :min="0" :max="maxVal" :lazy="true" width=100% tooltip-dir="bottom" @callback="onSlide" />
 			</div>
 		</div>
 		<h6 class="nav-link">Actual</h6>
 		<facets class="result-summaries-target" :groups="targetSummaries"></facets>
 		<h6 class="nav-link">Predicted</h6>
-		<result-facets
+		<result-facets 
+			v-on:activePipelineChange="onPipelineUpdate($event)" 
 			enable-group-collapse
 			enable-facet-filtering
 			:variables="variables"
 			:dataset="dataset"></result-facets>
+		<div class="check-button-container">
+			<b-btn v-b-modal.export variant="outline-success" class="check-button">Export Pipeline</b-btn>
+			<b-modal id="export" title="Export" @ok="onExport">
+				<div class="check-message-container">
+					<i class="fa fa-check-circle fa-3x check-icon"></i>
+					<div>This action will export pipeline <b>{{activePipelineName}}</b> and terminate the session.</div>
+				</div>
+			</b-modal>
+		</div>
 	</div>
 </template>
 
@@ -50,7 +52,9 @@ export default {
 
 	data() {
 		return {
-			value: this.minVal
+			value: this.minVal,
+			activePipelineName: null,
+			activePipelineId: null
 		};
 	},
 
@@ -101,13 +105,26 @@ export default {
 			}
 			const task = getTask(targetVar.type);
 			return task.schemaName === 'regression';
-		}
+		},
 	},
 
 	methods: {
 		onSlide(value) {
 			const entry = createRouteEntryFromRoute(this.$route, { residualThreshold: value });
 			this.$router.push(entry);
+		},
+
+		onExport() {
+			this.$router.replace('/');
+			this.$store.dispatch('exportPipeline', {
+				pipelineId: this.activePipelineId,
+				sessionId: this.$store.state.pipelineSession.id
+			});
+		},
+
+		onPipelineUpdate(args) {
+			this.activePipelineName = args.name;
+			this.activePipelineId = args.id;
 		}
 	}
 };
@@ -118,45 +135,83 @@ export default {
 	display: flex;
 	flex-direction: column;
 }
+
 .result-summaries-target {
 	margin-bottom: 12px;
 }
+
 .result-summaries-target .facets-group {
 	box-shadow: none;
 }
+
 .result-summaries-target .facets-facet-horizontal .facet-histogram-bar-highlighted {
 	fill: #00C851;
 }
+
 .result-summaries-target .facets-facet-horizontal .facet-histogram-bar-highlighted:hover {
-	  fill: #007E33;
+	fill: #007E33;
 }
+
 .result-summaries-target .facets-facet-vertical .facet-bar-selected {
 	box-shadow: inset 0 0 0 1000px #00C851;
 }
+
 .result-summaries-target .facets-facet-horizontal .facet-range-filter {
 	box-shadow: inset 0 0 0 1000px rgba(0, 225, 11, 0.15);
 }
+
 .result-summaries-error {
 	display: flex;
 	flex-direction: row;
 	justify-content: flex-start;
 	margin-bottom: 30px;
 }
+
 .result-summaries-label {
 	display: flex;
-	flex-basis:auto;
-	margin-left:10px;
-	margin-right:15px;
+	flex-basis: auto;
+	margin-left: 10px;
+	margin-right: 15px;
 }
+
 .result-summaries-slider {
 	display: flex;
 	flex-grow: 1;
 }
+
 .result-summaries-slider .vue-slider-component .vue-slider-process {
-	background-color:#00C851;
+	background-color: #00C851;
 }
+
 .result-summaries-slider .vue-slider-component .vue-slider-tooltip {
 	border: 1px solid #00C851;
-    background-color: #00C851;
+	background-color: #00C851;
+}
+
+.check-message-container {
+	display: flex;
+	justify-content: flex-start;
+	flex-direction: row;
+	align-items: center;
+}
+
+.check-icon {
+	display: flex;
+	flex-shrink: 0;
+	color:#00C851;
+	padding-right: 15px;
+}
+
+.check-button-container {
+	margin-top: 15px;
+	display: flex;
+	justify-content: center;
+}
+
+.check-button {
+	display: flex;
+	margin-top: 15px;
+	flex-basis: 60%;
+	justify-content: center;
 }
 </style>

--- a/public/store/actions.js
+++ b/public/store/actions.js
@@ -324,3 +324,23 @@ export function highlightFeatureValues(context, highlight) {
 export function clearFeatureHighlightValues(context) {
 	context.commit('clearFeatureHighlightValues');
 }
+
+export function abort() {
+	return axios.get('/distil/abort')
+	.then(() => {
+		console.log('User initiated session abort');
+	})
+	.catch(error => {
+		console.error(`Failed to abort with error ${error}`);
+	});
+}
+
+export function exportPipeline(context, args) {
+	return axios.get(`/distil/export/${args.sessionId}/${args.pipelineId}`)
+	.then(() => {
+		console.log(`User exported pipeline ${args.pipelineId}`);
+	})
+	.catch(error => {
+		console.error(`Failed to export with error ${error}`);
+	});
+}


### PR DESCRIPTION
Adds an abort button to the nav bar that will kill the app server and return to the home screen, and an export button that will make the export call to ta2, kill the app server and return to the home screen.  We will have the container in auto-restart mode so the server will come back up.