### PR TITLE
updates to Vue 2.5 and fixes refs usage bug it introduces

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "jquery": "3.2.1",
     "lodash": "4.17.4",
     "popper.js": "^1.12.5",
-    "vue": "2.4.4",
-    "vue-router": "2.7.0",
+    "vue": "^2.5.2",
+    "vue-router": "^3.0.1",
     "vue-slider-component": "2.4.1",
-    "vue-template-compiler": "2.4.4",
-    "vuex": "2.4.1",
-    "vuex-router-sync": "4.3.2"
+    "vue-template-compiler": "^2.5.2",
+    "vuex": "^3.0.0",
+    "vuex-router-sync": "^5.0.0"
   },
   "devDependencies": {
     "babel-core": "6.26.0",

--- a/public/components/Facets.vue
+++ b/public/components/Facets.vue
@@ -28,7 +28,7 @@ export default {
 	mounted() {
 		const component = this;
 		// instantiate the external facets widget
-		this.facets = new Facets(this.$refs.facets, this.groups.map(group => {
+		this.facets = new Facets(this.$el, this.groups.map(group => {
 			return _.cloneDeep(group);
 		}));
 		this.groups.forEach(group => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4371,9 +4371,9 @@ vue-loader@13.0.5:
     vue-style-loader "^3.0.0"
     vue-template-es2015-compiler "^1.5.3"
 
-vue-router@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-2.7.0.tgz#16d424493aa51c3c8cce8b7c7210ea4c3a89aff1"
+vue-router@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.0.1.tgz#d9b05ad9c7420ba0f626d6500d693e60092cc1e9"
 
 vue-slider-component@2.4.1:
   version "2.4.1"
@@ -4386,9 +4386,9 @@ vue-style-loader@^3.0.0:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
 
-vue-template-compiler@2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.4.4.tgz#2cde3b704124985c27d50b5387c9691ba515fb57"
+vue-template-compiler@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.5.2.tgz#6f198ebc677b8f804315cd33b91e849315ae7177"
   dependencies:
     de-indent "^1.0.2"
     he "^1.1.0"
@@ -4397,17 +4397,17 @@ vue-template-es2015-compiler@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.3.tgz#22787de4e37ebd9339b74223bc467d1adee30545"
 
-vue@2.4.4:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.4.4.tgz#ea9550b96a71465fd2b8b17b61673b3561861789"
+vue@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.2.tgz#fd367a87bae7535e47f9dc5c9ec3b496e5feb5a4"
 
-vuex-router-sync@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/vuex-router-sync/-/vuex-router-sync-4.3.2.tgz#604b61a377daaa68b2ef6e8e0326b2cad26f359e"
+vuex-router-sync@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vuex-router-sync/-/vuex-router-sync-5.0.0.tgz#1a225c17a1dd9e2f74af0a1b2c62072e9492b305"
 
-vuex@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/vuex/-/vuex-2.4.1.tgz#7890b650ba8565b70937b4e7670577082dfe8bc1"
+vuex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.0.0.tgz#98b4b5c4954b1c1c1f5b29fa0476a23580315814"
 
 watchpack@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Updates to Vue to 2.5.2, and brings other vue libs in line.  In testing an issue was found where only a single instance of the facets would display - so in the select screen we saw training variables facets, while available variables was empty.  This ended up being an issue (maybe race condition?) introduced by Vue 2.5.2 whereby the `$refs.facets` attribute in the `mount()` call for `Facets.vue` was undefined.  Using `$el` returns the component we want directly, and was populated by the time `mount` was called. 