### PR TITLE
moves table highlight computation out of getter

### DIFF
--- a/public/components/ExploreDataTable.vue
+++ b/public/components/ExploreDataTable.vue
@@ -36,24 +36,30 @@ import Vue from 'vue';
 import { getters as dataGetters } from '../store/data/module';
 import { getters as routeGetters } from '../store/route/module';
 import { actions } from '../store/data/module';
+import { Dictionary } from '../store/data/index';
+import { FilterMap } from '../util/filters';
+import { FieldInfo } from '../store/data/getters';
+import { updateTableHighlights } from '../util/highlights';
 
 export default Vue.extend({
 	name: 'explore-data-table',
 
 	computed: {
 		// get dataset from route
-		dataset() {
+		dataset(): string {
 			return routeGetters.getRouteDataset(this.$store);
 		},
 		// extracts the table data from the store
-		items() {
-			return dataGetters.getFilteredDataItems(this.$store);
+		items(): Dictionary<any> {
+			const data = dataGetters.getFilteredDataItems(this.$store);
+			updateTableHighlights(data, dataGetters.getHighlightedFeatureRanges(this.$store));
+			return data;
 		},
 		// extract the table field header from the store
-		fields() {
+		fields(): Dictionary<FieldInfo> {
 			return dataGetters.getFilteredDataFields(this.$store);
 		},
-		filters() {
+		filters(): FilterMap {
 			return routeGetters.getDecodedFilters(this.$store);
 		}
 	},
@@ -78,14 +84,16 @@ export default Vue.extend({
 				filters: this.filters
 			});
 		},
-		onTypeChange(field, suggested) {
+
+		onTypeChange(field: { label: string }, suggested: { type: string }) {
 			actions.setVariableType(this.$store, {
 				dataset: this.dataset,
 				field: field.label,
 				type: suggested.type
 			});
 		},
-		onRowHovered(event) {
+
+		onRowHovered(event: Event) {
 			// set new values
 			const highlights = {};
 			_.forIn(this.fields, (field, key) => {
@@ -93,6 +101,7 @@ export default Vue.extend({
 			});
 			actions.highlightFeatureValues(this.$store, highlights);
 		},
+
 		onMouseOut() {
 			actions.clearFeatureHighlightValues(this.$store);
 		}

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -37,6 +37,7 @@ import _ from 'lodash';
 import Vue from 'vue';
 import { getters as dataGetters, actions } from '../store/data/module';
 import { getters as routeGetters } from '../store/route/module';
+import { updateTableHighlights } from '../util/highlights';
 
 export default Vue.extend({
 	name: 'selected-data-table',
@@ -48,7 +49,9 @@ export default Vue.extend({
 		},
 		// extracts the table data from the store
 		items() {
-			return dataGetters.getSelectedDataItems(this.$store);
+			const data = dataGetters.getSelectedDataItems(this.$store);
+			updateTableHighlights(data, dataGetters.getHighlightedFeatureRanges(this.$store));
+			return data;
 		},
 		// extract the table field header from the store
 		fields() {

--- a/public/store/data/getters.ts
+++ b/public/store/data/getters.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { Variable, Data, DataState, Dictionary, Datasets, VariableSummary } from './index';
 import { FilterMap } from '../../util/filters';
+import { Range } from './index';
 
 function getTargetIndexFromPredicted(columns: string[], predictedIndex: number) {
 	const targetName = columns[predictedIndex].replace('_res', '');
@@ -135,11 +136,6 @@ export const getters = {
 				for (const [index, col] of state.filteredData.columns.entries()) {
 					row[col] = d[index];
 				}
-				_.forIn(state.highlightedFeatureRanges, (range, name) => {
-					if (row[name] >= range.from && row[name] <= range.to) {
-						row._rowVariant = 'info';
-					}
-				});
 				return row;
 			});
 		}
@@ -196,14 +192,6 @@ export const getters = {
 				if (errorIdx >= 0) {
 					row._target.error = resultData.columns[errorIdx];
 				}
-				// if row is in the current highlght range, set its style to info
-				// TODO: this shouldn't be in the getter because it causes the entire
-				// function to re-run whenever the high changes
-				_.forIn(state.highlightedFeatureRanges, (range, name) => {
-					if (row[name] >= range.from && row[name] <= range.to) {
-						row._rowVariant = 'info';
-					}
-				});
 				return row;
 			});
 		}
@@ -268,11 +256,6 @@ export const getters = {
 				for (const [index, col] of state.selectedData.columns.entries()) {
 					row[col] = d[index];
 				}
-				_.forIn(state.highlightedFeatureRanges, (range, name) => {
-					if (row[name] >= range.from && row[name] <= range.to) {
-						row._rowVariant = 'info';
-					}
-				});
 				return row;
 			});
 		}
@@ -306,5 +289,9 @@ export const getters = {
 
 	getHighlightedFeatureValues(state: DataState): Dictionary<any> {
 		return state.highlightedFeatureValues;
+	},
+
+	getHighlightedFeatureRanges(state: DataState): Range {
+		return state.highlightedFeatureRanges;
 	}
 }

--- a/public/store/data/module.ts
+++ b/public/store/data/module.ts
@@ -38,7 +38,8 @@ export const getters = {
 	getSelectedData: read(moduleGetters.getSelectedData),
 	getSelectedDataItems: read(moduleGetters.getSelectedDataItems),
 	getSelectedDataFields: read(moduleGetters.getSelectedDataFields),
-	getHighlightedFeatureValues: read(moduleGetters.getHighlightedFeatureValues)
+	getHighlightedFeatureValues: read(moduleGetters.getHighlightedFeatureValues),
+	getHighlightedFeatureRanges: read(moduleGetters.getHighlightedFeatureRanges)
 }
 
 // Typed actions

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -1,0 +1,22 @@
+import { Dictionary, Range } from '../store/data/index';
+import _ from 'lodash';
+
+// Updates table rows that fall into the highlight range
+export function updateTableHighlights(data: Dictionary<any>, highlightRanges: Range) {
+	// if highlight feature ranges is empty, clear everything
+	if (_.isEmpty(highlightRanges)) {
+		_.forEach(data, row => row._rowVariant = null);
+		return;
+	}
+
+	// highlight any table row that has a value in the feature range
+	_.forIn(data, row => {
+		_.forIn(highlightRanges, (range, name) => {
+			if (row[name] >= range.from && row[name] <= range.to) {
+				row._rowVariant = 'info';
+			} else {
+				row._rowVariant = null;
+			}
+		});
+	});
+}


### PR DESCRIPTION
Table highlght computation was being done as part of the getter that created table data from raw results.  This resulted in the getter being re-run every time the highlight changed.  Moving the highlght computation into the component lets the table data conversion results get cached.