### PR TITLE
disables cache to prevent stale summary data being returned to client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,4 @@ postgres:
     - "5432:5432"
   command:
     -d postgres
-redis:
-  image:
-    redis:latest
-  ports:
-    - "6379:6379"
-  command:
-    redis-server --save "" --appendonly no
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ import (
 	pg "github.com/unchartedsoftware/distil/api/model/storage/postgres"
 	"github.com/unchartedsoftware/distil/api/pipeline"
 	"github.com/unchartedsoftware/distil/api/postgres"
-	"github.com/unchartedsoftware/distil/api/redis"
 	"github.com/unchartedsoftware/distil/api/routes"
 	"github.com/unchartedsoftware/distil/api/ws"
 )
@@ -86,15 +85,10 @@ func main() {
 	}
 	defer pipelineClient.Close()
 
-	// instantiate redis pool
-	redisPool := redis.NewPool(config.RedisEndpoint, config.RedisExpiry)
-
 	// register routes
 	mux := goji.NewMux()
-
 	mux.Use(middleware.Log)
 	mux.Use(middleware.Gzip)
-	mux.Use(middleware.Redis(redisPool))
 
 	registerRoute(mux, "/distil/datasets/:index", routes.DatasetsHandler(metadataStorageCtor))
 	registerRoute(mux, "/distil/variables/:index/:dataset", routes.VariablesHandler(metadataStorageCtor))


### PR DESCRIPTION
Redis caches by method/URL/body.  Changing the type of a variable would update data on the server, but the subsequent summary fetch would return the cached value since there is no invalidation.  We've removed the cache middleware for now, but it should be re-instated at some point with a proper invalidation strategy.

fixes #197 
