### PR TITLE
improves result col names and simplifies client side handling

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -85,6 +85,16 @@ func (s *Storage) buildFilteredQueryField(dataset string, variables []*model.Var
 	return strings.Join(fields, ","), nil
 }
 
+func (s *Storage) buildFilteredResultQueryField(dataset string, variables []*model.Variable, targetVariable *model.Variable, filterParams *model.FilterParams, inclusive bool) (string, error) {
+	fields := make([]string, 0)
+	for _, variable := range model.GetFilterVariables(filterParams, variables, inclusive) {
+		if strings.Compare(targetVariable.Name, variable.Name) != 0 {
+			fields = append(fields, fmt.Sprintf("\"%s\"", variable.Name))
+		}
+	}
+	return strings.Join(fields, ","), nil
+}
+
 // FetchData creates a postgres query to fetch a set of rows.  Applies filters to restrict the
 // results to a user selected set of fields, with rows further filtered based on allowed ranges and
 // categories.

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -43,6 +43,7 @@ import { createGroups, Group } from '../util/facets';
 import { createRouteEntryFromRoute } from '../util/routes';
 import { getPipelineResultById } from '../util/pipelines';
 import { getTask } from '../util/pipelines';
+import { getErrorCol } from '../util/data';
 import { getters as dataGetters} from '../store/data/module';
 import { getters as routeGetters } from '../store/route/module';
 import { actions } from '../store/app/module';
@@ -97,8 +98,10 @@ export default Vue.extend({
 
 		minVal(): number {
 			const resultItems = dataGetters.getResultDataItems(this.$store) as { [name: string]: any }[];
-			if (!_.isEmpty(resultItems) && _.has(resultItems[0], 'error')) {
-				const minErr = Math.abs(_.minBy(resultItems, r => Math.abs(r.error)).error);
+			const errorCol = getErrorCol(routeGetters.getRouteTargetVariable(this.$store));
+			if (!_.isEmpty(resultItems) && _.has(resultItems[0], errorCol)) {
+				const min = _.minBy(resultItems, r => Math.abs(<number>(r[errorCol])));
+				const minErr = Math.abs(<number>(min[errorCol]));
 				// round to closest 2 decimal places, otherwise interval computation makes the slider angry
 				return Math.ceil(100 * minErr) / 100;
 			}
@@ -106,9 +109,11 @@ export default Vue.extend({
 		},
 
 		maxVal(): number {
-			const resultItems = dataGetters.getResultDataItems(this.$store) as { [name: string]: any }[]	;
-			if (!_.isEmpty(resultItems) && _.has(resultItems[0], 'error')) {
-				const maxErr = Math.abs(_.maxBy(resultItems, r => Math.abs(r.error)).error);
+			const resultItems = dataGetters.getResultDataItems(this.$store) as { [name: string]: any }[];
+			const errorCol = getErrorCol(routeGetters.getRouteTargetVariable(this.$store));
+			if (!_.isEmpty(resultItems) && _.has(resultItems[0], errorCol)) {
+				const max = _.maxBy(resultItems, r => Math.abs(<number>(r[errorCol])));
+				const maxErr = Math.abs(<number>max[errorCol]);
 				// round to closest 2 decimal places, otherwise interval computation makes the slider angry
 				return Math.ceil(100 * maxErr) / 100;
 			}

--- a/public/components/ResultsComparison.vue
+++ b/public/components/ResultsComparison.vue
@@ -26,6 +26,7 @@ import Vue from 'vue';
 import { getters as dataGetters} from '../store/data/module';
 import { getters as routeGetters} from '../store/route/module';
 import { actions } from '../store/data/module';
+import { getTargetCol, getPredictedCol, getErrorCol } from '../util/data';
 import { PipelineState, PipelineInfo } from '../store/pipelines/index';
 import { Variable, TargetRow } from '../store/data/index';
 import { getPipelineResults } from '../util/pipelines';
@@ -130,26 +131,26 @@ export default Vue.extend({
 
 		// Methods passed to classification result table instances to filter their displays.
 		classificationMatchFilter(dataItem: TargetRow): boolean {
-			return dataItem[dataItem._target.truth] === dataItem[dataItem._target.predicted];
+			return dataItem[getTargetCol(this.target)] === dataItem[getPredictedCol(this.target)];
 		},
 
 		classificationNoMatchFilter(dataItem: TargetRow): boolean {
-			return dataItem[dataItem._target.truth] !== dataItem[dataItem._target.predicted];
+			return dataItem[getTargetCol(this.target)] !== dataItem[getPredictedCol(this.target)];
 		},
 
 		// Methods passed to classification result table instance to update their row visuals post-filter
 		classificationMatchDecorate(dataItem: TargetRow): TargetRow {
 			dataItem._cellVariants = {
-				[dataItem._target.truth]: 'primary',
-				[dataItem._target.predicted]: 'success'
+				[getTargetCol(this.target)]: 'primary',
+				[getPredictedCol(this.target)]: 'success'
 			};
 			return dataItem;
 		},
 
 		classificationNoMatchDecorate(dataItem: TargetRow): TargetRow {
 			dataItem._cellVariants = {
-				[dataItem._target.truth]: 'primary',
-				[dataItem._target.predicted]: 'danger'
+				[getTargetCol(this.target)]: 'primary',
+				[getPredictedCol(this.target)]: 'danger'
 			};
 			return dataItem;
 		},
@@ -158,20 +159,20 @@ export default Vue.extend({
 
 		regressionInRangeFilter(dataItem: TargetRow): boolean {
 			// grab the residual threshold slider value and update
-			return Math.abs(dataItem[dataItem._target.error]) <= _.toNumber(this.residualThreshold);
+			return Math.abs(dataItem[getErrorCol(this.target)]) <= _.toNumber(this.residualThreshold);
 		},
 
 		regressionOutOfRangeFilter(dataItem: TargetRow): boolean {
-			return Math.abs(dataItem[dataItem._target.error]) > _.toNumber(this.residualThreshold);
+			return Math.abs(dataItem[getErrorCol(this.target)]) > _.toNumber(this.residualThreshold);
 		},
 
 		// Methods passed to classification result table instance to update their row visuals post-filter
 
 		regressionInRangeDecorate(dataItem: TargetRow): TargetRow {
 			dataItem._cellVariants = {
-				[dataItem._target.truth]: 'primary',
-				[dataItem._target.predicted]: 'success',
-				[dataItem._target.error]: 'success'
+				[getTargetCol(this.target)]: 'primary',
+				[getPredictedCol(this.target)]: 'success',
+				[getErrorCol(this.target)]: 'success'
 			};
 			return dataItem;
 		},
@@ -180,9 +181,9 @@ export default Vue.extend({
 
 		regressionOutOfRangeDecorate(dataItem: TargetRow): TargetRow {
 			dataItem._cellVariants = {
-				[dataItem._target.truth]: 'primary',
-				[dataItem._target.predicted]: 'warning',
-				[dataItem._target.error]: 'warning'
+				[getTargetCol(this.target)]: 'primary',
+				[getPredictedCol(this.target)]: 'warning',
+				[getErrorCol(this.target)]: 'warning'
 			};
 			return dataItem;
 		}

--- a/public/store/data/index.ts
+++ b/public/store/data/index.ts
@@ -53,14 +53,7 @@ export interface FieldInfo {
 	sortable: boolean
 }
 
-export interface TargetInfo {
-	predicted: string;
-	truth: string;
-	error?: string;
-}
-
 export interface TargetRow {
-	_target: TargetInfo;
 	_cellVariants?: Dictionary<string>;
 }
 

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -8,6 +8,11 @@ import { ActionContext } from 'vuex';
 import axios from 'axios';
 import Vue from 'vue';
 
+
+export const PREDICTED_POSTFIX = '_predicted';
+export const TARGET_POSTFIX = '_target';
+export const ERROR_POSTFIX = '_error';
+
 export type DataContext = ActionContext<DataState, DistilState>;
 
 // filters datasets by id
@@ -34,17 +39,15 @@ export function addRecentDataset(dataset: string) {
 }
 
 export function isInTrainingSet(col: string, training: Dictionary<boolean>) {
-	return (isPredictedIndex(col) ||
-		isErrorIndex(col) ||
+	return (isPredicted(col) ||
+		isError(col) ||
 		isTarget(col) ||
 		training[col]);
 }
 
 export function removeNonTrainingItems(items: TargetRow[], training: Dictionary<boolean>):  TargetRow[] {
 	return _.map(items, item => {
-		const row = {
-			_target: item._target
-		};
+		const row: TargetRow = {};
 		_.forIn(item, (val, col) => {
 			if (isInTrainingSet(col.toLowerCase(), training)) {
 				row[col] = val;
@@ -64,23 +67,40 @@ export function removeNonTrainingFields(fields: Dictionary<FieldInfo>, training:
 	return res;
 }
 
-export function isPredictedIndex(col: string) {
-	return col.endsWith('_res');
+export function isPredicted(col: string): boolean {
+	return col.endsWith(PREDICTED_POSTFIX);
 }
 
-export function isErrorIndex(col: string) {
-	return col === 'error';
+export function isError(col: string): boolean {
+	return col.endsWith(ERROR_POSTFIX);
 }
 
-export function isTarget(col: string) {
-	return col === '_target';
-}
-export function getPredictedIndex(columns: string[]) {
-	return _.findIndex(columns, isPredictedIndex);
+export function isTarget(col: string): boolean {
+	return col.endsWith(TARGET_POSTFIX);
 }
 
-export function getErrorIndex(columns: string[]) {
-	return _.findIndex(columns, isErrorIndex);
+export function getPredictedIndex(columns: string[]): number {
+	return _.findIndex(columns, isPredicted);
+}
+
+export function getErrorIndex(columns: string[]): number {
+	return _.findIndex(columns, isError);
+}
+
+export function getTargetIndex(columns: string[]): number {
+	return _.findIndex(columns, isTarget);
+}
+
+export function getTargetCol(target: string): string {
+	return target + TARGET_POSTFIX;
+}
+
+export function getPredictedCol(target: string): string {
+	return target + PREDICTED_POSTFIX;
+}
+
+export function getErrorCol(target: string): string {
+	return target + ERROR_POSTFIX;
 }
 
 export function updateSummaries(summary: VariableSummary, summaries: VariableSummary[], matchField: string) {


### PR DESCRIPTION
On the server side, renames the target column `<varname>_target`, the predicted column `<varname>_predicted` and the computed error (if regression) `<varname>_error`.  On the client side, the code for processing the columns has been updated to take advantage of the new structured naming.