### PR TITLE
allows command line config path to override env var

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -58,6 +58,11 @@ func LoadConfig() (Config, error) {
 }
 
 func overideFromStartupFile(cfg *Config) error {
+	// Override env/default value with the command line value if set.
+	if len(os.Args) > 1 {
+		cfg.StartupConfigFile = os.Args[1]
+	}
+
 	// read startup config JSON file
 	startupConfig, err := ioutil.ReadFile(cfg.StartupConfigFile)
 	if err != nil {

--- a/deploy/data/ta3_search
+++ b/deploy/data/ta3_search
@@ -1,2 +1,2 @@
 #!/bin/sh
-./distil
+./distil $1


### PR DESCRIPTION
Allows for NIST eval framework to pass the path to their config file as the first (and currently only) command line argument.