### PR TITLE
Result facet highlights

### DIFF
--- a/public/components/Facets.vue
+++ b/public/components/Facets.vue
@@ -63,15 +63,9 @@ export default Vue.extend({
 			component.$emit('histogram-mouse-leave', key);
 		});
 		this.facets.on('facet:mouseenter', (event: Event, key: string, value: number) => {
-			// actions.highlightFeatureRange(this.$store, {
-			// 	name: key,
-			// 	from: value,
-			// 	to: value
-			// });
 			component.$emit('facet-mouse-enter', key, value);
 		});
 		this.facets.on('facet:mouseleave', (event: Event, key: string) => {
-			// actions.clearFeatureHighlightRange(this.$store, key);
 			component.$emit('facet-mouse-leave', key);
 		});
 		// click events
@@ -114,7 +108,7 @@ export default Vue.extend({
 	},
 
 	watch: {
-		groups: function(currGroups: Group[], prevGroups: Group[]) {
+		groups(currGroups: Group[], prevGroups: Group[]) {
 			// get map of all existing group keys in facets
 			const prevMap: Dictionary<Group> = {};
 			prevGroups.forEach(group => {
@@ -127,7 +121,7 @@ export default Vue.extend({
 			// for the unchanged, update selection
 			this.updateSelections(unchangedGroups, prevMap);
 		},
-		highlights: function(currHighlights) {
+		highlights(currHighlights: Dictionary<any>) {
 			if (_.isEmpty(currHighlights)) {
 				(this.groups as Group[]).forEach(groupSpec => {
 					const group = this.facets.getGroup(groupSpec.key);
@@ -166,7 +160,7 @@ export default Vue.extend({
 				}
 			});
 		},
-		sort: function(currSort) {
+		sort(currSort) {
 			this.facets.sort(currSort);
 		}
 	},
@@ -186,6 +180,7 @@ export default Vue.extend({
 				$group.append(this.html);
 			}
 		},
+
 		groupsEqual(a: Group, b: Group): boolean {
 			const OMITTED_FIELDS = ['selection', 'selected'];
 			// NOTE: we dont need to check key, we assume its already equal
@@ -204,6 +199,7 @@ export default Vue.extend({
 			}
 			return true;
 		},
+
 		updateGroups(currGroups: Group[], prevGroups: Dictionary<Group>): Group[] {
 			const toAdd: Group[] = [];
 			const unchanged: Group[] = [];
@@ -251,6 +247,7 @@ export default Vue.extend({
 			// return unchanged groups
 			return unchanged;
 		},
+
 		updateCollapsed(unchangedGroups) {
 			unchangedGroups.forEach(group => {
 				// get the existing facet
@@ -262,6 +259,7 @@ export default Vue.extend({
 				}
 			});
 		},
+
 		updateSelections(unchangedGroups, prevGroups) {
 			unchangedGroups.forEach(groupSpec => {
 				// get the existing facet

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -48,9 +48,9 @@ import { getTask } from '../util/pipelines';
 import { getErrorCol, /*isPredicted, isError,*/ isTarget, getVarFromTarget /*, getVarFromPredicted, getVarFromError*/ } from '../util/data';
 import { getters as dataGetters} from '../store/data/module';
 import { getters as routeGetters } from '../store/route/module';
-import { actions as dataActions } from '../store/data/module';
+import { mutations as dataMutations } from '../store/data/module';
 import { actions } from '../store/app/module';
-import { Dictionary } from '../store/data/index';
+import { Dictionary } from '../util/dict';
 import vueSlider from 'vue-slider-component';
 import Vue from 'vue';
 import _ from 'lodash';
@@ -95,8 +95,8 @@ export default Vue.extend({
 			// find var marked as 'target' and use that name/value tuple to
 			// highlight the ground truth
 			const highlights = dataGetters.getHighlightedFeatureValues(this.$store);
-			const facetHighlights: Dictionary<string> = {};
-			_.forEach(highlights, (value, varName) => {
+			const facetHighlights: Dictionary<any> = {};
+			_.forEach(highlights.values, (value, varName) => {
 				if (isTarget(varName)) {
 					facetHighlights[getVarFromTarget(varName)] = value;
 				}
@@ -179,16 +179,20 @@ export default Vue.extend({
 		histogramMouseEnter(key, value) {
 			// extract the var name from the key
 			const varName = `${key}_target`;
-			dataActions.highlightFeatureRange(this.$store, {
-				name: varName,
-				from: _.toNumber(value.label[0]),
-				to: _.toNumber(value.toLabel[value.toLabel.length-1])
+			dataMutations.highlightFeatureRange(this.$store, {
+				context: 'result_summary',
+				ranges: {
+					[varName]: {
+						from: _.toNumber(value.label[0]),
+						to: _.toNumber(value.toLabel[value.toLabel.length-1])
+					}
+				}
 			});
 		},
 
 		histogramMouseLeave(key) {
 			const varName = `${key}_target`;
-			dataActions.clearFeatureHighlightRange(this.$store, varName);
+			dataMutations.clearFeatureHighlightRange(this.$store, varName);
 		},
 
 		updateThreshold(value: number) {

--- a/public/store/data/actions.ts
+++ b/public/store/data/actions.ts
@@ -6,7 +6,7 @@ import { getSummaries } from '../../util/data';
 import { Variable, Data } from './index';
 import { PipelineInfo } from '../pipelines/index';
 import { mutations } from './module'
-import { DataContext } from '../../util/data';
+import { DataContext, getPredictedFacetKey, getErrorFacetKey } from '../../util/data';
 
 export const ES_INDEX = 'datasets';
 
@@ -154,7 +154,7 @@ export const actions = {
 	getResultsSummaries(context: DataContext, args: { dataset: string, requestId: string }) {
 		const results = getPipelineResultsOkay(context.rootState.pipelineModule, args.requestId);
 		const endPoint = `/distil/results-summary/${ES_INDEX}/${args.dataset}`
-		const nameFunc = (p: PipelineInfo) => `${p.feature} - predicted`;
+		const nameFunc = (p: PipelineInfo) => getPredictedFacetKey(p.feature);
 		getSummaries(context, endPoint, results, nameFunc, mutations.setResultsSummaries, mutations.updateResultsSummaries);
 	},
 
@@ -162,7 +162,7 @@ export const actions = {
 	getResidualsSummaries(context: DataContext, args: { dataset: string, requestId: string }) {
 		const results = getPipelineResultsOkay(context.rootState.pipelineModule, args.requestId);
 		const endPoint = `/distil/residuals-summary/${ES_INDEX}/${args.dataset}`
-		const nameFunc = (p: PipelineInfo) => `${p.feature} - error`;
+		const nameFunc = (p: PipelineInfo) => getErrorFacetKey(p.feature);
 		getSummaries(context, endPoint, results, nameFunc, mutations.setResidualsSummaries, mutations.updateResidualsSummaries);
 	},
 
@@ -178,21 +178,5 @@ export const actions = {
 			.catch(error => {
 				console.error(`Failed to fetch results from ${args.pipelineId} with error ${error}`);
 			});
-	},
-
-	highlightFeatureRange(context: DataContext, highlight: { name: string, to: number, from: number}) {
-		mutations.highlightFeatureRange(context, highlight);
-	},
-
-	clearFeatureHighlightRange(context: DataContext, varName: string) {
-		mutations.clearFeatureHighlightRange(context, varName);
-	},
-
-	highlightFeatureValues(context: DataContext, highlight: { [name: string]: any }) {
-		mutations.highlightFeatureValues(context, highlight);
-	},
-
-	clearFeatureHighlightValues(context: DataContext) {
-		mutations.clearFeatureHighlightValues(context);
 	}
 }

--- a/public/store/data/getters.ts
+++ b/public/store/data/getters.ts
@@ -1,10 +1,9 @@
 import _ from 'lodash';
-import { Variable, Data, DataState, Datasets, VariableSummary, TargetRow } from './index';
+import { FieldInfo, Variable, Data, DataState, Datasets, VariableSummary, TargetRow, RangeHighlights, ValueHighlights } from './index';
 import { Filter, EMPTY_FILTER } from '../../util/filters';
 import { TARGET_POSTFIX, PREDICTED_POSTFIX } from '../../util/data';
 import { Dictionary } from '../../util/dict';
 import { getPredictedIndex, getErrorIndex, getTargetIndex } from '../../util/data';
-import { FieldInfo, Range } from './index';
 
 function validateData(data: Data) {
 	return !_.isEmpty(data) &&
@@ -290,11 +289,11 @@ export const getters = {
 		return {} as Dictionary<FieldInfo>;
 	},
 
-	getHighlightedFeatureValues(state: DataState): Dictionary<any> {
+	getHighlightedFeatureValues(state: DataState): ValueHighlights {
 		return state.highlightedFeatureValues;
 	},
 
-	getHighlightedFeatureRanges(state: DataState): Range {
+	getHighlightedFeatureRanges(state: DataState): RangeHighlights {
 		return state.highlightedFeatureRanges;
 	}
 }

--- a/public/store/data/index.ts
+++ b/public/store/data/index.ts
@@ -59,7 +59,21 @@ export interface TargetRow {
 	_cellVariants?: Dictionary<string>;
 }
 
-export type Range = Dictionary<{ from: number, to: number }>;
+export interface Highlights {
+	context: string;
+}
+
+export interface RangeHighlights extends Highlights {
+	ranges: Range;
+}
+
+export interface ValueHighlights extends Highlights {
+	values: Dictionary<any>;
+}
+
+export type Range = Dictionary<{
+	from: number, to: number
+}>;
 
 export type Dictionary<T> = { [key: string]: T }
 
@@ -72,8 +86,8 @@ export interface DataState {
 	resultData: Data;
 	filteredData: Data;
 	selectedData: Data;
-	highlightedFeatureRanges: Range;
-	highlightedFeatureValues: Dictionary<any>;
+	highlightedFeatureRanges: RangeHighlights;
+	highlightedFeatureValues: ValueHighlights;
 }
 
 export const state = {

--- a/public/store/data/module.ts
+++ b/public/store/data/module.ts
@@ -54,11 +54,7 @@ export const actions = {
 	updateSelectedData: dispatch(moduleActions.updateSelectedData),
 	getResultsSummaries: dispatch(moduleActions.getResultsSummaries),
 	getResidualsSummaries: dispatch(moduleActions.getResidualsSummaries),
-	updateResults: dispatch(moduleActions.updateResults),
-	highlightFeatureRange: dispatch(moduleActions.highlightFeatureRange),
-	clearFeatureHighlightRange: dispatch(moduleActions.clearFeatureHighlightRange),
-	highlightFeatureValues: dispatch(moduleActions.highlightFeatureValues),
-	clearFeatureHighlightValues: dispatch(moduleActions.clearFeatureHighlightValues)
+	updateResults: dispatch(moduleActions.updateResults)
 }
 
 

--- a/public/store/data/mutations.ts
+++ b/public/store/data/mutations.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash';
-import Vue from 'vue';
-import { DataState, Variable, Datasets, VariableSummary, Data } from './index';
+import { DataState, Variable, Datasets, VariableSummary, Data, ValueHighlights, RangeHighlights } from './index';
 import { updateSummaries } from '../../util/data';
 
 export const mutations = {
@@ -59,22 +58,19 @@ export const mutations = {
 		state.resultData = resultData;
 	},
 
-	highlightFeatureRange(state: DataState, highlight: { name: string, to: number, from: number }) {
-		Vue.set(state.highlightedFeatureRanges, highlight.name, {
-			from: highlight.from,
-			to: highlight.to
-		});
+	highlightFeatureRange(state: DataState, highlight: RangeHighlights) {
+		state.highlightedFeatureRanges = highlight;
 	},
 
 	clearFeatureHighlightRange(state: DataState, name: string) {
-		Vue.delete(state.highlightedFeatureRanges, name);
+		state.highlightedFeatureRanges = <RangeHighlights>{};
 	},
 
-	highlightFeatureValues(state: DataState, highlights: { [name: string]: any }) {
+	highlightFeatureValues(state: DataState, highlights: ValueHighlights) {
 		state.highlightedFeatureValues = highlights;
 	},
 
 	clearFeatureHighlightValues(state: DataState) {
-		state.highlightedFeatureValues = {};
+		state.highlightedFeatureValues = <ValueHighlights>{};
 	}
 }

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -8,10 +8,13 @@ import { ActionContext } from 'vuex';
 import axios from 'axios';
 import Vue from 'vue';
 
-
+// Postfixes for special variable names
 export const PREDICTED_POSTFIX = '_predicted';
 export const TARGET_POSTFIX = '_target';
 export const ERROR_POSTFIX = '_error';
+
+export const PREDICTED_FACET_KEY_POSTFIX = ' - predicted';
+export const ERROR_FACET_KEY_POSTFIX = ' - error';
 
 export type DataContext = ActionContext<DataState, DistilState>;
 
@@ -113,6 +116,22 @@ export function getVarFromError(decorated: string) {
 
 export function getVarFromTarget(decorated: string) {
 	return decorated.replace(TARGET_POSTFIX, '');
+}
+
+export function getPredictedFacetKey(target: string) {
+	return target + PREDICTED_FACET_KEY_POSTFIX;
+}
+
+export function getErrorFacetKey(target: string) {
+	return target + ERROR_FACET_KEY_POSTFIX;
+}
+
+export function getErrorColFromFacetKey(facetKey: string) {
+	return facetKey.replace(ERROR_FACET_KEY_POSTFIX, ERROR_POSTFIX);
+}
+
+export function getPredictedColFromFacetKey(facetKey: string) {
+	return facetKey.replace(PREDICTED_FACET_KEY_POSTFIX, PREDICTED_POSTFIX);
 }
 
 export function updateSummaries(summary: VariableSummary, summaries: VariableSummary[], matchField: string) {

--- a/run.sh
+++ b/run.sh
@@ -4,5 +4,5 @@ export ES_ENDPOINT=http://localhost:9200
 export PIPELINE_DATA_DIR=`pwd`/datasets
 export PG_STORAGE=true
 export PIPELINE_COMPUTE_TRACE=true
-export PG_LOG_LEVEL=info # debug, error, warn, info, none
+export PG_LOG_LEVEL=none # debug, error, warn, info, none
 witch --cmd="make compile && make fmt && go run main.go" --watch="main.go,api/**/*.go" --ignore=""


### PR DESCRIPTION
`Facets.vue` is now just emitting mouse in/out events so that higher level components can handle them with more context.  This allows for error and prediction variables to be properly interpreted by the result table and result facet components.

fixes #235 