### PR TITLE
Eval 2 Help - Glossary Cleanup

### DIFF
--- a/public/static/help/glossary.html
+++ b/public/static/help/glossary.html
@@ -332,7 +332,7 @@
         
           
             <dt id="available-feature">Available Feature</dt>
-            <dd>In the Select stage, available features are columns or fields in the chosen dataset. You can use an available feature either as the target you want the model to predict or as a part of the training set the model uses to predict the target.</dd>
+            <dd>In the Create Models stage, available features are columns or fields in the chosen dataset. You can use an available feature as a part of the training set the model uses to predict the target.</dd>
           
         
           
@@ -357,14 +357,13 @@
         
           
             <dt id="distance">Distance</dt>
-            <dd>In regression models, distance indicates how far away from the actual value the predicted value is. Distance is used as a measure of error for each prediction.<br><br>
-For example, if the actual weight of a car is 4,079 lb., but the model predicts it to be higher at 4,098 lb., the distance between the predicted value and the actual value is 19. Similarly, if the model predicts weight the to be lower at 4,060 lb., the distance is still 19.
+            <dd>In regression models, distance indicates how far away from the actual value the predicted value is. Distance is used as a measure of error for each prediction.
 </dd>
           
         
           
             <dt id="error">Error</dt>
-            <dd>In regression results, the error threshold allows you to configure how accurate the model should be. Error is calculated by the distance of the predicted value from the actual value. By default, the error is set to the 25th percentile of the error range.</dd>
+            <dd>In regression results, the error threshold allows you to configure how accurate the model should be. Error is calculated by the distance of the predicted value from the actual value.</dd>
           
         
           
@@ -401,13 +400,13 @@ For example, if the actual weight of a car is 4,079 lb., but the model predicts 
         
           
             <dt id="sample">Sample</dt>
-            <dd>In the Select stage, Distil shows a representative sample of values for the selected target feature and training features.</dd>
+            <dd>In the Create Models stage, Distil shows a representative sample of values for the selected target feature and training features.</dd>
           
         
           
             <dt id="summary">Summary</dt>
-            <dd>On the Home and Search pages, the summary describes the contents of the available datasets that you can use in model building.<br><br>
-On the Results pages, the feature summaries show the range of values in results in the dataset.
+            <dd>On the Home and Search Data pages, the summary describes the contents of the available datasets that you can use in model building.<br><br>
+On the View Models page, the feature summaries show the range of values in results in the dataset.
 </dd>
           
         


### PR DESCRIPTION
Fix references to old view names and error threshold functionality.