### PR TITLE
displays correct prediction count in categorical facets

### DIFF
--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -26,6 +26,7 @@ export interface CategoricalFacet {
 	selected: { count: number } | SelectedSegments;
 	value: string;
 	count: number;
+	countLabel: string;
 	filterable: boolean;
 	segments: Segment[];
 }
@@ -165,6 +166,7 @@ function createCategoricalSummaryFacet(summary: VariableSummary, enableCollapse:
 
 		// Populate segments if buckets are nested.  If a nested bucket's key matches the parent bucket key, values
 		// are given a colour to signify a match, all other nested buckets are summed and displayed as not matching.
+		let label = b.key;
 		if (b.buckets) {
 			segments.push( { color: CATEGORY_MATCH_COLOR, count: 0 });
 			segments.push( { color: CATEGORY_NO_MATCH_COLOR, count: 0 });
@@ -177,6 +179,8 @@ function createCategoricalSummaryFacet(summary: VariableSummary, enableCollapse:
 			}
 			// TODO: Add proper highlight state visuals once highlighting is cleaned up
 			selected = { segments: segments, selected: b.count };
+			const totalCount = <number>(segments[0].count + segments[1].count);
+			label = `${segments[0].count}/${totalCount}`;
 		} else {
 			// if no segments, just use basic count selection
 			selected = { count: b.count };
@@ -185,6 +189,7 @@ function createCategoricalSummaryFacet(summary: VariableSummary, enableCollapse:
 		const facet: CategoricalFacet = {
 			icon : { class : getGroupIcon(summary) },
 			value: b.key,
+			countLabel: label,
 			count: b.count,
 			selected: selected,
 			segments: segments,


### PR DESCRIPTION
resolves #419 

Using count label functionality provided by facets lib.  As an alternative I tried directly manipulating the label, but it was confusing without some type of visual distinction between the predicted correct and the category value itself.  Ended up looking like:

**10** 0: 5/10 predictions correct

Submitted change does:

**5/10** 0

Where 0 is the hall of fame code (which should really not be a number)