### PR TITLE
Dataset persist index

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -112,11 +112,23 @@ func (s *Storage) FetchNumRows(dataset string, filters map[string]interface{}) (
 	return numRows, nil
 }
 
+func (s *Storage) filterIncludesIndex(filterParams *model.FilterParams) bool {
+	for _, v := range filterParams.Filters {
+		if v.Name == d3mIndexFieldName {
+			return true
+		}
+	}
+
+	return false
+}
+
 // FetchData creates a postgres query to fetch a set of rows.  Applies filters to restrict the
 // results to a user selected set of fields, with rows further filtered based on allowed ranges and
 // categories.
 func (s *Storage) FetchData(dataset string, index string, filterParams *model.FilterParams, inclusive bool) (*model.FilteredData, error) {
-	variables, err := s.metadata.FetchVariables(dataset, index, false)
+	// Include the d3m if inclusive XOR index is specified
+	indexSpecified := s.filterIncludesIndex(filterParams)
+	variables, err := s.metadata.FetchVariables(dataset, index, inclusive != indexSpecified)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not pull variables from ES")
 	}

--- a/api/pipeline/dataset_persist.go
+++ b/api/pipeline/dataset_persist.go
@@ -264,15 +264,6 @@ func writeDataSchema(schemaPath string, dataset string, filteredData *model.Filt
 		DataResources: drs,
 	}
 
-	// Both outputs have the index.
-	//ds.DataResources[0].Variables = append(ds.DataResources[0].Variables, &DataVariable{
-	//	ColName:  "d3mIndex",
-	//	Role:     []string{"index"},
-	//	ColType:  "integer",
-	//	ColIndex: 0,
-	//})
-
-	// Add all other variables.
 	// NOTE: the target is identified by the suggested target role.
 	for i, c := range filteredData.Columns {
 		role := []string{"attribute"}
@@ -287,7 +278,7 @@ func writeDataSchema(schemaPath string, dataset string, filteredData *model.Filt
 			ColName:  c,
 			Role:     role,
 			ColType:  model.MapTA2Type(vars[c].Type),
-			ColIndex: i + 1,
+			ColIndex: i,
 		}
 		ds.DataResources[0].Variables = append(ds.DataResources[0].Variables, v)
 	}

--- a/api/routes/discovery.go
+++ b/api/routes/discovery.go
@@ -25,6 +25,12 @@ func ProblemDiscoveryHandler(ctorData model.DataStorageCtor, ctorMeta model.Meta
 		}
 		filterParams.Size = -1
 
+		// NOTE: D3M index field is needed in the persisted data.
+		filterParams.Filters = append(filterParams.Filters, &model.Filter{
+			Name: "d3mIndex",
+			Type: "empty",
+		})
+
 		// get storages
 		dataStorage, err := ctorData()
 		if err != nil {
@@ -43,7 +49,7 @@ func ProblemDiscoveryHandler(ctorData model.DataStorageCtor, ctorMeta model.Meta
 			return dataStorage.FetchData(dataset, index, filterParams, false)
 		}
 		fetchVariables := func(dataset string, index string) ([]*model.Variable, error) {
-			return metadataStorage.FetchVariables(dataset, index, false)
+			return metadataStorage.FetchVariables(dataset, index, true)
 		}
 		fetchVariable := func(dataset string, index string, name string) (*model.Variable, error) {
 			return metadataStorage.FetchVariable(dataset, index, name)

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -241,14 +241,10 @@ func handleCreatePipelines(conn *Connection, client *pipeline.Client, metadataCt
 	// persist the filtered dataset if necessary
 	fetchFilteredData := func(dataset string, index string, filterParams *model.FilterParams) (*model.FilteredData, error) {
 		// fetch the whole data, including the target and index
-		log.Infof("FILTER: %v", *filterParams)
-		for _, f := range filterParams.Filters {
-			log.Infof("FILTER IN: %v", *f)
-		}
 		return dataStorage.FetchData(dataset, index, filterParams, false)
 	}
 	fetchVariable := func(dataset string, index string) ([]*model.Variable, error) {
-		return metadata.FetchVariables(dataset, index, false)
+		return metadata.FetchVariables(dataset, index, true)
 	}
 	datasetPath, err := pipeline.PersistFilteredData(fetchFilteredData, fetchVariable, client.DataDir, clientCreateMsg.Dataset, clientCreateMsg.Index, clientCreateMsg.Feature, filters)
 	if err != nil {
@@ -489,7 +485,7 @@ func handleCreatePipelinesSuccess(conn *Connection, msg *Message, proxy *pipelin
 // be cached by Redis, but still worth looking into storing some of the dataset info.
 func fetchFilteredVariables(metadata model.MetadataStorage, index string, dataset string, filters *model.FilterParams) ([]string, error) {
 	// fetch the variable set from es
-	variables, err := metadata.FetchVariables(dataset, index, false)
+	variables, err := metadata.FetchVariables(dataset, index, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Persisting data used the row index as d3m index. That does not work if the index is not sequential. These changes now pull the d3m index from storage when persisting data so that the proper index can be passed to TA2 systems.