### PR TITLE
Result summary count limit

### DIFF
--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -522,7 +522,7 @@ func (s *Storage) fetchCategoricalResultHistogram(resultURI string, dataset stri
 	if len(categories.Buckets) > catResultLimit {
 		bucketsComplete := categories.Buckets
 		sort.Slice(bucketsComplete, func(i, j int) bool {
-			return bucketsComplete[i].Count < bucketsComplete[j].Count
+			return bucketsComplete[i].Count > bucketsComplete[j].Count
 		})
 		categories.Buckets = bucketsComplete[:catResultLimit]
 	}


### PR DESCRIPTION
Updated the categorical result summary to limit the number of categories returned after the data is parsed and bucketed. Limiting the data in the query leads to incomplete data for categories if the target,predicted group count is greater than the category limit.