### PR TITLE
Export nginx error

### DIFF
--- a/public/store/app/actions.ts
+++ b/public/store/app/actions.ts
@@ -28,9 +28,14 @@ export const actions = {
 				mutations.setAborted(context);
 			})
 			.catch(error => {
-				// NOTE: request always fails because we exit on the server
-				console.warn(`User exported pipeline ${args.pipelineId}`);
-				mutations.setAborted(context);
+				// check for case where target / task doesn't match the problem requests - server returns
+				// a bad request staus code along with an error message
+				if (error.response && error.response.status === 400) {
+					return new Error(error.response.data);
+				} else {
+					console.warn(`User exported pipeline ${args.pipelineId}`);
+					mutations.setAborted(context);
+				}
 			});
 	}
 };


### PR DESCRIPTION
We observed an issue on the deployment cluster where a seemingly successful import resulted in an error modal being displayed, with a message consisting of nginx 502 html markup.  We were counting on the system having no valid response info in the error produced by the axios get call on a successful import, but when we run against an nginx proxy, it does give us back a 502 in the case where the server gets shut down.  We now explicitly check for a 400 (client request is bad) when determining whether or not to display the error message to the user - other cases are skipped.