### PR TITLE
maps boolean type to classification task

### DIFF
--- a/public/util/pipelines.ts
+++ b/public/util/pipelines.ts
@@ -218,5 +218,6 @@ const variableType: Dictionary<Task> = {
 	postal_code: classification,
 	uri: classification,
 	datetime: classification,
-	text: classification
+	text: classification,
+	boolean: classification
 };


### PR DESCRIPTION
Could not initiate pipeilne creating when using a var type of boolean for a target .