### PR TITLE
skips extrema + residual calls for classification tasks

### DIFF
--- a/public/store/data/actions.ts
+++ b/public/store/data/actions.ts
@@ -180,10 +180,6 @@ export const actions = {
 			console.warn('`pipelineId` argument is missing');
 			return null;
 		}
-		if (!args.extrema || (!args.extrema.min && !args.extrema.max)) {
-			console.warn('`extrema` argument is missing');
-			return null;
-		}
 		const pipeline = getPipelineById(context.rootState.pipelineModule, args.pipelineId);
 		// commit empty place holders, if there is no data
 		const promises = [];
@@ -231,10 +227,6 @@ export const actions = {
 			console.warn('`pipelineId` argument is missing');
 			return null;
 		}
-		if (!args.extrema || (!args.extrema.min && !args.extrema.max)) {
-			console.warn('`extrema` argument is missing');
-			return null;
-		}
 		const pipeline = getPipelineById(context.rootState.pipelineModule, args.pipelineId);
 		if (!pipeline.resultId) {
 			// no results ready to pull
@@ -243,7 +235,7 @@ export const actions = {
 		// only use extrema if this is the feature variable
 		let extremaMin = null;
 		let extremaMax = null;
-		if (args.variable === pipeline.feature) {
+		if (args.variable === pipeline.feature && args.extrema) {
 			extremaMin = args.extrema.min;
 			extremaMax = args.extrema.max;
 		}
@@ -426,12 +418,15 @@ export const actions = {
 			console.warn('`pipelineId` argument is missing');
 			return null;
 		}
-		if (!args.extrema || (!args.extrema.min && !args.extrema.max)) {
-			console.warn('`extrema` argument is missing');
-			return null;
+		// only use extrema if this is the feature variable
+		let extremaMin = null;
+		let extremaMax = null;
+		if (args.extrema) {
+			extremaMin = args.extrema.min;
+			extremaMax = args.extrema.max;
 		}
 		const pipeline = getPipelineById(context.rootState.pipelineModule, args.pipelineId);
-		const endPoint = `/distil/results-summary/${ES_INDEX}/${args.dataset}/${args.extrema.min}/${args.extrema.max}`
+		const endPoint = `/distil/results-summary/${ES_INDEX}/${args.dataset}/${extremaMin}/${extremaMax}`
 		const nameFunc = (p: PipelineInfo) => getPredictedCol(p.feature);
 		const labelFunc = (p: PipelineInfo) => 'Predicted';
 		getSummary(context, endPoint, pipeline, nameFunc, labelFunc, mutations.updatePredictedSummaries);
@@ -447,12 +442,15 @@ export const actions = {
 			console.warn('`requestIds` argument is missing');
 			return null;
 		}
-		if (!args.extrema) {
-			console.warn('`extrema` argument is missing');
-			return null;
+		// only use extrema if this is the feature variable
+		let extremaMin = null;
+		let extremaMax = null;
+		if (args.extrema) {
+			extremaMin = args.extrema.min;
+			extremaMax = args.extrema.max;
 		}
 		const pipelines = getPipelinesByRequestIds(context.rootState.pipelineModule, args.requestIds);
-		const endPoint = `/distil/results-summary/${ES_INDEX}/${args.dataset}/${args.extrema.min}/${args.extrema.max}`
+		const endPoint = `/distil/results-summary/${ES_INDEX}/${args.dataset}/${extremaMin}/${extremaMax}`
 		const nameFunc = (p: PipelineInfo) => getPredictedCol(p.feature);
 		const labelFunc = (p: PipelineInfo) => 'Predicted';
 		getSummaries(context, endPoint, pipelines, nameFunc, labelFunc, mutations.updatePredictedSummaries);

--- a/public/store/pipelines/actions.ts
+++ b/public/store/pipelines/actions.ts
@@ -6,6 +6,7 @@ import { DistilState } from '../store';
 import { mutations } from './module';
 import { getWebSocketConnection } from '../../util/ws';
 import { FilterParams } from '../../util/filters';
+import { regression } from '../../util/pipelines';
 
 const ES_INDEX = 'datasets';
 const CREATE_PIPELINES_MSG = 'CREATE_PIPELINES';
@@ -37,17 +38,24 @@ function updateCurrentPipelineResults(context: any, req: PipelineRequest, res: P
 		});
 	}
 
-	Promise.all([
-		context.dispatch('fetchResultExtrema', {
-			dataset: req.dataset,
-			variable: req.feature,
-			pipelineId: res.pipelineId
-		}),
-		context.dispatch('fetchPredictedExtrema', {
-			dataset: req.dataset,
-			pipelineId: res.pipelineId
-		})
-	]).then(() => {
+	// if this is a regression task, pull extrema as a first step
+	const isRegression = req.task.toLowerCase() === regression.schemaName.toLowerCase();
+	let extremaFetches = [];
+	if (isRegression) {
+		extremaFetches = [
+			context.dispatch('fetchResultExtrema', {
+				dataset: req.dataset,
+				variable: req.feature,
+				pipelineId: res.pipelineId
+			}),
+			context.dispatch('fetchPredictedExtrema', {
+				dataset: req.dataset,
+				pipelineId: res.pipelineId
+			})
+		]
+	}
+
+	Promise.all(extremaFetches).then(() => {
 		// if current pipelineId, pull result summaries
 		if (res.pipelineId === currentPipelineId) {
 			context.dispatch('fetchResultSummaries', {
@@ -64,31 +72,37 @@ function updateCurrentPipelineResults(context: any, req: PipelineRequest, res: P
 		});
 	});
 
-	context.dispatch('fetchResidualsExtrema', {
-		dataset: req.dataset,
-		pipelineId: res.pipelineId
-	}).then(() => {
-		context.dispatch('fetchResidualsSummary', {
+	if (isRegression) {
+		context.dispatch('fetchResidualsExtrema', {
 			dataset: req.dataset,
-			pipelineId: res.pipelineId,
-			extrema: context.getters.getResidualExtrema
+			pipelineId: res.pipelineId
+		}).then(() => {
+			context.dispatch('fetchResidualsSummary', {
+				dataset: req.dataset,
+				pipelineId: res.pipelineId,
+				extrema: context.getters.getResidualExtrema
+			});
 		});
-	});
+	}
 }
 
 function updatePipelineResults(context: any, req: PipelineRequest, res: PipelineInfo) {
-
-	Promise.all([
-		context.dispatch('fetchResultExtrema', {
-			dataset: req.dataset,
-			variable: req.feature,
-			pipelineId: res.pipelineId
-		}),
-		context.dispatch('fetchPredictedExtrema', {
-			dataset: req.dataset,
-			pipelineId: res.pipelineId
-		})
-	]).then(() => {
+	const isRegression = req.task.toLowerCase() === regression.schemaName.toLowerCase();
+	let extremaFetches = [];
+	if (isRegression) {
+		extremaFetches = [
+			context.dispatch('fetchResultExtrema', {
+				dataset: req.dataset,
+				variable: req.feature,
+				pipelineId: res.pipelineId
+			}),
+			context.dispatch('fetchPredictedExtrema', {
+				dataset: req.dataset,
+				pipelineId: res.pipelineId
+			})
+		]
+	}
+	Promise.all(extremaFetches).then(() => {
 		context.dispatch('fetchPredictedSummary', {
 			dataset: req.dataset,
 			pipelineId: res.pipelineId,
@@ -96,16 +110,18 @@ function updatePipelineResults(context: any, req: PipelineRequest, res: Pipeline
 		});
 	});
 
-	context.dispatch('fetchResidualsExtrema', {
-		dataset: req.dataset,
-		pipelineId: res.pipelineId
-	}).then(() => {
-		context.dispatch('fetchResidualsSummary', {
+	if (isRegression) {
+		context.dispatch('fetchResidualsExtrema', {
 			dataset: req.dataset,
-			pipelineId: res.pipelineId,
-			extrema: context.getters.getResidualExtrema
+			pipelineId: res.pipelineId
+		}).then(() => {
+			context.dispatch('fetchResidualsSummary', {
+				dataset: req.dataset,
+				pipelineId: res.pipelineId,
+				extrema: context.getters.getResidualExtrema
+			});
 		});
-	});
+	}
 }
 
 export const actions = {

--- a/public/util/pipelines.ts
+++ b/public/util/pipelines.ts
@@ -186,7 +186,7 @@ const defaultRegressionMetrics: Dictionary<NameInfo> = {
 const metrics = [classificationMetrics, regressionMetrics];
 
 // classification task info
-const classification: Task = {
+export const classification: Task = {
 	displayName: 'Classification',
 	schemaName: 'classification',
 	metrics: classificationMetrics,
@@ -194,7 +194,7 @@ const classification: Task = {
 };
 
 // regression task info
-const regression: Task = {
+export const regression: Task = {
 	displayName: 'Regression',
 	schemaName: 'regression',
 	metrics: regressionMetrics,


### PR DESCRIPTION
Our result and predicted result fetch code was expecting extrema to be available in all cases, which doesn't hold for classification tasks.  Additionally, we were always making calls to the server to fetch residuals, which is only relevant for regression tasks.  End result would be errors during fetches when displaying model results, manifesting as an empty result table.