### PR TITLE
maps country code to text type and adds formatting for empty string

### DIFF
--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -25,6 +25,7 @@ const TEXT_TYPES = [
 	'city',
 	'state',
 	'country',
+	'country_code',
 	'email',
 	'phone',
 	'postal_code',
@@ -106,6 +107,9 @@ export function formatValue(colValue: any, colType: string): any {
 		return colValue;
 	}
 	if (_.isInteger(colValue)) {
+		return colValue;
+	}
+	if (colValue === '') {
 		return colValue;
 	}
 	switch (colType) {


### PR DESCRIPTION
Ensures that empty strings with an unidentified type are not formatted as numbers, which leads to an exception at runtime.  Also added `country_code` in as a text type.