### PR TITLE
Reworked resource proxy to be dataset based.

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -80,7 +80,7 @@ type Config struct {
 	ServiceRetryCount                  int     `env:"SERVICE_RETRY_COUNT" envDefault:"10"`
 	VerboseError                       bool    `env:"VERBOSE_ERROR" envDefault:"false"`
 	RootResourceDirectory              string  `env:"ROOT_RESOURCE_DIRECTORY" envDefault:"http://localhost:8001"`
-	ResourceProxy                      bool    `env:"RESOURCE_PROXY" envDefault:"true"`
+	ResourceProxy                      string  `env:"RESOURCE_PROXY" envDefault:"d_22_hy_dataset_TRAIN_dataset"`
 	IngestPrimitive                    bool    `env:"INGEST_PRIMITIVE" envDefault:"false"`
 }
 

--- a/api/routes/resource.go
+++ b/api/routes/resource.go
@@ -10,13 +10,13 @@ import (
 )
 
 // ResourceHandler provides a static file lookup route using simple directory mapping.
-func ResourceHandler(resourceDir string, proxy bool) func(http.ResponseWriter, *http.Request) {
+func ResourceHandler(resourceDir string, proxy map[string]bool) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// resources can either be local or remote
 		dataset := pat.Param(r, "dataset")
 		mediaFolder := pat.Param(r, "folder")
 		file := pat.Param(r, "file")
-		if proxy {
+		if proxy[dataset] {
 			proxyResourceHandler(resourceDir, dataset, mediaFolder, file).ServeHTTP(w, r)
 		} else {
 			localFileHandler(resourceDir, dataset, mediaFolder, file).ServeHTTP(w, r)

--- a/main.go
+++ b/main.go
@@ -180,6 +180,8 @@ func main() {
 			os.Exit(1)
 		}
 	}
+	datasetsToProxy := parseResourceProxy(config.ResourceProxy)
+
 	// register routes
 	mux := goji.NewMux()
 	mux.Use(middleware.Log)
@@ -212,7 +214,7 @@ func main() {
 	registerRoutePost(mux, "/distil/predicted-summary/:index/:dataset/:min/:max/:results-uuid", routes.PredictedSummaryHandler(pgSolutionStorageCtor, pgDataStorageCtor))
 
 	// static
-	registerRoute(mux, "/distil/image/:dataset/:folder/:file", routes.ResourceHandler(config.RootResourceDirectory, config.ResourceProxy))
+	registerRoute(mux, "/distil/image/:dataset/:folder/:file", routes.ResourceHandler(config.RootResourceDirectory, datasetsToProxy))
 	registerRoute(mux, "/*", routes.FileHandler("./dist"))
 
 	// catch kill signals for graceful shutdown
@@ -248,4 +250,14 @@ func waitForPostEndpoint(endpoint string) bool {
 	}
 
 	return up
+}
+
+func parseResourceProxy(datasets string) map[string]bool {
+	toProxy := make(map[string]bool)
+	datasetIds := strings.Split(datasets, ",")
+	for _, d := range datasetIds {
+		toProxy[d] = true
+	}
+
+	return toProxy
 }


### PR DESCRIPTION
CSV specified resources are proxied to a remote host (resource server). Everything not listed in the config setting is assumed to be locally available. Assumes that dataset ids will not have commas.