### PR TITLE
Updated to latest importance ranking loading.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -168,9 +168,9 @@
     "rest",
     "smmry"
   ]
-  revision = "f8224151b7d1a1f76deed20b996518e123ff2ee3"
+  revision = "be44bcb18b70d75b1b89ecc694e0b388941658e8"
   source = "git@github.com:unchartedsoftware/distil-ingest.git"
-  version = "0.4.2"
+  version = "0.4.3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@
 [[constraint]]
   name = "github.com/unchartedsoftware/distil-ingest"
   source = "git@github.com:unchartedsoftware/distil-ingest.git"
-  version = "0.4.2"
+  version = "0.4.3"
 
 [[constraint]]
   branch = "master"

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -217,11 +217,7 @@ func Ingest(storage model.MetadataStorage, index string, dataset string, config 
 	// Adjust the ID & name of the dataset as needed
 	fixDatasetIDName(meta)
 
-	indices := make([]int, len(meta.DataResources[0].Variables))
-	for i := 0; i < len(indices); i++ {
-		indices[i] = i
-	}
-	err = meta.LoadImportance(config.getTmpAbsolutePath(config.RankingOutputPathRelative), indices)
+	err = meta.LoadImportance(config.getTmpAbsolutePath(config.RankingOutputPathRelative))
 	if err != nil {
 		return errors.Wrap(err, "unable to load importance from file")
 	}


### PR DESCRIPTION
Ranking used to not support non numerical columns. When that restriction was removed, the code was not properly updated to read the importance results. This fix uses the latest version of distil-ingest which has been updated to read an importance for every column.