### PR TITLE
Export success when proxy present

### DIFF
--- a/public/store/app/actions.ts
+++ b/public/store/app/actions.ts
@@ -30,7 +30,10 @@ export const actions = {
 				mutations.setAborted(context);
 			})
 			.catch(error => {
-				if (error.response) {
+				 // If there's a proxy involved (NGINX) we will end up getting a 502 on a successful export because
+				 // the server exits.  We need to explicitly check for the condition here so that we don't interpret
+				// a success case as a failure.
+				if (error.response && error.response.status != 502) {
 					return new Error(error.response.data);
 				} else {
 					// NOTE: request always fails because we exit on the server


### PR DESCRIPTION
fixes #607

Adds an explicit check for a 502 to account for a proxy like NGINX running between the client and the server.  When the export is complete, the server shuts itself down, which NGINX picks up and reports as a 502, rather than the error code the server was attempting to return.