### PR TITLE
Fixed URI exchanging with TA2 systems on fully specified pipeline

### DIFF
--- a/api/compute/execute_pipeline_request.go
+++ b/api/compute/execute_pipeline_request.go
@@ -2,6 +2,8 @@ package compute
 
 import (
 	"context"
+	"fmt"
+	"path"
 	"sync"
 	"time"
 
@@ -38,7 +40,7 @@ type ExecPipelineRequest struct {
 // the pipeline description.
 func NewExecPipelineRequest(datasetURI string, pipelineDesc *pipeline.PipelineDescription) *ExecPipelineRequest {
 	return &ExecPipelineRequest{
-		datasetURI:    datasetURI,
+		datasetURI:    fmt.Sprintf("file://%s", path.Join(datasetURI, "datasetDoc.json")),
 		pipelineDesc:  pipelineDesc,
 		wg:            &sync.WaitGroup{},
 		finished:      make(chan error),

--- a/api/task/primitives.go
+++ b/api/task/primitives.go
@@ -61,6 +61,8 @@ func submitPrimitive(dataset string, step *pipeline.PipelineDescription) (string
 		return "", errors.Wrap(errPipeline, "error executing pipeline")
 	}
 
+	datasetURI = strings.Replace(datasetURI, "file://", "", -1)
+
 	return datasetURI, nil
 }
 


### PR DESCRIPTION
URIs sent to TA2 need to point to file and have file:// prefix. URIs received from TA2 have file:// prefix.