### PR TITLE
Lower bound for bucket count and single value bucket handling

### DIFF
--- a/api/model/extrema.go
+++ b/api/model/extrema.go
@@ -46,7 +46,15 @@ func (e *Extrema) GetBucketCount() int {
 	interval := e.GetBucketInterval()
 	rounded := e.GetBucketMinMax()
 	rang := rounded.Max - rounded.Min
-	return int(round(rang / interval))
+
+	// rounding issues could lead to negative numbers
+	count := int(round(rang / interval))
+	if count < 0 {
+		count = 1
+	} else if count > maxNumBuckets {
+		count = maxNumBuckets
+	}
+	return count
 }
 
 // GetBucketMinMax calculates the bucket min and max for the extrema.

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -476,23 +476,6 @@ func (s *Storage) getResultMinMaxAggsQuery(variable *model.Variable, resultVaria
 	return queryPart
 }
 
-func (s *Storage) getResultHistogramAggQuery(extrema *model.Extrema, variable *model.Variable, resultVariable *model.Variable) (string, string, string) {
-	// compute the bucket interval for the histogram
-	interval := extrema.GetBucketInterval()
-
-	// Only numeric types should occur.
-	fieldTyped := fmt.Sprintf("cast(\"%s\" as double precision)", resultVariable.Key)
-
-	// get histogram agg name & query string.
-	histogramAggName := fmt.Sprintf("\"%s%s\"", model.HistogramAggPrefix, extrema.Key)
-	rounded := extrema.GetBucketMinMax()
-	bucketQueryString := fmt.Sprintf("width_bucket(%s, %g, %g, %d) - 1",
-		fieldTyped, rounded.Min, rounded.Max, extrema.GetBucketCount())
-	histogramQueryString := fmt.Sprintf("(%s) * %g + %g", bucketQueryString, interval, rounded.Min)
-
-	return histogramAggName, bucketQueryString, histogramQueryString
-}
-
 func (s *Storage) fetchResultsExtrema(resultURI string, dataset string, variable *model.Variable, resultVariable *model.Variable) (*model.Extrema, error) {
 	// add min / max aggregation
 	aggQuery := s.getResultMinMaxAggsQuery(variable, resultVariable)

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -12,19 +12,6 @@ const (
 	catResultLimit = 100
 )
 
-func (s *Storage) getHistogramAggQuery(extrema *model.Extrema) (string, string, string) {
-	interval := extrema.GetBucketInterval()
-
-	// get histogram agg name & query string.
-	histogramAggName := fmt.Sprintf("\"%s%s\"", model.HistogramAggPrefix, extrema.Key)
-	rounded := extrema.GetBucketMinMax()
-	bucketQueryString := fmt.Sprintf("width_bucket(\"%s\", %g, %g, %d) - 1",
-		extrema.Key, rounded.Min, rounded.Max, extrema.GetBucketCount())
-	histogramQueryString := fmt.Sprintf("(%s) * %g + %g", bucketQueryString, interval, rounded.Min)
-
-	return histogramAggName, bucketQueryString, histogramQueryString
-}
-
 func (s *Storage) parseExtrema(row *pgx.Rows, variable *model.Variable) (*model.Extrema, error) {
 	var minValue *float64
 	var maxValue *float64


### PR DESCRIPTION
Fixes #632 

There were two errors: rounding made the bucket count negative and having the same value for bucket edges is not allowed. Added a lower bound of 1 for bucket count to safeguard against that case. Also made it return into a single bucket if min = max.