### PR TITLE
returns a nil pipeline when stages do no processing

### DIFF
--- a/api/compute/description/preprocessing.go
+++ b/api/compute/description/preprocessing.go
@@ -33,6 +33,11 @@ func CreateUserDatasetPipeline(name string, description string, allFeatures []*m
 		return nil, err
 	}
 
+	// If neither have any content, we'll skip the template altogether.
+	if len(updateSemanticTypes) == 0 && removeFeatures == nil {
+		return nil, nil
+	}
+
 	// instantiate the pipeline
 	builder := NewBuilder(name, description)
 	for _, v := range updateSemanticTypes {
@@ -41,6 +46,7 @@ func CreateUserDatasetPipeline(name string, description string, allFeatures []*m
 	if removeFeatures != nil {
 		builder = builder.Add(removeFeatures)
 	}
+
 	pip, err := builder.AddInferencePoint().Compile()
 	if err != nil {
 		return nil, err

--- a/api/compute/description/preprocessing_test.go
+++ b/api/compute/description/preprocessing_test.go
@@ -80,3 +80,23 @@ func TestCreateUserDatasetPipelineMappingError(t *testing.T) {
 	assert.Error(t, err)
 	t.Logf("\n%s", proto.MarshalTextString(pipeline))
 }
+
+func TestCreateUserDatasetEmpty(t *testing.T) {
+
+	variables := []*model.Variable{
+		{
+			Key:          "test_var_0",
+			OriginalType: "categorical",
+			Type:         "categorical",
+			Index:        0,
+		},
+	}
+
+	pipeline, err := CreateUserDatasetPipeline(
+		"test_user_pipeline", "a test user pipeline", variables, "test_target", []string{"test_var_0"})
+
+	assert.Nil(t, pipeline)
+	assert.Nil(t, err)
+
+	t.Logf("\n%s", proto.MarshalTextString(pipeline))
+}


### PR DESCRIPTION
fixes #663 - If both the remove columns and semantic type updates are identity transformations we skip creating the pipeline