### PR TITLE
Removed dataset suffix references in ES storage.

### DIFF
--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -5,10 +5,7 @@ import (
 )
 
 const (
-	// DatasetSuffix is the suffix for the dataset entry when stored in
-	// elasticsearch.
-	DatasetSuffix = "_dataset"
-	metadataType  = "metadata"
+	metadataType = "metadata"
 )
 
 // Dataset represents a decsription of a dataset.

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -2,7 +2,6 @@ package elastic
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/unchartedsoftware/distil/api/model"
@@ -13,7 +12,6 @@ import (
 const (
 	// DatasetSuffix is the suffix for the dataset entry when stored in
 	// elasticsearch.
-	DatasetSuffix    = "_dataset"
 	metadataType     = "metadata"
 	datasetsListSize = 1000
 )
@@ -27,7 +25,7 @@ func (s *Storage) parseDatasets(res *elastic.SearchResult, includeIndex bool, in
 			return nil, errors.Wrap(err, "failed to parse dataset")
 		}
 		// extract dataset id
-		name := strings.TrimSuffix(hit.Id, DatasetSuffix)
+		name := hit.Id
 		// extract the description
 		description, ok := json.String(src, "description")
 		if !ok {
@@ -131,7 +129,7 @@ func (s *Storage) updateVariables(dataset string, variables []*model.Variable) e
 	_, err := s.client.Update().
 		Index(s.index).
 		Type(metadataType).
-		Id(dataset + DatasetSuffix).
+		Id(dataset).
 		Doc(source).
 		Do(context.Background())
 	if err != nil {

--- a/api/model/storage/elastic/variable.go
+++ b/api/model/storage/elastic/variable.go
@@ -168,7 +168,7 @@ func (s *Storage) parseVariables(searchHit *elastic.SearchHit, includeIndex bool
 // FetchVariable returns the variable for the provided index, dataset, and variable.
 func (s *Storage) FetchVariable(dataset string, varName string) (*model.Variable, error) {
 	// get dataset id
-	datasetID := dataset + DatasetSuffix
+	datasetID := dataset
 	// create match query
 	query := elastic.NewMatchQuery("_id", datasetID)
 	// create fetch context
@@ -216,7 +216,7 @@ func (s *Storage) FetchVariableDisplay(dataset string, varName string) (*model.V
 // FetchVariables returns all the variables for the provided index and dataset.
 func (s *Storage) FetchVariables(dataset string, includeIndex bool, includeMeta bool) ([]*model.Variable, error) {
 	// get dataset id
-	datasetID := dataset + DatasetSuffix
+	datasetID := dataset
 	// create match query
 	query := elastic.NewMatchQuery("_id", datasetID)
 	// create fetch context

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -25,7 +25,6 @@ import (
 const (
 	rankingFilename = "rank-no-missing.csv"
 	baseTableSuffix = "_base"
-	datasetIDSuffix = "_dataset"
 )
 
 var (
@@ -311,7 +310,7 @@ func Ingest(storage model.MetadataStorage, index string, dataset string, config 
 		return errors.Wrap(err, "unable to ingest metadata")
 	}
 
-	dbTable := strings.Replace(meta.ID, datasetIDSuffix, "", -1)
+	dbTable := meta.ID
 	dbTable = fmt.Sprintf("%s%s", config.ESDatasetPrefix, dbTable)
 
 	// Drop the current table if requested.
@@ -385,10 +384,6 @@ func fixDatasetIDName(meta *metadata.Metadata) {
 	// The ID MUST end in _dataset, and the name should be representative.
 	if isTrainDataset(meta) {
 		meta.ID = strings.TrimSuffix(meta.ID, "_TRAIN")
-		if !strings.HasSuffix(meta.ID, datasetIDSuffix) {
-			meta.ID = fmt.Sprintf("%s%s", meta.ID, datasetIDSuffix)
-		}
-		meta.Name = strings.TrimSuffix(meta.ID, datasetIDSuffix)
 	}
 }
 
@@ -420,7 +415,7 @@ func matchDataset(storage model.MetadataStorage, meta *metadata.Metadata, index 
 }
 
 func deleteDataset(name string, index string, pg *postgres.Database, es *elastic.Client) error {
-	id := fmt.Sprintf("%s%s", name, datasetIDSuffix)
+	id := name
 	success := false
 	for i := 0; i < 10 && !success; i++ {
 		_, err := es.Delete().Index(index).Id(id).Type("metadata").Do(context.Background())


### PR DESCRIPTION
Fixes #670 

As holdover from the original schema files and ingest behaviour, a suffix was applied to dataset ids loaded into ES. This suffix has now been removed from the backend.