### PR TITLE
removes datamart dir contents rather than dir itself

### DIFF
--- a/api/model/storage/datamart/dataset.go
+++ b/api/model/storage/datamart/dataset.go
@@ -105,7 +105,7 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 	}
 
 	// copy the formatted output to the datamart output path (delete existing copy)
-	err = os.RemoveAll(s.outputPath)
+	err = util.RemoveContents(s.outputPath)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to delete raw datamart dataset")
 	}

--- a/api/util/file.go
+++ b/api/util/file.go
@@ -133,3 +133,23 @@ func Copy(sourceFolder string, destinationFolder string) error {
 
 	return nil
 }
+
+// RemoveContents removes the files and directories from the supplied parent.
+func RemoveContents(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		err = os.RemoveAll(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ pipeline_server:
     - SOLUTION_ERR_PERCENT=0.1
   volumes:
     - $PWD/datasets:$PWD/datasets
+    - $PWD/datamart:$PWD/datamart
     - $PWD/outputs/temp:$PWD/outputs/temp
 
 postgres:


### PR DESCRIPTION
The import process was calling a RemoveAll on the output dir (`datamart` in this case) and re-created in a subsequent copy step.  This caused the pipeline runner to lose its mount to the `datamart` directory, but when it was created, the mount  was not properly re-established, and it could no longer see any files add it to it.  End result was a `file not found` error from the runner when it tried to import. 