### PR TITLE
Add conditional overflow to the dataslot depending on which view is u…

### DIFF
--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -54,7 +54,7 @@
 			<small class="row-number-label" v-html="tableTitle"></small>
 		</p>
 
-		<div class="select-data-container">
+		<div class="select-data-container" v-bind:style="{ overflow: isSlotScrollable ? 'auto' : 'hidden' }">
 			<div class="select-data-no-results" v-if="!hasData">
 				<div v-html="spinnerHTML"></div>
 			</div>
@@ -151,6 +151,10 @@ export default Vue.extend({
 
 		numItems(): number {
 			return this.items ? this.items.length : 0;
+		},
+
+		isSlotScrollable(): boolean {
+			return this.viewType === TABLE_VIEW;
 		},
 
 		activeFilter(): Filter {
@@ -253,7 +257,6 @@ export default Vue.extend({
 .select-data-container {
 	display: flex;
 	background-color: white;
-	overflow: auto;
 	flex-flow: wrap;
 	height: 100%;
 	width: 100%;
@@ -307,4 +310,8 @@ table tr {
 .view-button {
 	cursor: pointer;
 }
+.view-button input[type=radio]{	
+    display:none;
+}
+
 </style>

--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -131,7 +131,7 @@ export default Vue.extend({
 				return {
 					type,
 					label: getLabelFromType(type),
-					isRecommended: this.topNonSchemaType.type === type,
+					isRecommended: this.topNonSchemaType && this.topNonSchemaType.type === type,
 					isSelected: this.type === type,
 				};
 			});


### PR DESCRIPTION
Add conditional overflow to the dataslot depending on which view is used. Ex. for table view we want scrolling, for geo / graph / timeseries views we dont.

Fix unrelated undefined prop lookup causing exception in typechange menu.