### PR TITLE
Facet fixes

### DIFF
--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -179,7 +179,6 @@ export default Vue.extend({
 		onFacetClick(context: string, key: string, value: string, dataset: string) {
 			if (this.enableHighlighting) {
 				if (key && value) {
-					// extract the var name from the key
 					updateHighlightRoot(this.$router, {
 						context: context,
 						dataset: dataset,

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -76,13 +76,14 @@ export const actions = {
 		const paginatedVariables = context.getters.getJoinDatasetsPaginatedVariables;
 
 		const datasets = context.getters.getDatasets;
+
 		const joinDatasets = datasets.filter(d => {
 			return d.id === datasetIDs[0] || d.id === datasetIDs[1];
 		});
 
 		return Promise.all([
 			context.dispatch('fetchJoinDatasetsHighlightValues', {
-				datasets: datasets,
+				datasets: joinDatasets,
 				variables: paginatedVariables,
 				highlightRoot: highlightRoot,
 				filterParams: filterParams


### PR DESCRIPTION
- Fixed issue caused by dataset param not being sent through to certain facet event callbacks.
- Fixed issue where the wrong datasets array was sent to the `JoinDatasets` view highlight summary fetching, causing the incorrect highlights to be fetched.
- Added deemphasis for facts in the `JoinDatasets` when the active highlight does not affect that facets dataset.
- Fixed exception casued by debounced highlight injection function in facets being called after component is destroyed.