### PR TITLE
Add timeseries formatter

### DIFF
--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -69,6 +69,10 @@ func Merge(datasetSource metadata.DatasetSource, schemaFile string, index string
 	header := csvData[0][1:]
 	for i, field := range header {
 		v := vars[field]
+		if v == nil {
+			// create new variables (ex: series_id)
+			v = model.NewVariable(i, field, field, field, model.TextType, model.TextType, []string{"attribute"}, model.VarRoleData, nil, outputMeta.DataResources[0].Variables, false)
+		}
 		v.Index = i
 		outputMeta.DataResources[0].Variables = append(outputMeta.DataResources[0].Variables, v)
 	}


### PR DESCRIPTION
If a timeseries dataset is ingested, the merge step calls the formatter rather than the denorm.