### PR TITLE
Ensures joined dataset is written out to augmented directory

### DIFF
--- a/api/task/join.go
+++ b/api/task/join.go
@@ -156,7 +156,7 @@ func createDatasetFromCSV(config *env.Config, csvFile *os.File, datasetName stri
 
 	metadata.DataResources = []*model.DataResource{dataResource}
 
-	outputPath := env.ResolvePath(ingestMetadata.Contrib, datasetName)
+	outputPath := env.ResolvePath(ingestMetadata.Augmented, datasetName)
 
 	// create dest csv file
 	csvDestFolder := path.Join(outputPath, compute.D3MDataFolder)

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -107,7 +107,7 @@ func TestJoin(t *testing.T) {
 		{"3", "4.0", "d"},
 	}
 
-	csvFile, err := os.Open("test_data/test_1-test_2/tables/learningData.csv")
+	csvFile, err := os.Open("test_data/augmented/test_1-test_2/tables/learningData.csv")
 	assert.NoError(t, err)
 	defer csvFile.Close()
 


### PR DESCRIPTION
Was causing the join to fail because the join step wrote to `contrib` while the import step looked for `augmented`.  We should be able to drop `augmented` completely, but that's a more involved change.