### PR TITLE
Input path definition

### DIFF
--- a/api/env/path.go
+++ b/api/env/path.go
@@ -20,6 +20,12 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-ingest/metadata"
+
+	"github.com/uncharted-distil/distil/api/util"
+)
+
+const (
+	seedFolderName = "seed_datasets_current"
 )
 
 var (
@@ -39,7 +45,12 @@ func Initialize(config *Config) error {
 		return errors.Errorf("path resolution already initialized")
 	}
 
-	seedPath = config.D3MInputDir
+	updatedInputPath, err := determineSeedPath(config.D3MInputDir)
+	if err != nil {
+		return err
+	}
+
+	seedPath = updatedInputPath
 	seedSubPath = path.Join("TRAIN", "dataset_TRAIN")
 	tmpPath = config.TmpDataPath
 
@@ -49,6 +60,63 @@ func Initialize(config *Config) error {
 	initialized = true
 
 	return nil
+}
+
+func determineSeedPath(inputPath string) (string, error) {
+	// the input can be either:
+	//   1. a dataset folder
+	//   2. a folder containing dataset folders
+	//   3. a parent folder of the seed dataset folder ('seed_datasets_current')
+	if util.IsDatasetDir(inputPath) {
+		return inputPath, nil
+	}
+
+	// get the list of folders
+	dirs, err := util.GetDirectories(inputPath)
+	if err != nil {
+		return "", err
+	}
+
+	// empty folder
+	if len(dirs) == 0 {
+		return inputPath, nil
+	}
+
+	// if one folder is a dataset, then assume they all are
+	if util.IsDatasetDir(dirs[0]) {
+		return inputPath, nil
+	}
+
+	// find the seed dataset subfolder
+	return findSeedDatasetDirectory(inputPath)
+}
+
+func findSeedDatasetDirectory(inputPath string) (string, error) {
+	dirs, err := util.GetDirectories(inputPath)
+	if err != nil {
+		return "", err
+	}
+
+	// look for the seed dataset folder
+	for _, d := range dirs {
+		if path.Base(d) == seedFolderName {
+			return d, nil
+		}
+	}
+
+	// look in the subfolders
+	for _, d := range dirs {
+		dir, err := findSeedDatasetDirectory(d)
+		if err != nil {
+			return "", err
+		}
+		if dir != "" {
+			return dir, nil
+		}
+	}
+
+	// not found
+	return "", nil
 }
 
 // GetTmpPath returns the tmp path as initialized.

--- a/api/env/path.go
+++ b/api/env/path.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-ingest/metadata"
+	log "github.com/unchartedsoftware/plog"
 
 	"github.com/uncharted-distil/distil/api/util"
 )
@@ -41,6 +42,7 @@ var (
 
 // Initialize the path resolution.
 func Initialize(config *Config) error {
+	log.Infof("initializing path values")
 	if initialized {
 		return errors.Errorf("path resolution already initialized")
 	}
@@ -56,6 +58,12 @@ func Initialize(config *Config) error {
 
 	contribPath = config.DatamartImportFolder
 	augmentedPath = path.Join(config.TmpDataPath, config.AugmentedSubFolder)
+
+	log.Infof("using '%s' as seed path", seedPath)
+	log.Infof("using '%s' as seed sub path", seedSubPath)
+	log.Infof("using '%s' as tmp path", tmpPath)
+	log.Infof("using '%s' as contrib path", contribPath)
+	log.Infof("using '%s' as augmented path", augmentedPath)
 
 	initialized = true
 

--- a/api/util/file.go
+++ b/api/util/file.go
@@ -134,9 +134,26 @@ func RemoveContents(dir string) error {
 	return nil
 }
 
-// IsDatasetDir indicate whether or not a directory contains a single d3m dataset
+// IsDatasetDir indicate whether or not a directory contains a single d3m dataset.
 func IsDatasetDir(dir string) bool {
 	datasetPath := path.Join(dir, "TRAIN", "dataset_TRAIN")
 	_, err := os.Stat(datasetPath)
 	return !os.IsNotExist(err)
+}
+
+// GetDirectories returns a list of directories found using the supplied path.
+func GetDirectories(inputPath string) ([]string, error) {
+	files, err := ioutil.ReadDir(inputPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list directory content")
+	}
+
+	dirs := make([]string, 0)
+	for _, f := range files {
+		if f.IsDir() {
+			dirs = append(dirs, path.Join(inputPath, f.Name()))
+		}
+	}
+
+	return dirs, nil
 }


### PR DESCRIPTION
On the API CI, the complete datasets directory gets mounted. This update finds the `seed_datasets_current` folder and uses that as input folder if `D3MINPUTDIR` is not set to a dataset folder or the seed dataset folder already.