### PR TITLE
Trigger join from join status panel

### DIFF
--- a/public/components/StatusPanel.vue
+++ b/public/components/StatusPanel.vue
@@ -14,10 +14,31 @@
 				<div class="circle-spinner"></div>
 			</div>
 			<div v-else-if="isResolved">
-				<div>
-					<p>
-						{{ contentData.resolvedMsg }}
-					</p>
+				<div v-if="this.statusType === 'JOIN_SUGGESTION'">
+					<div v-for="dataset in requestData.result.datasets" :key="dataset.id">
+						<p>
+							{{dataset.id}}
+						</p>
+						<p>
+							name: {{dataset.name}}
+						</p>
+						<p>
+							{{dataset.description}}
+						</p>
+						<p>
+							rows: {{dataset.numRows}}
+						</p>
+						<p>
+							size: {{dataset.numBytes}}
+						</p>
+					</div>
+				</div>
+				<div v-esle>
+					<div>
+						<p>
+							{{ contentData.resolvedMsg }}
+						</p>
+					</div>
 				</div>
 				<b-button variant="primary" @click="applyChange">Apply</b-button>
 				<b-button variant="secondary" @click="clearData">Discard</b-button>
@@ -64,6 +85,7 @@ export default Vue.extend({
 			const request = datasetGetters
 				.getPendingRequests(this.$store)
 				.find(request => request.dataset === this.dataset && request.type === this.statusType);
+			console.log(request);
 			return request;
 		},
 		isPending: function () {
@@ -103,7 +125,7 @@ export default Vue.extend({
 					return {
 						title: 'Join Suggestion',
 						pendingMsg: '',
-						resolvedMsg: '',
+						resolvedMsg: 'Suggested data sets for join',
 						errorMsg: '',
 					};
 				default:

--- a/public/components/StatusPanel.vue
+++ b/public/components/StatusPanel.vue
@@ -1,7 +1,7 @@
 <template>
 
 <div class="status-panel" v-if="isOpen">
-	<div>
+	<div class="d-flex flex-column h-100">
 		<div class="heading">
 			<h4 class="title">{{ contentData.title }}</h4>
 			<div class="close-button" @click="close()">
@@ -15,33 +15,17 @@
 			</div>
 			<div v-else-if="isResolved">
 				<div v-if="this.statusType === 'JOIN_SUGGESTION'">
-					<div v-for="dataset in requestData.result.datasets" :key="dataset.id">
-						<p>
-							{{dataset.id}}
-						</p>
-						<p>
-							name: {{dataset.name}}
-						</p>
-						<p>
-							{{dataset.description}}
-						</p>
-						<p>
-							rows: {{dataset.numRows}}
-						</p>
-						<p>
-							size: {{dataset.numBytes}}
-						</p>
-					</div>
+					<status-panel-join></status-panel-join>
 				</div>
-				<div v-esle>
+				<div v-else>
 					<div>
 						<p>
 							{{ contentData.resolvedMsg }}
 						</p>
 					</div>
+					<b-button variant="primary" @click="applyChange">Apply</b-button>
+					<b-button variant="secondary" @click="clearData">Discard</b-button>
 				</div>
-				<b-button variant="primary" @click="applyChange">Apply</b-button>
-				<b-button variant="secondary" @click="clearData">Discard</b-button>
 			</div>
 			<div v-else-if="isError">
 				<div>
@@ -60,6 +44,8 @@
 <script lang="ts">
 
 import Vue from 'vue';
+import axios from 'axios';
+import StatusPanelJoin from '../components/StatusPanelJoin';
 import { DatasetPendingRequest, DatasetPendingRequestType, VariableRankingPendingRequest, DatasetPendingRequestStatus, GeocodingPendingRequest } from '../store/dataset/index';
 import { actions as datasetActions, getters as datasetGetters } from '../store/dataset/module';
 import { actions as appActions, getters as appGetters } from '../store/app/module';
@@ -68,6 +54,9 @@ import { StatusPanelState, StatusPanelContentType } from '../store/app';
 
 export default Vue.extend({
 	name: 'status-panel',
+	components: {
+		StatusPanelJoin,
+	},
 	computed: {
 		dataset(): string {
 			return routeGetters.getRouteDataset(this.$store);
@@ -79,6 +68,7 @@ export default Vue.extend({
 			return this.statusPanelState.isOpen;
 		},
 		statusType(): StatusPanelContentType {
+			console.log(this.statusPanelState.contentType);
 			return this.statusPanelState.contentType;
 		},
 		requestData: function () {
@@ -125,8 +115,7 @@ export default Vue.extend({
 					return {
 						title: 'Join Suggestion',
 						pendingMsg: '',
-						resolvedMsg: 'Suggested data sets for join',
-						errorMsg: '',
+						errorMsg: 'Unexpected error has happened while retreving join suggestions',
 					};
 				default:
 					return {
@@ -169,7 +158,7 @@ export default Vue.extend({
 			if (this.requestData) {
 				datasetActions.removePendingRequest(this.$store, this.requestData.id);
 			}
-		}
+		},
 	}
 });
 
@@ -201,6 +190,7 @@ export default Vue.extend({
 
 .status-panel .content {
 	padding: 10px;
+	overflow: auto;
 }
 
 .status-panel .title {

--- a/public/components/StatusPanel.vue
+++ b/public/components/StatusPanel.vue
@@ -75,7 +75,6 @@ export default Vue.extend({
 			const request = datasetGetters
 				.getPendingRequests(this.$store)
 				.find(request => request.dataset === this.dataset && request.type === this.statusType);
-			console.log(request);
 			return request;
 		},
 		isPending: function () {

--- a/public/components/StatusPanel.vue
+++ b/public/components/StatusPanel.vue
@@ -13,10 +13,8 @@
 			<div v-else-if="isPending" class="spinner">
 				<div class="circle-spinner"></div>
 			</div>
-			<div v-else-if="isResolved">
-				<div v-if="this.statusType === 'JOIN_SUGGESTION'">
-					<status-panel-join></status-panel-join>
-				</div>
+			<div v-else-if="isResolved" class="h-100">
+				<status-panel-join v-if="this.statusType === 'JOIN_SUGGESTION'"></status-panel-join>
 				<div v-else>
 					<div>
 						<p>
@@ -189,7 +187,6 @@ export default Vue.extend({
 
 .status-panel .content {
 	padding: 10px;
-	overflow: auto;
 }
 
 .status-panel .title {

--- a/public/components/StatusPanel.vue
+++ b/public/components/StatusPanel.vue
@@ -178,6 +178,7 @@ export default Vue.extend({
 
 .status-panel .heading {
 	height: 58px;
+	flex-shrink: 0;
 	border-bottom: 1px solid #f1f3f4;
 	display: flex;
 	align-items: center;

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -1,0 +1,134 @@
+<template>
+    <div class="status-panel-join">
+		<p>Select a dataset to join with</p>
+        <div v-for="(item, index) in suggestionItems" :key="item.id">
+			<div @click="selectItem(index)" v-bind:class="{ selected: index === selectedIndex, available: item.isAvailable, noavail: item.isAvailable === false }">
+				<p>
+					{{item.dataset.id}}
+				</p>
+				<p>
+					name: {{item.dataset.name}}
+				</p>
+				<p>
+					{{item.dataset.description}}
+				</p>
+				<p>
+					rows: {{item.dataset.numRows}}
+				</p>
+				<p>
+					size: {{item.dataset.numBytes}}
+				</p>
+			</div>
+        </div>
+        <b-button :disabled="!selectedItem || !selectedItem.isAvailable" variant="primary" @click="join">Join</b-button>
+    </div>
+</template>
+
+<script lang="ts">
+
+import Vue from 'vue';
+import axios from 'axios';
+import {
+	Dataset,
+	DatasetPendingRequestType,
+	JoinSuggestionPendingRequest
+} from '../store/dataset/index';
+import { actions as datasetActions, getters as datasetGetters } from '../store/dataset/module';
+import { actions as appActions, getters as appGetters } from '../store/app/module';
+import { getters as routeGetters } from '../store/route/module';
+import { StatusPanelState, StatusPanelContentType } from '../store/app';
+
+interface JoinSuggestionItem {
+	dataset: Dataset;
+	isAvailable: boolean; // tell if dataset is available in the system for join
+}
+
+interface StatusPanelJoinState {
+	selectedIndex: number;
+	suggestionItems: JoinSuggestionItem[];
+}
+
+export default Vue.extend({
+	name: 'status-panel-join',
+	data(): StatusPanelJoinState {
+		return {
+			selectedIndex: -1,
+			suggestionItems: [],
+		};
+	},
+	computed: {
+		dataset(): string {
+			return routeGetters.getRouteDataset(this.$store);
+		},
+		joinSuggestionRequestData(): JoinSuggestionPendingRequest {
+			const request = datasetGetters.getPendingRequests(this.$store)
+				.find(request => request.dataset === this.dataset && request.type === DatasetPendingRequestType.JOIN_SUGGESTION);
+			return <JoinSuggestionPendingRequest>request;
+		},
+		joinSuggestoins(): Dataset[] {
+			const joinSuggestions = this.joinSuggestionRequestData.suggestions;
+			return joinSuggestions;
+		},
+		selectedItem(): JoinSuggestionItem {
+			return this.suggestionItems[this.selectedIndex];
+		},
+	},
+	methods: {
+		updateSuggestionItems() {
+			const items = this.joinSuggestoins || [];
+			this.suggestionItems = items.map(suggestion => ({
+				dataset: suggestion,
+				isAvailable: undefined
+			}));
+			console.log(this.suggestionItems);
+		},
+		selectItem(index) {
+			this.selectedIndex = index;
+			const selected = this.suggestionItems[this.selectedIndex];
+			if (selected.isAvailable === undefined) {
+				this.checkDatasetExist(selected.dataset.id).then(exist => selected.isAvailable = exist);
+			}
+			setTimeout(() => {
+				selected.isAvailable = true;
+			}, 4000);
+		},
+		join() {
+			const selected = this.suggestionItems[this.selectedIndex];
+		},
+		checkDatasetExist(datasetId) {
+			return axios.get(`/distil/datasets/${datasetId}`).then(result => {
+				return result ? true : false;
+			}).catch(e => {
+				return false;
+			});
+		},
+		importDataset(args: {datasetID: string, source: string, provenance: string}) {
+			// return axios.post(`/distil/import/${args.datasetID}/${args.source}/${args.provenance}`, {})
+		}
+	},
+	watch: {
+		joinSuggestions(suggestions) {
+			this.updateSuggestionItems();
+		},
+	},
+	created() {
+		this.updateSuggestionItems();
+	},
+});
+
+</script>
+
+<style>
+.status-panel-join .selected {
+	background-color: bisque;
+}
+
+.status-panel-join .available {
+	background-color: aqua;
+}
+
+.status-panel-join .noavail {
+	background-color: brown;
+}
+
+</style>

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -59,7 +59,6 @@ import { actions as datasetActions, getters as datasetGetters } from '../store/d
 import { actions as appActions, getters as appGetters } from '../store/app/module';
 import { getters as routeGetters } from '../store/route/module';
 import { StatusPanelState, StatusPanelContentType } from '../store/app';
-import { Promise, async } from 'q';
 
 interface JoinSuggestionItem {
 	dataset: Dataset;
@@ -145,7 +144,8 @@ export default Vue.extend({
 			const selected = this.suggestionItems[this.selectedIndex];
 			if (selected.isAvailable === undefined) { return; }
 			if (selected.isAvailable === false) {
-				this.$refs['import-ask-modal'].show();
+				const importAskModal: any = this.$refs['import-ask-modal'];
+				importAskModal.show();
 			}
 		},
 		checkDatasetExist(datasetId) {
@@ -160,7 +160,7 @@ export default Vue.extend({
 			if (!this.isImporting) {
 				datasetActions.importJoinDataset(this.$store, {datasetID: id, source: 'contrib', provenance, time: 20000}).then(() => {
 					this.importedItem.isAvailable = true;
-				})
+				});
 			}
 		},
 	},
@@ -173,7 +173,7 @@ export default Vue.extend({
 		this.updateSuggestionItems();
 	},
 	beforeDestroy() {
-		const importRequest = this.joinDatasetImportRequestData; 
+		const importRequest = this.joinDatasetImportRequestData;
 		if (importRequest && importRequest.status !== DatasetPendingRequestStatus.PENDING) {
 			datasetActions.updatePendingRequestStatus(this.$store, {
 				id: importRequest.id,

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -8,7 +8,7 @@
 				Successfully imported <b>{{ importedDataset.name }}</b>
 			</b-alert>
 			<b-alert v-else-if="isImportRequestError" :show="showStatusMessage" variant="danger" dismissible  @dismissed="reviewImportingRequest">
-				Error has occured while importing <b>{{ importedDataset.name }}</b>
+				Unexpected error has occured while importing <b>{{ importedDataset.name }}</b>
 			</b-alert>
 		</div>
 		<div class="suggestion-heading">

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -15,6 +15,9 @@
 			<h6>Select a dataset to join with: </h6>
 		</div>
 		<div class="suggstion-list">
+			<div v-if="suggestionItems.length === 0">
+				No datasets are found
+			</div>
 			<b-list-group>
 				<b-list-group-item
 					v-for="item in suggestionItems"

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -9,7 +9,7 @@
 				<p>
 					name: {{item.dataset.name}}
 				</p>
-				<p>
+				<p v-html="item.dataset.description">
 					{{item.dataset.description}}
 				</p>
 				<p>

--- a/public/components/StatusSidebar.vue
+++ b/public/components/StatusSidebar.vue
@@ -11,12 +11,11 @@
 			<i v-if="isNew(geocodingStatus)" class="new-update-notification fa fa-circle"></i>
 			<i v-if="isPending(geocodingStatus)" class="new-update-notification fa fa-refresh fa-spin"></i>
         </div>
-		<!-- Join sugestions NYI -->
-        <!-- <div class="status-icon-wrapper" @click="onStatusIconClick(2)">
-            <i class="status-icon fa fa-2x fa-code-fork" aria-hidden="true"></i>
+        <div class="status-icon-wrapper" @click="onStatusIconClick(2)">
+            <i class="status-icon fa fa-2x fa-table" aria-hidden="true"></i>
 			<i v-if="isNew(joinSuggestionStatus)" class="new-update-notification fa fa-circle"></i>
 			<i v-if="isPending(joinSuggestionStatus)" class="new-update-notification fa fa-refresh fa-spin"></i>
-        </div> -->
+        </div>
     </div>
 </div>
     

--- a/public/components/StatusSidebar.vue
+++ b/public/components/StatusSidebar.vue
@@ -15,6 +15,8 @@
             <i class="status-icon fa fa-2x fa-table" aria-hidden="true"></i>
 			<i v-if="isNew(joinSuggestionStatus)" class="new-update-notification fa fa-circle"></i>
 			<i v-if="isPending(joinSuggestionStatus)" class="new-update-notification fa fa-refresh fa-spin"></i>
+			<i v-if="isReviewd(joinSuggestionStatus) && isNew(joinDataImportStatus)" class="new-update-notification fa fa-circle"></i>
+			<i v-if="isReviewd(joinSuggestionStatus) && isPending(joinDataImportStatus)" class="new-update-notification fa fa-refresh fa-spin"></i>
         </div>
     </div>
 </div>
@@ -27,7 +29,15 @@ import Vue from 'vue';
 import { actions as datasetActions, getters as datasetGetters } from '../store/dataset/module';
 import { actions as appActions } from '../store/app/module';
 import { getters as routeGetters } from '../store/route/module';
-import { DatasetPendingRequestType, DatasetPendingRequest, VariableRankingPendingRequest, DatasetPendingRequestStatus } from '../store/dataset/index';
+import {
+	DatasetPendingRequestType,
+	DatasetPendingRequest,
+	VariableRankingPendingRequest,
+	DatasetPendingRequestStatus,
+	GeocodingPendingRequest,
+	JoinSuggestionPendingRequest,
+	JoinDatasetImportPendingRequest,
+} from '../store/dataset/index';
 
 const STATUS_TYPES = [
 	DatasetPendingRequestType.VARIABLE_RANKING,
@@ -41,27 +51,38 @@ export default Vue.extend({
 		dataset(): string {
 			return routeGetters.getRouteDataset(this.$store);
 		},
-		pendingRequests: function () {
+		pendingRequests(): DatasetPendingRequest[] {
+			// pending requests for given dataset
 			const updates = datasetGetters.getPendingRequests(this.$store).filter(update => update.dataset === this.dataset);
 			return updates;
 		},
-		variableRankingRequestData: function () {
-			return this.pendingRequests.find(item =>  item.type === DatasetPendingRequestType.VARIABLE_RANKING);
+		variableRankingRequestData(): VariableRankingPendingRequest {
+			return <VariableRankingPendingRequest>this.pendingRequests.find(item => item.type === DatasetPendingRequestType.VARIABLE_RANKING);
 		},
-		geocodingRequestData: function () {
-			return this.pendingRequests.find(item => item.type === DatasetPendingRequestType.GEOCODING);
+		geocodingRequestData(): GeocodingPendingRequest {
+			return <GeocodingPendingRequest>this.pendingRequests.find(item => item.type === DatasetPendingRequestType.GEOCODING);
 		},
-		joinSuggestionRequestData: function () {
-			return this.pendingRequests.find(item => item.type === DatasetPendingRequestType.JOIN_SUGGESTION);
+		joinSuggestionRequestData(): JoinSuggestionPendingRequest {
+			return <JoinSuggestionPendingRequest>this.pendingRequests.find(item => item.type === DatasetPendingRequestType.JOIN_SUGGESTION);
 		},
-		variableRankingStatus: function () {
+		joinDataImportRequestData(): JoinDatasetImportPendingRequest {
+			const pendingRequests = datasetGetters.getPendingRequests(this.$store);
+			const joinSuggestions = this.joinSuggestionRequestData.suggestions;
+			const importRequest = <JoinDatasetImportPendingRequest>pendingRequests.find(item => item.type === DatasetPendingRequestType.JOIN_DATASET_IMPORT);
+			const matchingDataset = joinSuggestions.find(dataset => dataset.id === (importRequest && importRequest.dataset));
+			return matchingDataset && importRequest;
+		},
+		variableRankingStatus(): DatasetPendingRequestStatus {
 			return this.variableRankingRequestData && this.variableRankingRequestData.status;
 		},
-		geocodingStatus: function () {
+		geocodingStatus(): DatasetPendingRequestStatus {
 			return this.geocodingRequestData && this.geocodingRequestData.status;
 		},
-		joinSuggestionStatus: function () {
+		joinSuggestionStatus(): DatasetPendingRequestStatus {
 			return this.joinSuggestionRequestData && this.joinSuggestionRequestData.status;
+		},
+		joinDataImportStatus(): DatasetPendingRequestStatus {
+			return this.joinDataImportRequestData && this.joinDataImportRequestData.status;
 		},
 	},
 	methods: {
@@ -70,6 +91,9 @@ export default Vue.extend({
 		},
 		isPending(status) {
 			return DatasetPendingRequestStatus.PENDING === status;
+		},
+		isReviewd(status) {
+			return status === DatasetPendingRequestStatus.REVIEWED;
 		},
 		onStatusIconClick(iconIndex) {
 			const statusType = STATUS_TYPES[iconIndex];

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -2,7 +2,18 @@ import _ from 'lodash';
 import axios from 'axios';
 import { Dictionary } from '../../util/dict';
 import { ActionContext } from 'vuex';
-import { Dataset, DatasetState, Variable, VariableSummary, Grouping, DatasetPendingRequestType, DatasetPendingRequestStatus, DatasetPendingRequest, VariableRankingPendingRequest, GeocodingPendingRequest, JoinSuggestionPendingRequest } from './index';
+import {
+	Dataset,
+	DatasetState,
+	Variable,
+	Grouping,
+	DatasetPendingRequestType,
+	DatasetPendingRequestStatus,
+	VariableRankingPendingRequest,
+	GeocodingPendingRequest,
+	JoinSuggestionPendingRequest,
+	JoinDatasetImportPendingRequest,
+} from './index';
 import { mutations } from './module';
 import { DistilState } from '../store';
 import { HighlightRoot } from '../highlights/index';
@@ -150,7 +161,7 @@ export const actions = {
 			dataset: args.dataset,
 			type: DatasetPendingRequestType.JOIN_SUGGESTION,
 			status: DatasetPendingRequestStatus.PENDING,
-			suggestions: undefined,
+			suggestions: [],
 		};
 		mutations.updatePendingRequests(context, request);
 		return axios.get(`/distil/join-suggestions/${args.dataset}`, { params: { search: 'weather' } })
@@ -200,6 +211,39 @@ export const actions = {
 		return axios.post(`/distil/import/${args.datasetID}/${args.source}/${args.provenance}`, {})
 			.then(response => {
 				return context.dispatch('searchDatasets', args.terms);
+			});
+	},
+
+	importJoinDataset(context: DatasetContext, args: { datasetID: string, source: string, provenance: string, time: number }): Promise<void>  {
+		if (!args.datasetID) {
+			console.warn('`datasetID` argument is missing');
+			return null;
+
+		}
+		const mockImport = () => {
+			return new Promise((resolve, reject) => {
+				setTimeout(() => {
+					resolve('done');
+				}, args.time || 3000);
+			});
+		};
+
+		const id = _.uniqueId();
+		const update: JoinDatasetImportPendingRequest = {
+			id,
+			dataset: args.datasetID,
+			type: DatasetPendingRequestType.JOIN_DATASET_IMPORT,
+			status: DatasetPendingRequestStatus.PENDING,
+		};
+		mutations.updatePendingRequests(context, update);
+		// return axios.post(`/distil/import/${args.datasetID}/${args.source}/${args.provenance}`, {})
+		return mockImport()
+			.then(response => {
+				mutations.updatePendingRequests(context, { ...update, status: DatasetPendingRequestStatus.RESOLVED });
+			})
+			.catch(error => {
+				mutations.updatePendingRequests(context, { ...update, status: DatasetPendingRequestStatus.ERROR });
+				console.error(error);
 			});
 	},
 

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -150,12 +150,13 @@ export const actions = {
 			dataset: args.dataset,
 			type: DatasetPendingRequestType.JOIN_SUGGESTION,
 			status: DatasetPendingRequestStatus.PENDING,
-			result: undefined,
+			suggestions: undefined,
 		};
 		mutations.updatePendingRequests(context, request);
 		return axios.get(`/distil/join-suggestions/${args.dataset}`, { params: { search: 'weather' } })
 			.then((response) => {
-				mutations.updatePendingRequests(context, { ...request, status: DatasetPendingRequestStatus.RESOLVED, result: response.data });
+				const suggestions = response.data && response.data.datasets;
+				mutations.updatePendingRequests(context, { ...request, status: DatasetPendingRequestStatus.RESOLVED, suggestions });
 			})
 			.catch(error => {
 				mutations.updatePendingRequests(context, { ...request, status: DatasetPendingRequestStatus.ERROR });

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -214,7 +214,7 @@ export const actions = {
 			});
 	},
 
-	importJoinDataset(context: DatasetContext, args: { datasetID: string, source: string, provenance: string, time: number }): Promise<void>  {
+	importJoinDataset(context: DatasetContext, args: { datasetID: string, source: string, provenance: string, time: number }): Promise<any>  {
 		if (!args.datasetID) {
 			console.warn('`datasetID` argument is missing');
 			return null;
@@ -223,7 +223,7 @@ export const actions = {
 		const mockImport = () => {
 			return new Promise((resolve, reject) => {
 				setTimeout(() => {
-					resolve('done');
+					resolve({ result: 'ingested' });
 				}, args.time || 3000);
 			});
 		};
@@ -240,6 +240,7 @@ export const actions = {
 		return mockImport()
 			.then(response => {
 				mutations.updatePendingRequests(context, { ...update, status: DatasetPendingRequestStatus.RESOLVED });
+				return response;
 			})
 			.catch(error => {
 				mutations.updatePendingRequests(context, { ...update, status: DatasetPendingRequestStatus.ERROR });

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -164,9 +164,9 @@ export const actions = {
 			suggestions: [],
 		};
 		mutations.updatePendingRequests(context, request);
-		return axios.get(`/distil/join-suggestions/${args.dataset}`, { params: { search: 'weather' } })
+		return axios.get(`/distil/join-suggestions/${args.dataset}`, { params: { search: 'country' } })
 			.then((response) => {
-				const suggestions = response.data && response.data.datasets;
+				const suggestions = (response.data && response.data.datasets) || [];
 				mutations.updatePendingRequests(context, { ...request, status: DatasetPendingRequestStatus.RESOLVED, suggestions });
 			})
 			.catch(error => {

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -152,6 +152,7 @@ export enum DatasetPendingRequestType {
 	VARIABLE_RANKING = 'VARIABLE_RANKING',
 	GEOCODING = 'GEOCODING',
 	JOIN_SUGGESTION = 'JOIN_SUGGESTION',
+	JOIN_DATASET_IMPORT = 'JOIN_DATASET_IMPORT',
 }
 
 export enum DatasetPendingRequestStatus {
@@ -187,10 +188,18 @@ export interface JoinSuggestionPendingRequest {
 	suggestions: Dataset[];
 }
 
+export interface JoinDatasetImportPendingRequest {
+	id: string;
+	status: DatasetPendingRequestStatus;
+	type: DatasetPendingRequestType.JOIN_DATASET_IMPORT;
+	dataset: string;
+}
+
 export type DatasetPendingRequest =
 		VariableRankingPendingRequest
 	| GeocodingPendingRequest
-	| JoinSuggestionPendingRequest;
+	| JoinSuggestionPendingRequest
+	| JoinDatasetImportPendingRequest;
 
 export const state: DatasetState = {
 	// datasets and filtered datasets

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -57,6 +57,13 @@ export interface Dataset {
 	numRows: number;
 	provenance: string;
 	source: string;
+	joinSuggestion?: JoinSuggestion[];
+}
+
+export interface JoinSuggestion {
+	baseDataset: string;
+	baseColumns: string[];
+	joinColumns: string[];
 }
 
 export interface Extrema {
@@ -177,7 +184,7 @@ export interface JoinSuggestionPendingRequest {
 	status: DatasetPendingRequestStatus;
 	type: DatasetPendingRequestType.JOIN_SUGGESTION;
 	dataset: string;
-	result: string;
+	suggestions: Dataset[];
 }
 
 export type DatasetPendingRequest =

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -77,6 +77,7 @@ export const actions = {
 	removePendingRequest: dispatch(moduleActions.removePendingRequest),
 	// join suggestions
 	fetchJoinSuggestions: dispatch(moduleActions.fetchJoinSuggestions),
+	importJoinDataset: dispatch(moduleActions.importJoinDataset),
 	// files
 	fetchFiles: dispatch(moduleActions.fetchFiles),
 	fetchImage: dispatch(moduleActions.fetchImage),

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -70,6 +70,8 @@ export const actions = {
 	// pending request
 	updatePendingRequestStatus: dispatch(moduleActions.updatePendingRequestStatus),
 	removePendingRequest: dispatch(moduleActions.removePendingRequest),
+	// join suggestions
+	fetchJoinSuggestions: dispatch(moduleActions.fetchJoinSuggestions),
 	// files
 	fetchFiles: dispatch(moduleActions.fetchFiles),
 	fetchImage: dispatch(moduleActions.fetchImage),

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -129,6 +129,8 @@ export const actions = {
 		// fetch new state
 		const dataset = context.getters.getRouteDataset;
 
+		context.dispatch('fetchJoinSuggestions', { dataset });
+
 		return context.dispatch('fetchVariables', {
 			dataset: dataset
 		}).then(() => {


### PR DESCRIPTION
- Searching join candidate datasets in background in create models tab. 
- In the Join status panel, user can browse datamart datasets, import a dataset and trigger join.

Note: New join workflow/navigation is WIP. I'm trying to merge this change first before I jump in to working on the next 
