### PR TITLE
map back to original types when saving as dataset

### DIFF
--- a/api/task/join.go
+++ b/api/task/join.go
@@ -130,6 +130,13 @@ func createMergedVariables(varNames []string, varsLeft []*model.Variable, varsRi
 				return nil, errors.Errorf("can't find data for result var \"%s\"", varName)
 			}
 		}
+
+		// map any distil types (country, city, etc.) back to LL schema types since we are
+		// persisting as an LL dataset
+		if v.OriginalType != "" {
+			v.Type = v.OriginalType
+		}
+
 		v.Index = i
 		mergedVariables = append(mergedVariables, v)
 	}

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -61,9 +61,10 @@ func TestJoin(t *testing.T) {
 			Type:        model.IntegerType,
 		},
 		{
-			Name:        "charlie",
-			DisplayName: "Charlie",
-			Type:        model.CategoricalType,
+			Name:         "charlie",
+			DisplayName:  "Charlie",
+			Type:         model.CountryType,
+			OriginalType: model.CategoricalFilter,
 		},
 		{
 			Name:        "delta",


### PR DESCRIPTION
fixes #954 

We were saving out internal types such as `country` and `city` when writing the join dataset prior to import.  The types were not valid within the LL dataset schema, so the import process would fail when the D3M dataset loading / validation code ran.  We now ensure that the original LL types are written out.