### PR TITLE
Auto zoom map to data bound

### DIFF
--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -12,7 +12,7 @@
 				No results available
 			</div>
 
-			<template v-if="hasData">
+			<template v-if="hasData && !hasNoResults">
 				<results-data-table v-if="viewType===TABLE_VIEW" :data-fields="dataFields" :data-items="dataItems" :instance-name="instanceName"></results-data-table>
 				<results-timeseries-view v-if="viewType===TIMESERIES_VIEW" :fields="dataFields" :items="dataItems" :instance-name="instanceName"></results-timeseries-view>
 				<results-geo-plot v-if="viewType===GEO_VIEW" :data-fields="dataFields" :data-items="dataItems"  :instance-name="instanceName"></results-geo-plot>

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -16,7 +16,6 @@ export interface RouteArgs {
 	row?: string;
 	residualThresholdMin?: string;
 	residualThresholdMax?: string;
-	geo?: string;
 	joinDatasets?: string;
 	joinColumnA?: string;
 	joinColumnB?: string;
@@ -85,7 +84,6 @@ function validateQueryArgs(args: RouteArgs): RouteArgs {
 	if (!_.isUndefined(args.residualThresholdMax)) { query.residualThresholdMax = args.residualThresholdMax; }
 	if (!_.isUndefined(args.highlights)) { query.highlights = args.highlights; }
 	if (!_.isUndefined(args.row)) { query.row = args.row; }
-	if (!_.isUndefined(args.geo)) { query.geo = args.geo; }
 	if (!_.isUndefined(args.joinDatasets)) { query.joinDatasets = args.joinDatasets; }
 	if (!_.isUndefined(args.joinColumnA)) { query.joinColumnA = args.joinColumnA; }
 	if (!_.isUndefined(args.joinColumnB)) { query.joinColumnB = args.joinColumnB; }


### PR DESCRIPTION
Resolves #964 

- With this update, since map auto zooms to its bounds of data points, keeping map state in the url didn't seem so useful. So deleted the geo params from url. Now update in data points changes the zoom accordingly. 
- Fixed split result data tables layout when there's no results.
