### PR TITLE
Date/Time Entry Fix (#1015)

### DIFF
--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -63,7 +63,6 @@ const TYPES_TO_LABELS: Dictionary<string> = {
 	[COUNTRY_CODE_TYPE]: 'Country Code',
 	[URI_TYPE]: 'URI',
 	[DATE_TIME_TYPE]: 'Date/Time',
-	[DATE_TIME_LOWER_TYPE]: `Date/Time`,
 	[BOOL_TYPE]: 'Boolean',
 	[IMAGE_TYPE]: 'Image',
 	[TIMESERIES_TYPE]: 'Timeseries',
@@ -130,6 +129,7 @@ const LOCATION_TYPES = [
 
 const TIME_TYPES = [
 	DATE_TIME_TYPE,
+	DATE_TIME_LOWER_TYPE,
 	TIMESTAMP_TYPE
 ];
 
@@ -165,6 +165,13 @@ const EMAIL_SUGGESTIONS = [
 const URI_SUGGESTIONS = [
 	TEXT_TYPE,
 	URI_TYPE,
+	UNKNOWN_TYPE
+];
+
+const TIME_SUGGESTIONS = [
+	DATE_TIME_TYPE,
+	TEXT_TYPE,
+	CATEGORICAL_TYPE,
 	UNKNOWN_TYPE
 ];
 
@@ -244,6 +251,7 @@ const EQUIV_TYPES = {
 	[POSTAL_CODE_TYPE]: [ POSTAL_CODE_TYPE ],
 	[URI_TYPE]: [ URI_TYPE ],
 	[DATE_TIME_TYPE]: [ DATE_TIME_TYPE ],
+	[DATE_TIME_LOWER_TYPE]: [ DATE_TIME_TYPE ],
 	[BOOL_TYPE]: [ BOOL_TYPE ],
 	[IMAGE_TYPE]: [ IMAGE_TYPE ],
 	[TIMESERIES_TYPE]: [ TIMESERIES_TYPE ],
@@ -251,7 +259,6 @@ const EQUIV_TYPES = {
 };
 
 export function isEquivalentType(a: string, b: string): boolean {
-
 	const equiv = EQUIV_TYPES[a];
 	if (!equiv) {
 		console.warn(`Unable to find equivalent types for type '${a}', type unrecognized`);
@@ -261,6 +268,14 @@ export function isEquivalentType(a: string, b: string): boolean {
 		return type === b;
 	});
 	return matches.length > 0;
+}
+
+export function normalizedEquivalentType (rawType: string): string {
+	const normalizedType = EQUIV_TYPES[rawType];
+	if (!normalizedType) {
+		return rawType;
+	}
+	return normalizedType[0];
 }
 
 export function getVarType(varname: string): string {
@@ -450,6 +465,9 @@ export function guessTypeByValue(value: any): string[] {
 	}
 	if (IMAGE_REGEX.test(value)) {
 		return IMAGE_SUGGESTIONS;
+	}
+	if (Date.parse(value)) {
+		return TIME_SUGGESTIONS;
 	}
 	return TEXT_SUGGESTIONS;
 }


### PR DESCRIPTION
As a front-end only solution the duplicate date time issue, I modified types.ts to take the DATE_TIME_LOWER_TYPE out of the TYPES_TO_LABEL dictionary, but added it as a EQUIV_TYPE to DATE_TIME_TYPE, then I use EQUIV_TYPE in a new function, normalizedEquivalentType, which is used by TypeChangeMenu.vue's addMissingSuggestions and getSuggestedList functions to map types to their supported equivalents when possible. Additionally, I've added TIME_SUGGESTIONS to the guessTypeByValue function in types TS based on if Date.parse works on the value. Longer term, it'd be nice to have the types from the api as normalized as possible, but this is a suitable fix with flexibility for future inconsistent labeling if need to be in future.