### PR TITLE
Facet Menu Clean Up Fix (#1027)

### DIFF
--- a/public/components/Facets.vue
+++ b/public/components/Facets.vue
@@ -1041,9 +1041,7 @@ export default Vue.extend({
 
 		// specifically destroy menus so because we injected them
 		// and so we have to take manual action to destroy them
-		_.forIn(this.menus, function(menu){
-			menu.$destroy();
-		})
+		_.forIn(this.menus, menu => menu.$destroy());
 		this.menus = null;
 	},
 });

--- a/public/components/Facets.vue
+++ b/public/components/Facets.vue
@@ -983,9 +983,10 @@ export default Vue.extend({
 		// inject type headers
 		injectTypeChangeHeaders(group: Group, $elem: JQuery) {
 			if (this.enableTypeChange) {
+				const facetId = `${group.dataset}:${group.colName}`;
 				// if we have a menu for this already, destroy it to replace it
-				if (this.menus[group.colName]) {
-					this.menus[group.colName].$destroy();
+				if (this.menus[facetId]) {
+					this.menus[facetId].$destroy();
 				}
 				const $slot = $('<span/>');
 				$elem.find('.group-header').append($slot);
@@ -999,7 +1000,7 @@ export default Vue.extend({
 						}
 					});
 				menu.$mount($slot[0]);
-				this.menus[group.colName] = menu;
+				this.menus[facetId] = menu;
 			}
 		},
 

--- a/public/components/Facets.vue
+++ b/public/components/Facets.vue
@@ -69,6 +69,7 @@ export default Vue.extend({
 	data() {
 		const component = this as any;
 		return {
+			menus: {} as any,
 			facets: {} as any,
 			debouncedInjection: _.debounce((highlights: Highlight, selection: RowSelection, deemphasis: any) => {
 				// we need to guard here because this debounced call can execute
@@ -982,6 +983,10 @@ export default Vue.extend({
 		// inject type headers
 		injectTypeChangeHeaders(group: Group, $elem: JQuery) {
 			if (this.enableTypeChange) {
+				// if we have a menu for this already, destroy it to replace it
+				if (this.menus[group.colName]) {
+					this.menus[group.colName].$destroy();
+				}
 				const $slot = $('<span/>');
 				$elem.find('.group-header').append($slot);
 				const menu = new TypeChangeMenu(
@@ -994,6 +999,7 @@ export default Vue.extend({
 						}
 					});
 				menu.$mount($slot[0]);
+				this.menus[group.colName] = menu;
 			}
 		},
 
@@ -1031,6 +1037,13 @@ export default Vue.extend({
 	destroyed: function() {
 		this.facets.destroy();
 		this.facets = null;
+
+		// specifically destroy menus so because we injected them
+		// and so we have to take manual action to destroy them
+		_.forIn(this.menus, function(menu){
+			menu.$destroy();
+		})
+		this.menus = null;
 	},
 });
 </script>


### PR DESCRIPTION
Since we jquery inject menus into facets, we have to handle the destruction of those elements, otherwise every time we update a facet, we inject a new instance of TypeChangeMenu while the old instances aren't cleaned up (even though they're no longer displayed, their instances are still trying to act on prop changes; they are basically orphaned by the underlying uncharted-software/facets component as it changes, which is why it needs to re-inject every time anyway.) To handle this, its now tracking the menus by their column name as they're created in facets.vue such that if it's already created a menu for that column name, it calls destroy on the old menu before binding a new menu to the facet. It also calls destroy on all current menus when facets.vue is destroyed since the destroy call on our the imported facets instance won't call destroy on the injected menus otherwise, which was resulting in continued attempts at acting on updates even on pages which had no facets on them.