### PR TITLE
Timeseries Width Bucket

### DIFF
--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -209,11 +209,11 @@ func (f *CategoricalField) getTimeseriesHistogramAggQuery(extrema *api.Extrema, 
 		// want to return the count under bucket 0.
 		bucketQueryString = fmt.Sprintf("(%s - %s)", timeSelect, timeSelect)
 	} else {
-		bucketQueryString = fmt.Sprintf("width_bucket(%s, %g, %g, %d) - 1",
-			timeSelect, binning.Rounded.Min, binning.Rounded.Max, binning.Count)
+		bucketQueryString = fmt.Sprintf("width_bucket(%s, %d, %d, %d) - 1",
+			timeSelect, int(binning.Rounded.Min), int(binning.Rounded.Max), binning.Count)
 	}
 
-	histogramQueryString := fmt.Sprintf("(%s) * %g + %g", bucketQueryString, binning.Interval, binning.Rounded.Min)
+	histogramQueryString := fmt.Sprintf("(%s) * %d + %d", bucketQueryString, int(binning.Interval), int(binning.Rounded.Min))
 
 	return histogramAggName, bucketQueryString, histogramQueryString
 }

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -236,11 +236,11 @@ func (f *DateTimeField) getHistogramAggQuery(extrema *api.Extrema) (string, stri
 		// want to return the count under bucket 0.
 		bucketQueryString = fmt.Sprintf("(\"%s\" - \"%s\")", extrema.Key, extrema.Key)
 	} else {
-		bucketQueryString = fmt.Sprintf("width_bucket(cast(extract(epoch from \"%s\") as integer), %g, %g, %d) - 1",
-			extrema.Key, rounded.Min, rounded.Max, extrema.GetBucketCount())
+		bucketQueryString = fmt.Sprintf("width_bucket(cast(extract(epoch from \"%s\") as integer), %d, %d, %d) - 1",
+			extrema.Key, int(rounded.Min), int(rounded.Max), extrema.GetBucketCount())
 	}
 
-	histogramQueryString := fmt.Sprintf("(%s) * %g + %g", bucketQueryString, interval, rounded.Min)
+	histogramQueryString := fmt.Sprintf("(%s) * %d + %d", bucketQueryString, int(interval), int(rounded.Min))
 
 	return histogramAggName, bucketQueryString, histogramQueryString
 }
@@ -485,10 +485,10 @@ func (f *DateTimeField) getResultHistogramAggQuery(extrema *api.Extrema, resultV
 		// want to return the count under bucket 0.
 		bucketQueryString = fmt.Sprintf("(\"%s\" - \"%s\")", fieldTyped, fieldTyped)
 	} else {
-		bucketQueryString = fmt.Sprintf("width_bucket(%s, %g, %g, %d) - 1",
-			fieldTyped, rounded.Min, rounded.Max, extrema.GetBucketCount())
+		bucketQueryString = fmt.Sprintf("width_bucket(%s, %d, %d, %d) - 1",
+			fieldTyped, int(rounded.Min), int(rounded.Max), extrema.GetBucketCount())
 	}
-	histogramQueryString := fmt.Sprintf("(%s) * %g + %g", bucketQueryString, interval, rounded.Min)
+	histogramQueryString := fmt.Sprintf("(%s) * %d + %d", bucketQueryString, int(interval), int(rounded.Min))
 
 	return histogramAggName, bucketQueryString, histogramQueryString
 }

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -228,11 +228,11 @@ func (f *NumericalField) getTimeseriesHistogramAggQuery(extrema *api.Extrema, in
 		// want to return the count under bucket 0.
 		bucketQueryString = fmt.Sprintf("(%s - %s)", timeSelect, timeSelect)
 	} else {
-		bucketQueryString = fmt.Sprintf("width_bucket(%s, %g, %g, %d) - 1",
-			timeSelect, binning.Rounded.Min, binning.Rounded.Max, binning.Count)
+		bucketQueryString = fmt.Sprintf("width_bucket(%s, %d, %d, %d) - 1",
+			timeSelect, int(binning.Rounded.Min), int(binning.Rounded.Max), binning.Count)
 	}
 
-	histogramQueryString := fmt.Sprintf("(%s) * %g + %g", bucketQueryString, binning.Interval, binning.Rounded.Min)
+	histogramQueryString := fmt.Sprintf("(%s) * %d + %d", bucketQueryString, int(binning.Interval), int(binning.Rounded.Min))
 
 	return histogramAggName, bucketQueryString, histogramQueryString
 }

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -191,11 +191,11 @@ func (f *TextField) getTimeseriesHistogramAggQuery(extrema *api.Extrema, interva
 		// want to return the count under bucket 0.
 		bucketQueryString = fmt.Sprintf("(%s - %s)", timeSelect, timeSelect)
 	} else {
-		bucketQueryString = fmt.Sprintf("width_bucket(%s, %g, %g, %d) - 1",
-			timeSelect, binning.Rounded.Min, binning.Rounded.Max, binning.Count)
+		bucketQueryString = fmt.Sprintf("width_bucket(%s, %d, %d, %d) - 1",
+			timeSelect, int(binning.Rounded.Min), int(binning.Rounded.Max), binning.Count)
 	}
 
-	histogramQueryString := fmt.Sprintf("(%s) * %g + %g", bucketQueryString, binning.Interval, binning.Rounded.Min)
+	histogramQueryString := fmt.Sprintf("(%s) * %d + %d", bucketQueryString, int(binning.Interval), int(binning.Rounded.Min))
 
 	return histogramAggName, bucketQueryString, histogramQueryString
 }


### PR DESCRIPTION
Updated timeseries summary functions to use integers rather than floats of exponents since those can cause issues with width bucket intervals due to how floats are represented in binary.