### PR TITLE
Update Join Result Parsing

### DIFF
--- a/api/task/test_data/result.csv
+++ b/api/task/test_data/result.csv
@@ -1,5 +1,5 @@
-,d3mIndex,alpha,charlie
-0,0,1.0,a
-1,1,2.0,b
-2,2,3.0,c
-3,3,4.0,d
+d3mIndex,alpha,charlie
+0,1.0,a
+1,2.0,b
+2,3.0,c
+3,4.0,d


### PR DESCRIPTION
The new output function for dataframes in the latest core version removed the index from the output. The join had not yet been updated to no longer expect it and so was skipping the d3m index.