### PR TITLE
Validate there are join suggestions before display.

### DIFF
--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -34,7 +34,7 @@
 					<div class="description" v-html="item.dataset.description">
 						{{item.dataset.description}}
 					</div>
-					<div v-if="item.dataset.joinSuggestion" class="suggested-columns">
+					<div v-if="item.dataset.joinSuggestion && item.dataset.joinSuggestion[0]" class="suggested-columns">
 						<b>Suggested Join Columns: </b>{{item.dataset.joinSuggestion[0].joinColumns}}
 					</div>
 					<div>


### PR DESCRIPTION
Really should only be needed when the hack is in, but it's possible even the datamart return doesn't have join columns defined, and I don't want that to break the render.