### PR TITLE
Update modal class setting. (Fix for #1082)

### DIFF
--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -3,7 +3,7 @@
 
 		<b-modal
 			v-model="showJoinSuccess"
-			class="join-preview-modal"
+			modal-class="join-preview-modal"
 			@shown="onSuccessModalShwon"
 			cancel-disabled
 			hide-header


### PR DESCRIPTION
Setting the "class" attribute on a bootstrap vue modal doesn't work (any more at least,) it needed to be set on the "modal-class" attribute.