### PR TITLE
Timeseries result count

### DIFF
--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -28,6 +28,14 @@ const (
 	maxBatchSize = 250
 )
 
+type joinDefinition struct {
+	baseAlias     string
+	baseColumn    string
+	joinTableName string
+	joinAlias     string
+	joinColumn    string
+}
+
 func (s *Storage) getViewField(name string, displayName string, typ string, defaultValue interface{}) string {
 	return fmt.Sprintf("COALESCE(CAST(\"%s\" AS %s), %v) AS \"%s\"",
 		name, typ, defaultValue, displayName)
@@ -382,4 +390,14 @@ func (s *Storage) UpdateVariableBatch(storageName string, varName string, update
 	}
 
 	return nil
+}
+
+func getJoinSQL(join *joinDefinition, inner bool) string {
+	joinType := "INNER JOIN"
+	if !inner {
+		joinType = "LEFT OUTER JOIN"
+	}
+	return fmt.Sprintf("%s %s AS %s ON %s.\"%s\" = %s.\"%s\"",
+		joinType, join.joinTableName, join.joinAlias, join.joinAlias,
+		join.joinColumn, join.baseAlias, join.baseColumn)
 }

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -444,6 +444,12 @@ func (s *Storage) splitFilters(filterParams *api.FilterParams) *filters {
 // FetchNumRows pulls the number of rows in the table.
 func (s *Storage) FetchNumRows(storageName string, variables []*model.Variable, filters map[string]interface{}) (int, error) {
 
+	return s.fetchNumRowsJoined(storageName, variables, filters, nil)
+}
+
+// FetchNumRows pulls the number of rows in the table.
+func (s *Storage) fetchNumRowsJoined(storageName string, variables []*model.Variable, filters map[string]interface{}, join *joinDefinition) (int, error) {
+
 	countTarget := "*"
 
 	// match order by for distinct
@@ -466,7 +472,13 @@ func (s *Storage) FetchNumRows(storageName string, variables []*model.Variable, 
 		}
 	}
 
-	query := fmt.Sprintf("SELECT count(%s) FROM %s", countTarget, storageName)
+	joinSQL := ""
+	if join != nil {
+		join.baseAlias = "base_data"
+		joinSQL = getJoinSQL(join, true)
+	}
+
+	query := fmt.Sprintf("SELECT count(%s) FROM %s AS base_data %s", countTarget, storageName, joinSQL)
 	params := make([]interface{}, 0)
 	if filters != nil && len(filters) > 0 {
 		clauses := make([]string, 0)

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -539,7 +539,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 		joinAlias:     "joined",
 		joinColumn:    "index",
 	}
-	numRows, err := s.fetchNumRowsJoined(storageNameResult, variables, countFilter, joinDef)
+	numRows, err := s.fetchNumRowsJoined(storageName, variables, countFilter, joinDef)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not pull num rows")
 	}

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -533,7 +533,13 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 	countFilter := map[string]interface{}{
 		"result_id": resultURI,
 	}
-	numRows, err := s.FetchNumRows(storageNameResult, nil, countFilter)
+	joinDef := &joinDefinition{
+		baseColumn:    model.D3MIndexFieldName,
+		joinTableName: storageNameResult,
+		joinAlias:     "joined",
+		joinColumn:    "index",
+	}
+	numRows, err := s.fetchNumRowsJoined(storageNameResult, variables, countFilter, joinDef)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not pull num rows")
 	}


### PR DESCRIPTION
The result count when groupings existed now reflects the distinct count of groupings rather than the count of rows in the result table.