### PR TITLE
Bypass Join Column Selection For Direct Join #1109

### DIFF
--- a/api/routes/join.go
+++ b/api/routes/join.go
@@ -34,9 +34,7 @@ func JoinHandler(metaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *ht
 		// get dataset name
 		datasetIDLeft := pat.Param(r, "dataset-left")
 		sourceLeft := pat.Param(r, "source-left")
-		columnLeft := pat.Param(r, "column-left")
 		datasetIDRight := pat.Param(r, "dataset-right")
-		columnRight := pat.Param(r, "column-right")
 		sourceRight := pat.Param(r, "source-right")
 
 		// get storage client
@@ -59,14 +57,12 @@ func JoinHandler(metaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *ht
 		}
 
 		leftJoin := &task.JoinSpec{
-			Column:        columnLeft,
 			DatasetID:     datasetLeft.ID,
 			DatasetFolder: datasetLeft.Folder,
 			DatasetSource: metadata.DatasetSource(sourceLeft),
 		}
 
 		rightJoin := &task.JoinSpec{
-			Column:        columnRight,
 			DatasetID:     datasetRight.ID,
 			DatasetFolder: datasetRight.Folder,
 			DatasetSource: metadata.DatasetSource(sourceRight),

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -140,6 +140,7 @@ func createMergedVariables(varNames []string, leftVarsMap map[string]*model.Vari
 		// map any distil types (country, city, etc.) back to LL schema types since we are
 		// persisting as an LL dataset
 		if v.OriginalType != "" {
+			v.Type = v.OriginalType
 			v.Name = v.DisplayName
 			v.OriginalVariable = v.DisplayName
 		}

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -48,7 +48,6 @@ type JoinSpec struct {
 	DatasetID     string
 	DatasetFolder string
 	DatasetSource ingestMetadata.DatasetSource
-	Column        string
 }
 
 // Join will make all your dreams come true.
@@ -141,9 +140,9 @@ func createMergedVariables(varNames []string, leftVarsMap map[string]*model.Vari
 		// persisting as an LL dataset
 		if v.OriginalType != "" {
 			v.Type = v.OriginalType
-			v.Name = v.DisplayName
-			v.OriginalVariable = v.DisplayName
 		}
+		v.Name = v.DisplayName
+		v.OriginalVariable = v.DisplayName
 
 		v.Index = i
 		mergedVariables = append(mergedVariables, v)

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -140,7 +140,8 @@ func createMergedVariables(varNames []string, leftVarsMap map[string]*model.Vari
 		// map any distil types (country, city, etc.) back to LL schema types since we are
 		// persisting as an LL dataset
 		if v.OriginalType != "" {
-			v.Type = v.OriginalType
+			v.Name = v.DisplayName
+			v.OriginalVariable = v.DisplayName
 		}
 
 		v.Index = i

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -132,7 +132,19 @@ func createMergedVariables(varNames []string, leftVarsMap map[string]*model.Vari
 		if !ok {
 			v, ok = rightVarsMap[varName]
 			if !ok {
-				return nil, errors.Errorf("can't find data for result var \"%s\"", varName)
+				// variable is probably an aggregation
+				// create a new variable and default type to string
+				// ingest process should be able to provide better info
+				v = &model.Variable{
+					Name:             varName,
+					Type:             model.StringType,
+					OriginalType:     model.StringType,
+					SelectedRole:     "attribute",
+					Role:             []string{"attribute"},
+					DistilRole:       "data",
+					OriginalVariable: varName,
+					DisplayName:      varName,
+				}
 			}
 		}
 

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -82,14 +82,12 @@ func TestJoin(t *testing.T) {
 	env.Initialize(&cfg)
 
 	leftJoin := &JoinSpec{
-		Column:        "alpha",
 		DatasetID:     "test_1",
 		DatasetFolder: "test_1_TRAIN",
 		DatasetSource: "contrib",
 	}
 
 	rightJoin := &JoinSpec{
-		Column:        "charlie",
 		DatasetID:     "test_2",
 		DatasetFolder: "test_2_TRAIN",
 		DatasetSource: "contrib",
@@ -128,17 +126,17 @@ func TestJoin(t *testing.T) {
 	assert.ElementsMatch(t, result.Columns, []apiModel.Column{
 		{
 			Label: "D3M Index",
-			Key:   "d3mIndex",
+			Key:   "D3M Index",
 			Type:  model.IntegerType,
 		},
 		{
 			Label: "Alpha",
-			Key:   "alpha",
+			Key:   "Alpha",
 			Type:  model.RealType,
 		},
 		{
 			Label: "Charlie",
-			Key:   "charlie",
+			Key:   "Charlie",
 			Type:  model.CategoricalType,
 		},
 	})

--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func main() {
 	registerRoutePost(mux, "/distil/geocode/:dataset/:variable", routes.GeocodingHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/cluster/:dataset/:variable", routes.ClusteringHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/upload/:dataset", routes.UploadHandler(path.Join(config.TmpDataPath, config.AugmentedSubFolder), ingestConfig))
-	registerRoutePost(mux, "/distil/join/:dataset-left/:column-left/:source-left/:dataset-right/:column-right/:source-right", routes.JoinHandler(esMetadataStorageCtor))
+	registerRoutePost(mux, "/distil/join/:dataset-left/:source-left/:dataset-right/:source-right", routes.JoinHandler(esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries/:dataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:invert", routes.TimeseriesHandler(pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries-forecast/:dataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:result-uuid", routes.TimeseriesForecastHandler(pgDataStorageCtor, pgSolutionStorageCtor))
 

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -385,7 +385,7 @@ export const actions = {
 			return null;
 		}
 
-		return axios.post(`/distil/join/${args.datasetA.id}/${args.datasetAColumn}/${args.datasetA.source}/${args.datasetB.id}/${args.datasetBColumn}/${args.datasetB.source}`, {
+		return axios.post(`/distil/join/${args.datasetA.id}/${args.datasetA.source}/${args.datasetB.id}/${args.datasetB.source}`, {
 			accuracy: args.joinAccuracy
 		})
 			.then(response => {

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -188,6 +188,7 @@ export const actions = {
 		mutations.updatePendingRequests(context, request);
 
 		// Hack: force to include datamart.upload.fc0ceee28cb74bad83e4f8872979b111 to the result since that data set does not appear on the suggestion list.
+		/*
 		return axios.get(`/distil/datasets/${args.dataset}`)
 			.then(res => {
 				const dataset = res.data.dataset;
@@ -207,7 +208,7 @@ export const actions = {
 				mutations.updatePendingRequests(context, { ...request, status: DatasetPendingRequestStatus.ERROR });
 				console.error(error);
 			});
-		/*
+		*/
 		return axios.get(`/distil/datasets/${args.dataset}`)
 			.then(res => {
 				return axios.get(`/distil/join-suggestions/${args.dataset}`);
@@ -220,7 +221,6 @@ export const actions = {
 				mutations.updatePendingRequests(context, { ...request, status: DatasetPendingRequestStatus.ERROR });
 				console.error(error);
 			});
-		*/
 	},
 
 	uploadDataFile(context: DatasetContext, args: { datasetID: string, file: File }) {

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -224,9 +224,12 @@ export const actions = {
 			dataset: dataset
 		});
 
-		return fetchVariables(context, {
+		return Promise.all([fetchVariables(context, {
 			dataset: dataset
-		}).then(() => {
+		}),
+		datasetActions.fetchDataset(store, {
+			dataset: dataset
+		})]).then(() => {
 			fetchVariableRankings(context, { dataset, target });
 
 			return actions.updateSelectTrainingData(context);

--- a/public/views/SelectTraining.vue
+++ b/public/views/SelectTraining.vue
@@ -179,6 +179,9 @@ export default Vue.extend({
 		},
 		binningIntervalModel() {
 			viewActions.fetchSelectTrainingData(this.$store, true);
+		},
+		dataset() {
+			viewActions.fetchSelectTrainingData(this.$store, true);
 		}
 	},
 	beforeMount() {


### PR DESCRIPTION
Bypasses join selection for direct join after selecting a target join dataset in the join panel. Join button in panel attempts a join, if successful display preview modal where join can still be committed or canceled. All changes made are in service of making that work, including bypassing the hack for the actual datamarts as we don't have the desired column info in the hack.