### PR TITLE
Join After Import

### DIFF
--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -334,6 +334,7 @@ export default Vue.extend({
 				datasetActions.importJoinDataset(this.$store, {datasetID: id, source: 'contrib', provenance, searchResult}).then(res => {
 					if (res && (res.result === 'ingested')) {
 						this.importedItem.isAvailable = true;
+						this.importedDataset.source = 'contrib';
 					}
 				});
 			}


### PR DESCRIPTION
After an import, a refresh of the page was needed or the join would error with a 404 since the contrib was seemingly not being passed to the route.