### PR TITLE
allows for max training rows to be specified as config param

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -88,6 +88,7 @@ type Config struct {
 	IsTask1                            bool    `env:"TASK1" envDefault:"false"`
 	IsTask2                            bool    `env:"TASK2" envDefault:"false"`
 	SkipPreprocessing                  bool    `env:"SKIP_PREPROCESSING" envDefault:"false"`
+	MaxTrainingRows                    int     `env:"MAX_TRAINING_ROWS" envDefault:"10000"`
 }
 
 // LoadConfig loads the config from the environment if necessary and returns a


### PR DESCRIPTION
fixes #1143

Adds `MAX_TRAINING_ROWS` config param and applies it to limit the number of training rows created when doing the train / test split for a dataset at model creation time.