### PR TITLE
Dataset suggestions group

### DIFF
--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -58,6 +58,7 @@ type JoinSuggestion struct {
 	BaseDataset   string               `json:"baseDataset"`
 	BaseColumns   []string             `json:"baseColumns"`
 	JoinColumns   []string             `json:"joinColumns"`
+	JoinScore     float64              `json:"joinScore"`
 	DatasetOrigin *model.DatasetOrigin `json:"datasetOrigin"`
 }
 

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -57,6 +57,7 @@ type QueriedDataset struct {
 type JoinSuggestion struct {
 	BaseDataset   string               `json:"baseDataset"`
 	BaseColumns   []string             `json:"baseColumns"`
+	JoinDataset   string               `json:"joinDataset"`
 	JoinColumns   []string             `json:"joinColumns"`
 	JoinScore     float64              `json:"joinScore"`
 	DatasetOrigin *model.DatasetOrigin `json:"datasetOrigin"`

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -60,6 +60,7 @@ type JoinSuggestion struct {
 	JoinColumns   []string             `json:"joinColumns"`
 	JoinScore     float64              `json:"joinScore"`
 	DatasetOrigin *model.DatasetOrigin `json:"datasetOrigin"`
+	Index         int                  `json:"index"`
 }
 
 // FetchDataset builds a QueriedDataset from the needed parameters.

--- a/api/model/storage/datamart/isi.go
+++ b/api/model/storage/datamart/isi.go
@@ -209,10 +209,11 @@ func parseISIJoinSuggestion(result *ISISearchResult, baseDataset *api.Dataset) (
 		joins = append(joins, &api.JoinSuggestion{
 			BaseDataset:   baseDataset.ID,
 			BaseColumns:   leftColumnNames,
+			JoinDataset:   result.DatamartID,
 			JoinColumns:   rightColumnNames,
+			JoinScore:     result.Score,
 			DatasetOrigin: origin,
 			Index:         len(joins),
-			JoinScore:     result.Score,
 		})
 	}
 	return joins, materialization.Score, nil

--- a/api/model/storage/datamart/isi.go
+++ b/api/model/storage/datamart/isi.go
@@ -211,6 +211,8 @@ func parseISIJoinSuggestion(result *ISISearchResult, baseDataset *api.Dataset) (
 			BaseColumns:   leftColumnNames,
 			JoinColumns:   rightColumnNames,
 			DatasetOrigin: origin,
+			Index:         len(joins),
+			JoinScore:     result.Score,
 		})
 	}
 	return joins, materialization.Score, nil

--- a/api/model/storage/datamart/nyu.go
+++ b/api/model/storage/datamart/nyu.go
@@ -132,6 +132,7 @@ func parseNYUJoinSuggestion(result *SearchResult, baseDataset *api.Dataset) ([]*
 		joins = append(joins, &api.JoinSuggestion{
 			BaseDataset:   baseDataset.ID,
 			BaseColumns:   leftColumnNames,
+			JoinDataset:   result.Metadata.Name,
 			JoinColumns:   rightColumnNames,
 			JoinScore:     result.Score,
 			DatasetOrigin: origin,

--- a/api/model/storage/datamart/nyu.go
+++ b/api/model/storage/datamart/nyu.go
@@ -135,6 +135,7 @@ func parseNYUJoinSuggestion(result *SearchResult, baseDataset *api.Dataset) ([]*
 			JoinColumns:   rightColumnNames,
 			JoinScore:     result.Score,
 			DatasetOrigin: origin,
+			Index:         len(joins),
 		})
 	}
 	return joins, nil

--- a/api/model/storage/datamart/nyu.go
+++ b/api/model/storage/datamart/nyu.go
@@ -133,6 +133,7 @@ func parseNYUJoinSuggestion(result *SearchResult, baseDataset *api.Dataset) ([]*
 			BaseDataset:   baseDataset.ID,
 			BaseColumns:   leftColumnNames,
 			JoinColumns:   rightColumnNames,
+			JoinScore:     result.Score,
 			DatasetOrigin: origin,
 		})
 	}

--- a/api/routes/datasets.go
+++ b/api/routes/datasets.go
@@ -176,6 +176,9 @@ func loadDatasets(storage model.MetadataStorage, terms string, baseDataset *mode
 				if ds.JoinScore > existingDataset.JoinScore {
 					existingDataset.JoinScore = ds.JoinScore
 				}
+				for _, js := range ds.JoinSuggestions {
+					js.Index = js.Index + len(existingDataset.JoinSuggestions)
+				}
 				existingDataset.JoinSuggestions = append(existingDataset.JoinSuggestions, ds.JoinSuggestions...)
 			}
 		}

--- a/api/routes/join_suggestion.go
+++ b/api/routes/join_suggestion.go
@@ -102,7 +102,7 @@ func JoinSuggestionHandler(esCtor model.MetadataStorageCtor, metaCtors map[strin
 		}
 
 		datamartDatasets := append(datasetsMap[datamart.ProvenanceISI], datasetsMap[datamart.ProvenanceNYU]...)
-		datasets = filterDatasets(datamartDatasets, hasSuggestions)
+		datasets = filterDatasets(res, datamartDatasets, filterSuggestions)
 
 		localDatasets := make(map[string]*model.Dataset)
 		for provenance, datasets := range datasetsMap {
@@ -177,16 +177,25 @@ func getColNameByDisplayName(dataset model.Dataset, colDisplayName string) strin
 	return compute.NormalizeVariableName(colDisplayName) // fallback
 }
 
-func filterDatasets(datasets []*model.Dataset, predicate func(dataset *model.Dataset) bool) []*model.Dataset {
+func filterDatasets(queryDataset *model.Dataset, datasets []*model.Dataset,
+	predicate func(sourceDataset *model.Dataset, joinDataset *model.Dataset) bool) []*model.Dataset {
 	result := []*model.Dataset{}
 	for _, dataset := range datasets {
-		if predicate(dataset) {
+		if predicate(queryDataset, dataset) {
 			result = append(result, dataset)
 		}
 	}
 	return result
 }
 
-func hasSuggestions(dataset *model.Dataset) bool {
-	return dataset.JoinSuggestions != nil && len(dataset.JoinSuggestions) > 0
+func filterSuggestions(sourceDataset *model.Dataset, joinDataset *model.Dataset) bool {
+	// filter out datasets that have already been joined
+	for _, js := range sourceDataset.JoinSuggestions {
+		if joinDataset.Name == js.JoinDataset {
+			return false
+		}
+	}
+
+	// filter out join datasets with no suggestions
+	return joinDataset.JoinSuggestions != nil && len(joinDataset.JoinSuggestions) > 0
 }

--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -167,9 +167,8 @@ export default Vue.extend({
 			datasetActions.joinDatasetsPreview(this.$store, {
 				datasetA: a,
 				datasetB: b,
-				datasetAColumn: this.datasetAColumn.key,
-				datasetBColumn: this.datasetBColumn.key,
-				joinAccuracy: this.joinAccuracy
+				joinAccuracy: this.joinAccuracy,
+				joinSuggestionIndex: 0
 			}).then(tableData => {
 				this.pending = false;
 				this.showJoinSuccess = true;

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -34,9 +34,20 @@
 					<div class="description" v-html="item.dataset.description">
 						{{item.dataset.description}}
 					</div>
-					<div v-if="item.dataset.joinSuggestion && item.dataset.joinSuggestion[0]" class="suggested-columns">
-						<b>Suggested Join Columns: </b>{{item.dataset.joinSuggestion[0].joinColumns}}
-					</div>
+					<b-list-group>
+						<b-list-group-item
+                            v-for="suggestion in item.dataset.joinSuggestion"
+                            :key="suggestion.index"
+                            href="#"
+        					v-bind:class="{ selected: suggestion.selected }"
+        					:disabled="isImporting"
+        					@click="selectItem(suggestion)"
+						>
+                            <div  class="suggested-columns">
+                                <b>Suggested Join Columns: </b>{{suggestion.joinColumns}}
+                            </div>
+						</b-list-group-item>
+					</b-list-group>
 					<div>
 						<span>
 							<small v-if="!item.isAvailable" class="text-info">Requires import</small>

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -368,21 +368,13 @@ export const actions = {
 			});
 	},
 
-	joinDatasetsPreview(context: DatasetContext, args: { datasetA: Dataset, datasetB: Dataset, datasetAColumn: string, datasetBColumn: string, joinAccuracy: number }): Promise<void>  {
+	joinDatasetsPreview(context: DatasetContext, args: { datasetA: Dataset, datasetB: Dataset, joinAccuracy: number, joinSuggestionIndex: number }): Promise<void>  {
 		if (!args.datasetA) {
 			console.warn('`datasetA` argument is missing');
 			return null;
 		}
 		if (!args.datasetB) {
 			console.warn('`datasetB` argument is missing');
-			return null;
-		}
-		if (!args.datasetAColumn) {
-			console.warn('`datasetAColumn` argument is missing');
-			return null;
-		}
-		if (!args.datasetBColumn) {
-			console.warn('`datasetBColumn` argument is missing');
 			return null;
 		}
 
@@ -393,7 +385,7 @@ export const actions = {
 
 		return axios.post(`/distil/join/${args.datasetA.id}/${args.datasetA.source}/${args.datasetB.id}/${args.datasetB.source}`, {
 			accuracy: args.joinAccuracy,
-			searchResultIndex: 0
+			searchResultIndex: args.joinSuggestionIndex
 		})
 			.then(response => {
 				return response.data;

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -15,13 +15,6 @@ export interface Highlight {
 	value: any;
 }
 
-export interface Highlight {
-	context: string;
-	dataset: string;
-	key: string;
-	value: any;
-}
-
 export interface Column {
 	key: string;
 	value: any;
@@ -96,8 +89,11 @@ export interface Dataset {
 export interface JoinSuggestion {
 	baseDataset: string;
 	baseColumns: string[];
+	joinDataset: string;
 	joinColumns: string[];
+	joinScore: number;
 	datasetOrigin?: DatasetOrigin;
+	index: number;
 }
 
 export interface DatasetOrigin {


### PR DESCRIPTION
Datamarts will return multiple search results for a single dataset. This PR groups them together into a single card. The suggestions are then listed in the dataset card and the user can pick the exact suggestion to use when joining.