### PR TITLE
Result summary UI component visual stability

### DIFF
--- a/public/components/ErrorThresholdSlider.vue
+++ b/public/components/ErrorThresholdSlider.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="error-threshold-slider" v-if="hasExtrema">
+	<div class="error-threshold-slider">
 
 		<div>
 			<div class="error-header">
@@ -59,9 +59,10 @@ export default Vue.extend({
 	data() {
 		return {
 			symmetricSlider: true,
-			min: null,
-			max: null,
-			hasModified: false
+			min: null as number,
+			max: null as number,
+			hasModified: false,
+			lastExtrema: { min: -1.0, max: 1.0 } as Extrema
 		};
 	},
 
@@ -88,10 +89,13 @@ export default Vue.extend({
 
 		residualExtrema(): Extrema {
 			const extrema = resultsGetters.getResidualsExtrema(this.$store);
+			// cache the last non-null max min we found - we display that until we get an update from the server
 			if (extrema.min === null || extrema.max === null) {
-				return {
-					min: null,
-					max: null
+				return this.lastExtrema;
+			} else {
+				this.lastExtrema = {
+					min: extrema.min,
+					max: extrema.max
 				};
 			}
 			return {
@@ -113,10 +117,6 @@ export default Vue.extend({
 		hasThreshold(): boolean {
 			return this.thresholdMin !== null && this.thresholdMax !== null;
 		},
-
-		hasExtrema(): boolean {
-			return this.residualExtrema.min !== null && this.residualExtrema.max !== null;
-		}
 	},
 
 	methods: {
@@ -189,8 +189,7 @@ export default Vue.extend({
 		residualExtrema() {
 			// update threshold if there isnt one, or if the user hasn't touched
 			// the slider yet.
-			if ((this.hasExtrema && !this.hasThreshold) ||
-				(this.hasExtrema && !this.hasModified)) {
+			if (!this.hasThreshold || !this.hasModified) {
 				// set the route
 				const ORIGIN = (NUM_STEPS / 2);
 				const DEVIATION = NUM_STEPS * DEFAULT_PERCENTILE;

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -2,14 +2,14 @@ import axios from 'axios';
 import _ from 'lodash';
 import { ActionContext } from 'vuex';
 import { DistilState } from '../store';
-import { INCLUDE_FILTER, EXCLUDE_FILTER } from '../../util/filters';
+import { EXCLUDE_FILTER } from '../../util/filters';
 import { getSolutionsByRequestIds, getSolutionById } from '../../util/solutions';
 import { Variable, Highlight } from '../dataset/index';
 import { mutations } from './module';
-import { mutations as datasetMutations } from '../dataset/module';
 import { ResultsState } from './index';
 import { addHighlightToFilterParams } from '../../util/highlights';
 import { fetchSolutionResultSummary, createPendingSummary, createErrorSummary, createEmptyTableData, fetchSummaryExemplars, getTimeseriesAnalysisIntervals } from '../../util/data';
+import { getters as resultGetters } from '../results/module';
 
 export type ResultsContext = ActionContext<ResultsState, DistilState>;
 
@@ -318,13 +318,15 @@ export const actions = {
 			const endPoint = `distil/forecasting-summary/${args.dataset}/${timeseries}/${args.target}/${interval}`;
 			const key = solution.predictedKey;
 			const label = 'Forecasted';
-			return fetchSolutionResultSummary(context, endPoint, solution, args.target, key, label, mutations.updatePredictedSummaries, filterParams);
+			return fetchSolutionResultSummary(context, endPoint, solution, args.target, key, label,
+				resultGetters.getPredictedSummaries(context), mutations.updatePredictedSummaries, filterParams);
 		}
 
 		const endpoint = `/distil/predicted-summary/${args.dataset}/${args.target}`;
 		const key = solution.predictedKey;
 		const label = 'Predicted';
-		return fetchSolutionResultSummary(context, endpoint, solution, args.target, key, label, mutations.updatePredictedSummaries, filterParams);
+		return fetchSolutionResultSummary(context, endpoint, solution, args.target, key, label,
+			resultGetters.getPredictedSummaries(context), mutations.updatePredictedSummaries, filterParams);
 	},
 
 	// fetches result summaries for a given solution create request
@@ -375,7 +377,8 @@ export const actions = {
 		const endPoint = `/distil/residuals-summary/${args.dataset}/${args.target}`;
 		const key = solution.errorKey;
 		const label = 'Error';
-		return fetchSolutionResultSummary(context, endPoint, solution, args.target, key, label, mutations.updateResidualsSummaries, filterParams);
+		return fetchSolutionResultSummary(context, endPoint, solution, args.target, key, label,
+			resultGetters.getResidualsSummaries(context), mutations.updateResidualsSummaries, filterParams);
 	},
 
 	// fetches result summaries for a given solution create request
@@ -422,7 +425,8 @@ export const actions = {
 		const endPoint = `/distil/correctness-summary/${args.dataset}`;
 		const key = solution.errorKey;
 		const label = 'Error';
-		return fetchSolutionResultSummary(context, endPoint, solution, args.target, key, label, mutations.updateCorrectnessSummaries, filterParams);
+		return fetchSolutionResultSummary(context, endPoint, solution, args.target, key, label,
+			resultGetters.getCorrectnessSummaries(context), mutations.updateCorrectnessSummaries, filterParams);
 	},
 
 	// fetches result summaries for a given pipeline create request

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -4,10 +4,10 @@ import Vue from 'vue';
 import { Variable, VariableSummary, TimeseriesSummary, TableData, TableRow, TableColumn, Grouping, D3M_INDEX_FIELD } from '../store/dataset/index';
 import { Solution, SOLUTION_COMPLETED } from '../store/solutions/index';
 import { Dictionary } from './dict';
-import { Group } from './facets';
 import { FilterParams } from './filters';
 import store from '../store/store';
 import { actions as resultsActions } from '../store/results/module';
+import { ResultsContext } from '../store/results/actions';
 import { getters as datasetGetters, actions as datasetActions } from '../store/dataset/module';
 import { formatValue, TIMESERIES_TYPE, isTimeType, isIntegerType } from '../util/types';
 
@@ -249,21 +249,25 @@ export function createErrorSummary(key: string, label: string, dataset: string, 
 }
 
 export function fetchSolutionResultSummary(
-	context: any,
+	context: ResultsContext,
 	endpoint: string,
 	solution: Solution,
 	target: string,
 	key: string,
 	label: string,
-	updateFunction: (arg: any, summary: VariableSummary) => void,
+	resultSummaries: VariableSummary[],
+	updateFunction: (arg: ResultsContext, summary: VariableSummary) => void,
 	filterParams: FilterParams): Promise<any> {
 
 	const dataset = solution.dataset;
 	const solutionId = solution.solutionId;
 	const resultId = solution.resultId;
 
-	// save a placeholder histogram
-	updateFunction(context, createPendingSummary(key, label, dataset, solutionId));
+	const exists = _.find(resultSummaries, v => v.dataset === dataset && v.key === key);
+	if (!exists) {
+		// add placeholder
+		updateFunction(context, createPendingSummary(key, label, dataset, solutionId));
+	}
 
 	// fetch the results for each solution
 	if (solution.progress !== SOLUTION_COMPLETED) {


### PR DESCRIPTION
Fixes #1156

While data fetch associated with result summaries seem to be taking place as often as expected (issue originally logged as #1156), there was no management of component redraws as there is in the model creation screen.  This lead to place holder animations being displayed whenever result data was fetched, and the error slider being constantly removed and then re-added.  It seemed like there was more fetching going on compared to the model creation screen, but in the end it was just a lot of visual noise due components not being managed properly.  This update ensures that we only display place holders for the result related facets if they don't exist (as was already being done with variable summary facets), and leaves the error slider in place using the last fetched extrema rather than removing until the updated extrema are available.
