### PR TITLE
Filter joined sets from join suggestion #1084

### DIFF
--- a/api/routes/join_suggestion.go
+++ b/api/routes/join_suggestion.go
@@ -190,10 +190,8 @@ func filterDatasets(queryDataset *model.Dataset, datasets []*model.Dataset,
 
 func filterSuggestions(sourceDataset *model.Dataset, joinDataset *model.Dataset) bool {
 	// filter out datasets that have already been joined
-	for _, js := range sourceDataset.JoinSuggestions {
-		if joinDataset.Name == js.JoinDataset {
-			return false
-		}
+	if strings.Contains(sourceDataset.ID, joinDataset.ID) {
+		return false
 	}
 
 	// filter out join datasets with no suggestions


### PR DESCRIPTION
As per #1084 sets already joined are filtered from the suggestions. This is achieved by looking at the Join Suggestion return at the go/API level and doing string contains comparisions of the current id vs. the join IDs before serialization back, which should be sufficiently unique to not over-filter suggestions.