### PR TITLE
Disable type change for timeseries ID columns

### DIFF
--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -33,7 +33,7 @@ export default Vue.extend({
 		highlight: Object as () => Highlight,
 		rowSelection: Object as () => RowSelection,
 		deemphasis: Object as () => any,
-		enableTypeChange: Boolean as () => boolean,
+		enabledTypeChanges: Array as () => string[],
 		enableHighlighting: Boolean as () => boolean,
 		showOrigin: Boolean as () => boolean,
 		ignoreHighlights: Boolean as () => boolean,
@@ -847,8 +847,8 @@ export default Vue.extend({
 
 		// inject type headers
 		injectTypeChangeHeaders(group: Group, $elem: JQuery) {
-			if (this.enableTypeChange) {
-				const facetId = `${group.dataset}:${group.colName}`;
+			const facetId = `${group.dataset}:${group.colName}`;
+			if (this.enabledTypeChanges.find(e => e === facetId)) {
 				// if we have a menu for this already, destroy it to replace it
 				if (this.menus[facetId]) {
 					this.menus[facetId].$destroy();

--- a/public/components/FacetTimeseries.vue
+++ b/public/components/FacetTimeseries.vue
@@ -4,7 +4,7 @@
 			:summary="summary"
 			:highlight="highlight"
 			:row-selection="rowSelection"
-			:enable-type-change="enableTypeChange"
+			:enabled-type-changes="enabledTypeChanges"
 			:enable-highlighting="Boolean(enableHighlighting) && enableHighlighting[0]"
 			:ignore-highlights="Boolean(ignoreHighlights) && ignoreHighlights[0]"
 			:instanceName="instanceName"
@@ -18,6 +18,7 @@
 			:summary="timelineSummary"
 			:highlight="highlight"
 			:row-selection="rowSelection"
+			:enabled-type-changes="enabledTypeChanges"
 			:instanceName="instanceName"
 			:enable-highlighting="Boolean(enableHighlighting) && enableHighlighting[1]"
 			:ignore-highlights="Boolean(ignoreHighlights) && ignoreHighlights[1]"
@@ -50,7 +51,7 @@ export default Vue.extend({
 		highlight: Object as () => Highlight,
 		rowSelection: Object as () => RowSelection,
 		instanceName: String as () => string,
-		enableTypeChange: Boolean as () => boolean,
+		enabledTypeChanges: Array as () => string[],
 		enableHighlighting: Array as () => boolean[],
 		ignoreHighlights: Array as () => boolean[],
 		html: [ String as () => string, Object as () => any, Function as () => Function ],

--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -40,6 +40,7 @@
 							:highlight="highlight"
 							:row-selection="rowSelection"
 							:instanceName="predictedInstanceName"
+							:enabled-type-changes=[]
 							:enable-highlighting="[true, true]"
 							@numerical-click="onResultNumericalClick"
 							@range-change="onResultRangeChange"
@@ -52,6 +53,7 @@
 							enable-highlighting
 							:summary="summary"
 							:highlight="highlight"
+							:enabled-type-changes=[]
 							:row-selection="rowSelection"
 							:instanceName="predictedInstanceName"
 							@numerical-click="onResultNumericalClick"
@@ -67,6 +69,7 @@
 						enable-highlighting
 						:summary="summary"
 						:highlight="highlight"
+						:enabled-type-changes=[]
 						:row-selection="rowSelection"
 						:instanceName="residualInstanceName"
 						:deemphasis="residualThreshold"
@@ -80,6 +83,7 @@
 					enable-highlighting
 					:summary="summary"
 					:highlight="highlight"
+					:enabled-type-changes=[]
 					:row-selection="rowSelection"
 					:instanceName="correctnessInstanceName"
 					@facet-click="onCorrectnessCategoricalClick">

--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -28,7 +28,7 @@
 								:highlight="highlight"
 								:row-selection="rowSelection"
 								:html="html"
-								:enable-type-change="enableTypeChange"
+								:enabled-type-changes="enabledTypeChanges"
 								:enable-highlighting="[enableHighlighting, enableHighlighting]"
 								:ignore-highlights="[ignoreHighlights, ignoreHighlights]"
 								:instanceName="instanceName"
@@ -47,7 +47,7 @@
 								:row-selection="rowSelection"
 								:ranking="ranking[summary.key]"
 								:html="html"
-								:enable-type-change="enableTypeChange"
+								:enabled-type-changes="enabledTypeChanges"
 								:enable-highlighting="enableHighlighting"
 								:ignore-highlights="ignoreHighlights"
 								:instanceName="instanceName"
@@ -181,7 +181,18 @@ export default Vue.extend({
 				ranking[variable.colName] = getVariableRanking(variable);
 			});
 			return ranking;
-		}
+		},
+
+		enabledTypeChanges(): string[] {
+			const typeChangeStatus: string[] = [];
+			this.variables.forEach(variable => {
+				if (this.enableTypeChange && !this.isSeriesID(variable.colName)) {
+					const datasetName = routeGetters.getRouteDataset(this.$store);
+					typeChangeStatus.push(`${variable.datasetName}:${variable.colName}`);
+				}
+			});
+			return typeChangeStatus;
+		},
 	},
 
 	methods: {
@@ -244,6 +255,17 @@ export default Vue.extend({
 				return this.filter === '' || summary.key.toLowerCase().includes(this.filter.toLowerCase());
 			});
 			return searchFiltered.map(v => v.key);
+		},
+
+		isSeriesID(colName: string): boolean {
+			// Check to see if this facet is being used as a series ID
+			const targetVar = routeGetters.getTargetVariable(this.$store);
+			if (targetVar && targetVar.grouping) {
+				if (targetVar.grouping.subIds.length > 0) {
+					return !!targetVar.grouping.subIds.find(v => v === colName);
+				}
+			}
+			return false;
 		}
 	}
 });


### PR DESCRIPTION
Fixes #1181. `VariableFacets` will now check to see if a particular facet is representing a variable that is being used as a timeseries ID value, and if so, will force the underlying facet representation to hide the type change menu.