### PR TITLE
Ensures no forecast visuals are shown for timeseries classification

### DIFF
--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -31,7 +31,8 @@
 					:y-col="timeseriesGrouping.properties.yCol"
 					:timeseries-col="timeseriesGrouping.idCol"
 					:timeseries-id="data.item[timeseriesGrouping.idCol]"
-					:solution-id="solutionId">
+					:solution-id="solutionId"
+					:include-forecast="isTargetTimeseries">
 				</sparkline-preview>
 
 			</template>
@@ -136,6 +137,10 @@ export default Vue.extend({
 
 		isTargetNumerical(): boolean {
 			return !this.isTargetCategorical;
+		},
+
+		isTargetTimeseries(): boolean {
+			return (getVarType(this.target)) === 'timeseries';
 		},
 
 		predictedCol(): string {

--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -42,7 +42,8 @@ export default Vue.extend({
 		yCol: String as () => string,
 		timeseriesCol: String as () => string,
 		timeseriesId: String as () => string,
-		solutionId: String as () => string
+		solutionId: String as () => string,
+		includeForecast: Boolean as () => boolean
 	},
 	data() {
 		return {
@@ -70,7 +71,7 @@ export default Vue.extend({
 			}
 		},
 		forecast(): number[][] {
-			if (this.solutionId) {
+			if (this.solutionId && this.includeForecast) {
 				const forecasts = resultsGetters.getPredictedForecasts(this.$store);
 				const solutions = forecasts[this.solutionId];
 				if (!solutions) {

--- a/public/components/SparklineRow.vue
+++ b/public/components/SparklineRow.vue
@@ -47,7 +47,8 @@ export default Vue.extend({
 			type: Object as () => TimeseriesExtrema
 		},
 		solutionId: String as () => string,
-		prediction: Object as () => any
+		prediction: Object as () => any,
+		includeForecast: Boolean as () => boolean
 	},
 	data() {
 		return {
@@ -67,7 +68,7 @@ export default Vue.extend({
 			}
 		},
 		forecast(): number[][] {
-			if (this.solutionId) {
+			if (this.solutionId && this.includeForecast) {
 				const forecasts = resultsGetters.getPredictedForecasts(this.$store);
 				const solutions = forecasts[this.solutionId];
 				if (!solutions) {


### PR DESCRIPTION
The table view visuals for timeseries classification problems were displaying a constant forecast value of zero over the ground truth timeseries visual.  This should only be displayed for forecasting problems, so a check has been added.