### PR TITLE
Timeseries clustering fixes

### DIFF
--- a/api/routes/variables.go
+++ b/api/routes/variables.go
@@ -50,7 +50,7 @@ func VariablesHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 			return
 		}
 		// fetch variables
-		variables, err := meta.FetchVariables(dataset, false, false, false)
+		variables, err := meta.FetchVariables(dataset, false, true, false)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	unicornResultFieldName = "pred_class"
-	slothResultFieldName   = "0"
+	unicornResultFieldName = "label"
+	slothResultFieldName   = "cluster_labels"
 )
 
 // ClusterPoint contains data that has been clustered.

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -76,7 +76,7 @@ func ClusterDataset(datasetSource metadata.DatasetSource, schemaFile string, ind
 		mainDR.Variables = append(mainDR.Variables, f.Variable)
 
 		// header already removed, lines does not have a header
-		lines, err = appendFeature(dataset, d3mIndexField, false, f, lines)
+		lines, err = appendFeature(outputPath.outputFolder, d3mIndexField, false, f, lines)
 		if err != nil {
 			return "", errors.Wrap(err, "error appending clustered data")
 		}

--- a/api/task/pipelines.go
+++ b/api/task/pipelines.go
@@ -390,10 +390,6 @@ func initializeDatasetCopy(schemaFile string, dataset string, schemaPathRelative
 		return nil, errors.Wrap(err, "unable to copy source data")
 	}
 
-	// delete the existing files that will be overwritten
-	os.Remove(outputSchemaPath)
-	os.Remove(outputDataPath)
-
 	return &datasetCopyPath{
 		sourceFolder: sourceFolder,
 		outputFolder: outputFolder,


### PR DESCRIPTION
Fixes #1184.  In testing it was discovered that timeseries clustering had some path issues that prevented it from running properly in a Task2 startup ingest scenario.  That has been addressed, along with a column naming issue that was causing all timeseries to be set to `Pattern A`.  Note that in order to run, you need to use `distil-pipeline-runner:0.2.7` or greater.