### PR TITLE
Hide computed types from target selection #1192

### DIFF
--- a/public/components/AvailableTargetVariables.vue
+++ b/public/components/AvailableTargetVariables.vue
@@ -20,7 +20,6 @@ import { getters as datasetGetters, actions as datasetActions } from '../store/d
 import { getters as routeGetters } from '../store/route/module';
 import { createRouteEntry } from '../util/routes';
 import { filterSummariesByDataset, getComposedVariableKey } from '../util/data';
-import { IMAGE_TYPE } from '../util/types';
 import VariableFacets from '../components/VariableFacets.vue';
 import { Grouping, Variable, VariableSummary } from '../store/dataset/index';
 import { AVAILABLE_TARGET_VARS_INSTANCE, SELECT_TRAINING_ROUTE } from '../store/route/index';
@@ -57,53 +56,51 @@ export default Vue.extend({
 		html(): (group: Group) => HTMLDivElement {
 			return (group: Group) => {
 				const container = document.createElement('div');
-				if (group.type && group.type.toLowerCase() !== IMAGE_TYPE) {
-					const targetElem = document.createElement('button');
-					targetElem.className += 'btn btn-sm btn-success ml-2 mr-2 mb-2';
-					targetElem.innerHTML = 'Select Target';
-					targetElem.addEventListener('click', () => {
-						const target = group.colName;
-						// remove from training
-						const training = routeGetters.getDecodedTrainingVariableNames(this.$store);
-						const index = training.indexOf(target);
-						if (index !== -1) {
-							training.splice(index, 1);
-						}
+				const targetElem = document.createElement('button');
+				targetElem.className += 'btn btn-sm btn-success ml-2 mr-2 mb-2';
+				targetElem.innerHTML = 'Select Target';
+				targetElem.addEventListener('click', () => {
+					const target = group.colName;
+					// remove from training
+					const training = routeGetters.getDecodedTrainingVariableNames(this.$store);
+					const index = training.indexOf(target);
+					if (index !== -1) {
+						training.splice(index, 1);
+					}
 
-						const v = this.variables.find(v => {
-							return v.colName === group.colName;
-						});
-						if (v && v.grouping) {
-							if (v.grouping.subIds.length > 0) {
-								v.grouping.subIds.forEach(subId => {
-									const exists = training.find(t => {
-										return t === subId;
-									});
-									if (!exists) {
-										training.push(subId);
-									}
-								});
-							} else {
+					const v = this.variables.find(v => {
+						return v.colName === group.colName;
+					});
+					if (v && v.grouping) {
+						if (v.grouping.subIds.length > 0) {
+							v.grouping.subIds.forEach(subId => {
 								const exists = training.find(t => {
-									return t === v.grouping.idCol;
+									return t === subId;
 								});
 								if (!exists) {
-									training.push(v.grouping.idCol);
+									training.push(subId);
 								}
+							});
+						} else {
+							const exists = training.find(t => {
+								return t === v.grouping.idCol;
+							});
+							if (!exists) {
+								training.push(v.grouping.idCol);
 							}
 						}
+					}
 
-						const entry = createRouteEntry(SELECT_TRAINING_ROUTE, {
-							target: group.colName,
-							dataset: routeGetters.getRouteDataset(this.$store),
-							filters: routeGetters.getRouteFilters(this.$store),
-							timeseriesAnalysis: routeGetters.getRouteTimeseriesAnalysis(this.$store),
-							training: training.join(',')
-						});
-						this.$router.push(entry);
+					const entry = createRouteEntry(SELECT_TRAINING_ROUTE, {
+						target: group.colName,
+						dataset: routeGetters.getRouteDataset(this.$store),
+						filters: routeGetters.getRouteFilters(this.$store),
+						timeseriesAnalysis: routeGetters.getRouteTimeseriesAnalysis(this.$store),
+						training: training.join(',')
 					});
-					container.appendChild(targetElem);
-				}
+					this.$router.push(entry);
+				});
+				container.appendChild(targetElem);
 				return container;
 			};
 		}

--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -77,7 +77,7 @@ import FacetTimeseries from '../components/FacetTimeseries';
 import GeocoordinateFacet from '../components/GeocoordinateFacet';
 import { overlayRouteEntry, getRouteFacetPage } from '../util/routes';
 import { Dictionary } from '../util/dict';
-import { sortSummariesByImportance, filterVariablesByPage, getVariableRanking, getVariableImportance } from '../util/data';
+import { sortSummariesByImportance, filterVariablesByPage, getVariableRanking, getVariableImportance, filterUnsupportedTargets } from '../util/data';
 import { Highlight, RowSelection, Variable, VariableSummary } from '../store/dataset/index';
 import { getters as datasetGetters, actions as datasetActions } from '../store/dataset/module';
 import { getters as routeGetters } from '../store/route/module';
@@ -150,7 +150,7 @@ export default Vue.extend({
 		},
 
 		sortedFilteredSummaries(): VariableSummary[] {
-			return sortSummariesByImportance(this.filteredSummaries, this.variables);
+			return filterUnsupportedTargets(sortSummariesByImportance(this.filteredSummaries, this.variables));
 		},
 
 		paginatedSummaries(): VariableSummary[] {

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -295,7 +295,6 @@ export function fetchSolutionResultSummary(
 
 export function filterUnsupportedTargets(variables: VariableSummary[]): VariableSummary[] {
 	return variables.filter(variableSummary => {
-		console.log(variableSummary.key, variableSummary);
 		return !(variableSummary.varType && variableSummary.varType === IMAGE_TYPE) && !hasComputedVarPrefix(variableSummary.key);
 	});
 }

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -9,7 +9,7 @@ import store from '../store/store';
 import { actions as resultsActions } from '../store/results/module';
 import { ResultsContext } from '../store/results/actions';
 import { getters as datasetGetters, actions as datasetActions } from '../store/dataset/module';
-import { formatValue, TIMESERIES_TYPE, isTimeType, isIntegerType } from '../util/types';
+import { formatValue, hasComputedVarPrefix, isIntegerType, isTimeType, IMAGE_TYPE, TIMESERIES_TYPE } from '../util/types';
 
 // Postfixes for special variable names
 export const PREDICTED_SUFFIX = '_predicted';
@@ -293,7 +293,14 @@ export function fetchSolutionResultSummary(
 		});
 }
 
-export function filterVariablesByPage<T>(pageIndex: number, numPerPage: number, variables: T[]): T[] {
+export function filterUnsupportedTargets(variables: VariableSummary[]): VariableSummary[] {
+	return variables.filter(variableSummary => {
+		console.log(variableSummary.key, variableSummary);
+		return !(variableSummary.varType && variableSummary.varType === IMAGE_TYPE) && !hasComputedVarPrefix(variableSummary.key);
+	});
+}
+
+export function filterVariablesByPage(pageIndex: number, numPerPage: number, variables: VariableSummary[]): VariableSummary[] {
 	if (variables.length > numPerPage) {
 		const firstIndex = numPerPage * (pageIndex - 1);
 		const lastIndex = Math.min(firstIndex + numPerPage, variables.length);


### PR DESCRIPTION
- new filterUnsupportedTargets function in data.ts refactors prior work to keep image-type variables from being used as targets for feature prediction, and it extends to also disregard computed variables of any type.
- refactor removes image check in AvailableTargetVariable.vue
- new filterUnsupportedTarget function used in VariableFacets.vue to achieve desired hiding of variables that can't be targeted.