### PR TITLE
Geofacet position fixes

### DIFF
--- a/api/model/extrema_test.go
+++ b/api/model/extrema_test.go
@@ -85,21 +85,21 @@ var (
 )
 
 func TestExtremaBucketInterval(t *testing.T) {
-	assert.InDelta(t, samples[0].GetBucketInterval(), 0.05, epsilon)
-	assert.InDelta(t, samples[1].GetBucketInterval(), 1.0, zero)
-	assert.InDelta(t, samples[2].GetBucketInterval(), 2.0, zero)
-	assert.InDelta(t, samples[3].GetBucketInterval(), 0.05, epsilon)
-	assert.InDelta(t, samples[4].GetBucketInterval(), 1.0, zero)
-	assert.InDelta(t, samples[5].GetBucketInterval(), 2.0, zero)
-	assert.InDelta(t, samples[6].GetBucketInterval(), 0.1, zero)
-	assert.InDelta(t, samples[7].GetBucketInterval(), 2.0, zero)
-	assert.InDelta(t, samples[8].GetBucketInterval(), 1.0, zero)
-	assert.InDelta(t, samples[9].GetBucketInterval(), 50.0, zero)
+	assert.InDelta(t, samples[0].GetBucketInterval(MaxNumBuckets), 0.05, epsilon)
+	assert.InDelta(t, samples[1].GetBucketInterval(MaxNumBuckets), 1.0, zero)
+	assert.InDelta(t, samples[2].GetBucketInterval(MaxNumBuckets), 2.0, zero)
+	assert.InDelta(t, samples[3].GetBucketInterval(MaxNumBuckets), 0.05, epsilon)
+	assert.InDelta(t, samples[4].GetBucketInterval(MaxNumBuckets), 1.0, zero)
+	assert.InDelta(t, samples[5].GetBucketInterval(MaxNumBuckets), 2.0, zero)
+	assert.InDelta(t, samples[6].GetBucketInterval(MaxNumBuckets), 0.1, zero)
+	assert.InDelta(t, samples[7].GetBucketInterval(MaxNumBuckets), 2.0, zero)
+	assert.InDelta(t, samples[8].GetBucketInterval(MaxNumBuckets), 1.0, zero)
+	assert.InDelta(t, samples[9].GetBucketInterval(MaxNumBuckets), 50.0, zero)
 }
 
 func assertRangeIsDivisibleByInterval(t *testing.T, extrema *Extrema) {
-	minMax := extrema.GetBucketMinMax()
-	interval := extrema.GetBucketInterval()
+	minMax := extrema.GetBucketMinMax(MaxNumBuckets)
+	interval := extrema.GetBucketInterval(MaxNumBuckets)
 	div := (minMax.Max - minMax.Min) / interval
 	assert.InDelta(t, math.Mod(div, 1.0), 0.0, epsilon)
 }
@@ -108,8 +108,8 @@ func assertZeroIsBoundary(t *testing.T, extrema *Extrema) {
 	if extrema.Min > 0 || extrema.Max < 0 {
 		return
 	}
-	minMax := extrema.GetBucketMinMax()
-	interval := extrema.GetBucketInterval()
+	minMax := extrema.GetBucketMinMax(MaxNumBuckets)
+	interval := extrema.GetBucketInterval(MaxNumBuckets)
 	div := -minMax.Min / interval
 	assert.InDelta(t, math.Mod(div, 1.0), 0.0, epsilon)
 }
@@ -124,46 +124,46 @@ func TestExtremaBucketMinMax(t *testing.T) {
 		assertZeroIsBoundary(t, sample)
 	}
 
-	assert.InDelta(t, samples[0].GetBucketMinMax().Min, 0.25, epsilon)
-	assert.InDelta(t, samples[0].GetBucketMinMax().Max, 1.5, epsilon)
+	assert.InDelta(t, samples[0].GetBucketMinMax(MaxNumBuckets).Min, 0.25, epsilon)
+	assert.InDelta(t, samples[0].GetBucketMinMax(MaxNumBuckets).Max, 1.5, epsilon)
 
-	assert.InDelta(t, samples[1].GetBucketMinMax().Min, 1.0, epsilon)
-	assert.InDelta(t, samples[1].GetBucketMinMax().Max, 20.0, epsilon)
+	assert.InDelta(t, samples[1].GetBucketMinMax(MaxNumBuckets).Min, 1.0, epsilon)
+	assert.InDelta(t, samples[1].GetBucketMinMax(MaxNumBuckets).Max, 20.0, epsilon)
 
-	assert.InDelta(t, samples[2].GetBucketMinMax().Min, 0.0, epsilon)
-	assert.InDelta(t, samples[2].GetBucketMinMax().Max, 60.0, epsilon)
+	assert.InDelta(t, samples[2].GetBucketMinMax(MaxNumBuckets).Min, 0.0, epsilon)
+	assert.InDelta(t, samples[2].GetBucketMinMax(MaxNumBuckets).Max, 60.0, epsilon)
 
-	assert.InDelta(t, samples[3].GetBucketMinMax().Min, -1.5, epsilon)
-	assert.InDelta(t, samples[3].GetBucketMinMax().Max, -0.25, epsilon)
+	assert.InDelta(t, samples[3].GetBucketMinMax(MaxNumBuckets).Min, -1.5, epsilon)
+	assert.InDelta(t, samples[3].GetBucketMinMax(MaxNumBuckets).Max, -0.25, epsilon)
 
-	assert.InDelta(t, samples[4].GetBucketMinMax().Min, -20.0, epsilon)
-	assert.InDelta(t, samples[4].GetBucketMinMax().Max, -1.0, epsilon)
+	assert.InDelta(t, samples[4].GetBucketMinMax(MaxNumBuckets).Min, -20.0, epsilon)
+	assert.InDelta(t, samples[4].GetBucketMinMax(MaxNumBuckets).Max, -1.0, epsilon)
 
-	assert.InDelta(t, samples[5].GetBucketMinMax().Min, -60.0, epsilon)
-	assert.InDelta(t, samples[5].GetBucketMinMax().Max, 0.0, epsilon)
+	assert.InDelta(t, samples[5].GetBucketMinMax(MaxNumBuckets).Min, -60.0, epsilon)
+	assert.InDelta(t, samples[5].GetBucketMinMax(MaxNumBuckets).Max, 0.0, epsilon)
 
-	assert.InDelta(t, samples[6].GetBucketMinMax().Min, -1.5, epsilon)
-	assert.InDelta(t, samples[6].GetBucketMinMax().Max, 3.3, epsilon)
+	assert.InDelta(t, samples[6].GetBucketMinMax(MaxNumBuckets).Min, -1.5, epsilon)
+	assert.InDelta(t, samples[6].GetBucketMinMax(MaxNumBuckets).Max, 3.3, epsilon)
 
-	assert.InDelta(t, samples[7].GetBucketMinMax().Min, -22.0, epsilon)
-	assert.InDelta(t, samples[7].GetBucketMinMax().Max, 58.0, epsilon)
+	assert.InDelta(t, samples[7].GetBucketMinMax(MaxNumBuckets).Min, -22.0, epsilon)
+	assert.InDelta(t, samples[7].GetBucketMinMax(MaxNumBuckets).Max, 58.0, epsilon)
 
-	assert.InDelta(t, samples[8].GetBucketMinMax().Min, -3.0, epsilon)
-	assert.InDelta(t, samples[8].GetBucketMinMax().Max, 5.0, epsilon)
+	assert.InDelta(t, samples[8].GetBucketMinMax(MaxNumBuckets).Min, -3.0, epsilon)
+	assert.InDelta(t, samples[8].GetBucketMinMax(MaxNumBuckets).Max, 5.0, epsilon)
 
-	assert.InDelta(t, samples[9].GetBucketMinMax().Min, -550.0, epsilon)
-	assert.InDelta(t, samples[9].GetBucketMinMax().Max, 1100.0, epsilon)
+	assert.InDelta(t, samples[9].GetBucketMinMax(MaxNumBuckets).Min, -550.0, epsilon)
+	assert.InDelta(t, samples[9].GetBucketMinMax(MaxNumBuckets).Max, 1100.0, epsilon)
 }
 
 func TestExtremaBucketCount(t *testing.T) {
-	assert.InDelta(t, samples[0].GetBucketCount(), 25, epsilon)
-	assert.InDelta(t, samples[1].GetBucketCount(), 19, zero)
-	assert.InDelta(t, samples[2].GetBucketCount(), 30, zero)
-	assert.InDelta(t, samples[3].GetBucketCount(), 25, epsilon)
-	assert.InDelta(t, samples[4].GetBucketCount(), 19, zero)
-	assert.InDelta(t, samples[5].GetBucketCount(), 30, zero)
-	assert.InDelta(t, samples[6].GetBucketCount(), 48, zero)
-	assert.InDelta(t, samples[7].GetBucketCount(), 40, zero)
-	assert.InDelta(t, samples[8].GetBucketCount(), 8, zero)
-	assert.InDelta(t, samples[9].GetBucketCount(), 33, zero)
+	assert.InDelta(t, samples[0].GetBucketCount(MaxNumBuckets), 25, epsilon)
+	assert.InDelta(t, samples[1].GetBucketCount(MaxNumBuckets), 19, zero)
+	assert.InDelta(t, samples[2].GetBucketCount(MaxNumBuckets), 30, zero)
+	assert.InDelta(t, samples[3].GetBucketCount(MaxNumBuckets), 25, epsilon)
+	assert.InDelta(t, samples[4].GetBucketCount(MaxNumBuckets), 19, zero)
+	assert.InDelta(t, samples[5].GetBucketCount(MaxNumBuckets), 30, zero)
+	assert.InDelta(t, samples[6].GetBucketCount(MaxNumBuckets), 48, zero)
+	assert.InDelta(t, samples[7].GetBucketCount(MaxNumBuckets), 40, zero)
+	assert.InDelta(t, samples[8].GetBucketCount(MaxNumBuckets), 8, zero)
+	assert.InDelta(t, samples[9].GetBucketCount(MaxNumBuckets), 33, zero)
 }

--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -356,7 +356,7 @@ func (f *CategoricalField) FetchTimeseriesSummaryData(timeVar *model.Variable, i
 	if model.IsNumerical(timeVar.Type) || model.IsTimestamp(timeVar.Type) {
 
 		timelineField := NewNumericalField(f.Storage, f.StorageName, timeVar.Name, timeVar.Name, timeVar.Type)
-		timeline, err = timelineField.fetchHistogram(nil, invert)
+		timeline, err = timelineField.fetchHistogram(nil, invert, api.MaxNumBuckets)
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (f *CategoricalField) FetchTimeseriesSummaryData(timeVar *model.Variable, i
 	} else if model.IsDateTime(timeVar.Type) {
 
 		timelineField := NewDateTimeField(f.Storage, f.StorageName, timeVar.Name, timeVar.Name, timeVar.Type)
-		timeline, err = timelineField.fetchHistogram(nil, invert)
+		timeline, err = timelineField.fetchHistogram(nil, invert, api.MaxNumBuckets)
 		if err != nil {
 			return nil, err
 		}

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -26,6 +26,8 @@ import (
 	api "github.com/uncharted-distil/distil/api/model"
 )
 
+const coordinateBuckets = 20
+
 // CoordinateField defines behaviour for the coordinate field type.
 type CoordinateField struct {
 	Key         string
@@ -64,23 +66,23 @@ func (f *CoordinateField) FetchSummaryData(resultURI string, filterParams *api.F
 	var err error
 
 	if resultURI == "" {
-		baseline, err = f.fetchHistogram(nil, invert)
+		baseline, err = f.fetchHistogram(nil, invert, coordinateBuckets)
 		if err != nil {
 			return nil, err
 		}
 		if !filterParams.Empty() {
-			filtered, err = f.fetchHistogram(filterParams, invert)
+			filtered, err = f.fetchHistogram(filterParams, invert, coordinateBuckets)
 			if err != nil {
 				return nil, err
 			}
 		}
 	} else {
-		baseline, err = f.fetchHistogramByResult(resultURI, nil)
+		baseline, err = f.fetchHistogramByResult(resultURI, nil, coordinateBuckets)
 		if err != nil {
 			return nil, err
 		}
 		if !filterParams.Empty() {
-			filtered, err = f.fetchHistogramByResult(resultURI, filterParams)
+			filtered, err = f.fetchHistogramByResult(resultURI, filterParams, coordinateBuckets)
 			if err != nil {
 				return nil, err
 			}
@@ -116,25 +118,7 @@ func (f *CoordinateField) fetchFilter(fieldName string, filterParams *api.Filter
 	return filter
 }
 
-func (f *CoordinateField) splitExtrema(xCol string, yCol string, boundsFilter *model.Filter) (*api.Extrema, *api.Extrema) {
-	xExtrema := &api.Extrema{
-		Key:  xCol,
-		Type: model.RealType,
-		Min:  boundsFilter.Bounds.MinX,
-		Max:  boundsFilter.Bounds.MaxX,
-	}
-
-	yExtrema := &api.Extrema{
-		Key:  yCol,
-		Type: model.RealType,
-		Min:  boundsFilter.Bounds.MinY,
-		Max:  boundsFilter.Bounds.MaxY,
-	}
-
-	return xExtrema, yExtrema
-}
-
-func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert bool) (*api.Histogram, error) {
+func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert bool, numBuckets int) (*api.Histogram, error) {
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
@@ -145,13 +129,25 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
 		where = fmt.Sprintf("WHERE %s", strings.Join(wheres, " AND "))
 	}
 
-	fieldExtrema := f.fetchFilter(f.Key, filterParams)
+	// treat each axis as a separte field for the purposes of query generation
 	xField := NewNumericalField(f.Storage, f.StorageName, f.XCol, f.XCol, model.RealType)
 	yField := NewNumericalField(f.Storage, f.StorageName, f.YCol, f.YCol, model.RealType)
-	xExtrema, yExtrema := f.splitExtrema(f.XCol, f.YCol, fieldExtrema)
 
-	xHistogramName, xBucketQuery, xHistogramQuery := xField.getHistogramAggQuery(xExtrema)
-	yHistogramName, yBucketQuery, yHistogramQuery := yField.getHistogramAggQuery(yExtrema)
+	// get the extrema for each axis
+	xExtrema, err := xField.fetchExtrema()
+	if err != nil {
+		return nil, err
+	}
+	yExtrema, err := yField.fetchExtrema()
+	if err != nil {
+		return nil, err
+	}
+
+	xNumBuckets, yNumBuckets := f.getNumBuckets(numBuckets, xExtrema, yExtrema)
+
+	// generate a histogram query for each
+	xHistogramName, xBucketQuery, xHistogramQuery := xField.getHistogramAggQuery(xExtrema, xNumBuckets)
+	yHistogramName, yBucketQuery, yHistogramQuery := yField.getHistogramAggQuery(yExtrema, yNumBuckets)
 
 	// Get count by x & y
 	query := fmt.Sprintf(`SELECT %s as bucket, CAST(%s as double precision) AS %s, %s as bucket, CAST(%s as double precision) AS %s, COUNT(*) AS count
@@ -170,7 +166,7 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
 		defer res.Close()
 	}
 
-	histogram, err := f.parseHistogram(res, xExtrema, yExtrema)
+	histogram, err := f.parseHistogram(res, xExtrema, yExtrema, xNumBuckets, yNumBuckets)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +174,7 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
 	return histogram, nil
 }
 
-func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams) (*api.Histogram, error) {
+func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams, numBuckets int) (*api.Histogram, error) {
 
 	// get filter where / params
 	wheres, params, err := f.Storage.buildResultQueryFilters(f.StorageName, resultURI, filterParams)
@@ -193,13 +189,25 @@ func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams 
 		where = fmt.Sprintf("AND %s", strings.Join(wheres, " AND "))
 	}
 
-	fieldExtrema := f.fetchFilter(f.Key, filterParams)
+	// create a numerical field for each of X and Y
 	xField := NewNumericalField(f.Storage, f.StorageName, f.XCol, f.XCol, model.RealType)
 	yField := NewNumericalField(f.Storage, f.StorageName, f.YCol, f.YCol, model.RealType)
-	xExtrema, yExtrema := f.splitExtrema(f.XCol, f.YCol, fieldExtrema)
 
-	xHistogramName, xBucketQuery, xHistogramQuery := xField.getHistogramAggQuery(xExtrema)
-	yHistogramName, yBucketQuery, yHistogramQuery := yField.getHistogramAggQuery(yExtrema)
+	// get the extrema for each
+	xExtrema, err := xField.fetchExtrema()
+	if err != nil {
+		return nil, err
+	}
+	yExtrema, err := yField.fetchExtrema()
+	if err != nil {
+		return nil, err
+	}
+
+	xNumBuckets, yNumBuckets := f.getNumBuckets(numBuckets, xExtrema, yExtrema)
+
+	// create histograms given the the extrema
+	xHistogramName, xBucketQuery, xHistogramQuery := xField.getHistogramAggQuery(xExtrema, xNumBuckets)
+	yHistogramName, yBucketQuery, yHistogramQuery := yField.getHistogramAggQuery(yExtrema, yNumBuckets)
 
 	// Get count by x & y
 	query := fmt.Sprintf(`
@@ -221,7 +229,7 @@ func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams 
 		defer res.Close()
 	}
 
-	histogram, err := f.parseHistogram(res, xExtrema, yExtrema)
+	histogram, err := f.parseHistogram(res, xExtrema, yExtrema, xNumBuckets, yNumBuckets)
 	if err != nil {
 		return nil, err
 	}
@@ -229,18 +237,18 @@ func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams 
 	return histogram, nil
 }
 
-func (f *CoordinateField) parseHistogram(rows *pgx.Rows, xExtrema *api.Extrema, yExtrema *api.Extrema) (*api.Histogram, error) {
+func (f *CoordinateField) parseHistogram(rows *pgx.Rows, xExtrema *api.Extrema, yExtrema *api.Extrema, xNumBuckets int, yNumBuckets int) (*api.Histogram, error) {
 	// get histogram agg name
 	histogramAggName := api.HistogramAggPrefix + f.Key
 
 	// Parse bucket results.
-	xInterval := xExtrema.GetBucketInterval()
-	yInterval := yExtrema.GetBucketInterval()
-	xRounded := xExtrema.GetBucketMinMax()
-	yRounded := yExtrema.GetBucketMinMax()
+	xInterval := xExtrema.GetBucketInterval(xNumBuckets)
+	yInterval := yExtrema.GetBucketInterval(yNumBuckets)
+	xRounded := xExtrema.GetBucketMinMax(xNumBuckets)
+	yRounded := yExtrema.GetBucketMinMax(yNumBuckets)
 
-	xBucketCount := int64(xExtrema.GetBucketCount())
-	yBucketCount := int64(yExtrema.GetBucketCount())
+	xBucketCount := int64(xExtrema.GetBucketCount(xNumBuckets))
+	yBucketCount := int64(yExtrema.GetBucketCount(yNumBuckets))
 	xBuckets := make([]*api.Bucket, xBucketCount)
 
 	// initialize empty histogram structure
@@ -335,4 +343,18 @@ func (f *CoordinateField) fetchDefaultFilter(fieldName string) *model.Filter {
 	}
 
 	return filter
+}
+
+func (f *CoordinateField) getNumBuckets(numBuckets int, xExtrema *api.Extrema, yExtrema *api.Extrema) (int, int) {
+	// adjust the buckets to account for x/y ratio
+	xSize := xExtrema.Max - xExtrema.Min
+	ySize := yExtrema.Max - yExtrema.Min
+	xNumBuckets := numBuckets
+	yNumBuckets := numBuckets
+	if xSize > ySize {
+		yNumBuckets = int(ySize / xSize * float64(yNumBuckets))
+	} else {
+		xNumBuckets = int(xSize / ySize * float64(xNumBuckets))
+	}
+	return xNumBuckets, yNumBuckets
 }

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -341,7 +341,7 @@ func (f *TextField) FetchTimeseriesSummaryData(timeVar *model.Variable, interval
 	if model.IsNumerical(timeVar.Type) || model.IsTimestamp(timeVar.Type) {
 
 		timelineField := NewNumericalField(f.Storage, f.StorageName, timeVar.Name, timeVar.Name, timeVar.Type)
-		timeline, err = timelineField.fetchHistogram(nil, invert)
+		timeline, err = timelineField.fetchHistogram(nil, invert, api.MaxNumBuckets)
 		if err != nil {
 			return nil, err
 		}
@@ -349,7 +349,7 @@ func (f *TextField) FetchTimeseriesSummaryData(timeVar *model.Variable, interval
 	} else if model.IsDateTime(timeVar.Type) {
 
 		timelineField := NewDateTimeField(f.Storage, f.StorageName, timeVar.Name, timeVar.Name, timeVar.Type)
-		timeline, err = timelineField.fetchHistogram(nil, invert)
+		timeline, err = timelineField.fetchHistogram(nil, invert, api.MaxNumBuckets)
 		if err != nil {
 			return nil, err
 		}

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -239,7 +239,7 @@ func (f *TimeSeriesField) FetchSummaryData(resultURI string, filterParams *api.F
 
 	timelineField := NewNumericalField(f.Storage, f.StorageName, f.XCol, f.XCol, f.XColType)
 
-	timeline, err = timelineField.fetchHistogram(nil, invert)
+	timeline, err = timelineField.fetchHistogram(nil, invert, api.MaxNumBuckets)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/variable_summary.go
+++ b/api/model/variable_summary.go
@@ -32,8 +32,9 @@ const (
 
 // Bucket represents a single histogram bucket.
 type Bucket struct {
-	Key   string `json:"key"`
-	Count int64  `json:"count"`
+	Key     string    `json:"key"`
+	Count   int64     `json:"count"`
+	Buckets []*Bucket `json:"buckets,omitempty"`
 }
 
 // Histogram represents a single variable histogram.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "watch": "webpack --watch"
   },
   "dependencies": {
-    "@turf/turf": "^5.1.6",
+    "@turf/bbox": "^6.0.1",
+    "@turf/helpers": "^6.1.4",
     "@types/d3": "^5.7.0",
     "@types/jquery": "^3.3.2",
     "@types/lodash": "^4.14.120",

--- a/public/components/GeocoordinateFacet.vue
+++ b/public/components/GeocoordinateFacet.vue
@@ -10,7 +10,7 @@
 			:field="target">
 		</type-change-menu>
 		</div>
-	<div class="geo-plot-container" v-bind:class="{ 'selection-mode': isSelectionMode }">
+	<div class="geo-plot-container">
 		<div class="geo-plot" v-bind:id="mapID"></div>
 	</div>
 
@@ -22,64 +22,20 @@ import _ from 'lodash';
 import $ from 'jquery';
 import leaflet from 'leaflet';
 import Vue from 'vue';
-import IconBase from './icons/IconBase';
-import IconCropFree from './icons/IconCropFree';
 import { scaleThreshold } from 'd3';
 import { actions as datasetActions, getters as datasetGetters } from '../store/dataset/module';
 import { getters as routeGetters } from '../store/route/module';
 import { Dictionary } from '../util/dict';
-import {
-	TableColumn,
-	TableRow,
-	D3M_INDEX_FIELD,
-	Highlight,
-	RowSelection,
-	VariableSummary,
-	Bucket
-} from '../store/dataset/index';
-import { updateHighlight, clearHighlight } from '../util/highlights';
-import {
-	addRowSelection,
-	removeRowSelection,
-	isRowSelected
-} from '../util/row';
-import { LATITUDE_TYPE, LONGITUDE_TYPE, REAL_VECTOR_TYPE, GEOCOORDINATE_TYPE } from '../util/types';
-import { DUMMY_GEODATA } from '../util/data';
+import { VariableSummary, Bucket } from '../store/dataset/index';
 import TypeChangeMenu from '../components/TypeChangeMenu';
-import { SELECT_TARGET_ROUTE } from '../store/route';
-import { createRouteEntry } from '../util/routes';
-import { Filter, addFilterToRoute, removeFilterFromRoute, FilterParams, INCLUDE_FILTER, GEOCOORDINATE_FILTER, decodeFilters } from '../util/filters';
-
 
 import 'leaflet/dist/leaflet.css';
 import 'leaflet/dist/images/marker-icon.png';
 import 'leaflet/dist/images/marker-icon-2x.png';
 import 'leaflet/dist/images/marker-shadow.png';
+
 import helpers, { polygon, featureCollection } from '@turf/helpers';
 import bbox from '@turf/bbox';
-
-const SINGLE_FIELD = 1;
-const SPLIT_FIELD = 2;
-const CLOSE_BUTTON_CLASS = 'geo-close-button';
-const CLOSE_ICON_CLASS = 'fa-times';
-
-interface GeoField {
-	type: number;
-	latField?: string;
-	lngField?: string;
-	field?: string;
-}
-
-interface LatLng {
-	lat: number;
-	lng: number;
-	row: TableRow;
-}
-
-interface PointGroup {
-	field: GeoField;
-	points: LatLng[];
-}
 
 const PALETTE = [
 	'rgba(0,0,0,0)',
@@ -108,10 +64,8 @@ export default Vue.extend({
 	name: 'geocoordinate-facet',
 
 	components: {
-		IconBase,
-		IconCropFree,
 		TypeChangeMenu
-		},
+	},
 
 	props: {
 		summary: Object as () => VariableSummary,
@@ -121,47 +75,27 @@ export default Vue.extend({
 		return {
 			map: null,
 			baseLayer: null,
-			markers: null,
-			closeButton: null,
 			startingLatLng: null,
-			currentRect: null,
-			selectedRect: null,
 			bounds: null,
-			isSelectionMode: false,
-			currentFilter: null
 		};
-		},
+	},
 
 	computed: {
 		dataset(): string {
 			return routeGetters.getRouteDataset(this.$store);
-			},
-		datasummary(): any {
-			const buckets = this.summary.baseline.buckets;
-			const validPoints = buckets.filter((bucket) => {
-				return bucket.count > 0;
-			});
-
-			const dataPoints = validPoints.reduce((acc, curr) => {
-				const coordinates = curr.key.split(',');
-				const lon = coordinates[0];
-				const lat = coordinates[1];
-				const points = Array(curr.count).fill({
-					latitude: lat,
-					longitude: lon
-				});
-				acc.push(...points);
-				return acc;
-				}, [] as any);
-
-			return dataPoints;
 		},
+
+		target(): string {
+			return routeGetters.getRouteTargetVariable(this.$store);
+		},
+
 		// Computes the bounds of the summary data.
 		featureBounds(): helpers.BBox {
-			return bbox(this.featureCollection);
+			return bbox(this.features);
 		},
+
 		// Creates a GeoJSON feature collection that can be passed directly to a Leaflet layer for rendering.
-		featureCollection(): helpers.FeatureCollection {
+		features(): helpers.FeatureCollection {
 			// compute the bucket size in degrees
 			const buckets  = this.summary.baseline.buckets;
 			const xSize = _.toNumber(buckets[1].key) - _.toNumber(buckets[0].key);
@@ -186,378 +120,17 @@ export default Vue.extend({
 			});
 			return featureCollection(features);
 		},
+
 		instanceName(): string {
 			return 'unique-map';
-		},
-		dataItems(): any {
-			return this.datasummary;
-		},
-
-		target(): string {
-			return routeGetters.getRouteTargetVariable(this.$store);
-		},
-		targetSampleValues(): any[] {
-			const summaries = routeGetters.getTargetVariableSummaries(this.$store);
-			if (summaries.length > 0) {
-				const summary = summaries[0];
-				if (summary.baseline) {
-					return summary.baseline.buckets;
-				}
-			}
-			return [];
-		},
-		getTopVariables(): string[] {
-			const variables = datasetGetters
-				.getVariables(this.$store)
-				.filter(v => v.datasetName === this.dataset);
-			return variables
-				.map(variable => ({
-					variable: variable.colName,
-					order: _.isNumber(variable.ranking)
-						? variable.ranking
-						: variable.importance
-				}))
-				.sort((a, b) => b.order - a.order)
-				.map(r => r.variable);
 		},
 
 		mapID(): string {
 			return `map-${this.instanceName}`;
 		},
-
-		fieldSpecs(): GeoField[] {
-			const fields = [{
-				latField: `${LATITUDE_TYPE}`,
-				lngField: `${LONGITUDE_TYPE}`,
-				type: 2
-				}];
-			return fields;
-		},
-
-		pointGroups(): PointGroup[] {
-			const groups = [];
-
-			if (!this.dataItems) {
-				return groups;
-			}
-
-			this.fieldSpecs.forEach(fieldSpec => {
-				const group = {
-					field: fieldSpec,
-					points: []
-				};
-				group.points = this.dataItems
-					.map(item => {
-						const lat = this.latValue(fieldSpec, item);
-						const lng = this.lngValue(fieldSpec, item);
-						if (lat !== undefined && lng !== undefined) {
-							return {
-								lng: lng,
-								lat: lat,
-								row: item
-							};
-						}
-						return null;
-					})
-					.filter(p => !!p);
-				groups.push(group);
-			});
-
-			return groups;
-		},
-
-		highlight(): Highlight {
-			return routeGetters.getDecodedHighlight(this.$store);
-		},
-
-		mapCenter(): number[] {
-			return routeGetters.getGeoCenter(this.$store);
-		},
-
-		mapZoom(): number {
-			return routeGetters.getGeoZoom(this.$store);
-		},
-		rowSelection(): RowSelection {
-			return routeGetters.getDecodedRowSelection(this.$store);
-		},
-		filter(): any {
-			const filter = routeGetters.getRouteFilters(this.$store);
-			return filter;
-		}
 	},
 
 	methods: {
-		variableSummaryToGeocoordinate(key: string, label: string, buckets: Bucket[]): any {
-			const geocoordinates = buckets.map(b => [ _.parseInt(b.key), b.count ]);
-
-			const summaries = [{
-				label: label,
-				key: key,
-				geocoordinates: geocoordinates
-			}];
-
-			return summaries;
-		},
-		clearSelectionRect() {
-			if (this.selectedRect) {
-				this.selectedRect.remove();
-				this.selectedRect = null;
-			}
-			if (this.currentRect) {
-				this.currentRect.remove();
-				this.currentRect = null;
-			}
-			if (this.closeButton) {
-				this.closeButton.remove();
-				this.closeButton = null;
-			}
-		},
-		onMouseDown(event: MouseEvent) {
-			const mapEventTarget = event.target as HTMLElement;
-
-			// check if mapEventTarget is the close button or icon
-			if (
-				mapEventTarget.classList.contains(CLOSE_BUTTON_CLASS) ||
-				mapEventTarget.classList.contains(CLOSE_ICON_CLASS)
-			) {
-				this.clearSelection();
-				this.selectedRect.remove();
-				this.selectedRect = null;
-				this.closeButton.remove();
-				this.closeButton = null;
-				return;
-			}
-
-			if (this.isSelectionMode) {
-				this.clearSelectionRect();
-
-				const offset = $(this.map.getContainer()).offset();
-				this.startingLatLng = this.map.containerPointToLatLng({
-					x: event.pageX - offset.left,
-					y: event.pageY - offset.top
-				});
-
-				const bounds = [this.startingLatLng, this.startingLatLng];
-				this.currentRect = leaflet.rectangle(bounds, {
-					color: '#00c6e1',
-					weight: 1,
-					bubblingMouseEvents: false
-				});
-				this.currentRect.on('click', e => {
-					this.setSelection(e.target);
-				});
-				this.currentRect.addTo(this.map);
-
-				// enable drawing mode
-				// this.map.off('click', this.clearSelection);
-				this.map.dragging.disable();
-			}
-		},
-		onMouseUp(event: MouseEvent) {
-			if (this.currentRect) {
-				this.setSelection(this.currentRect);
-				this.currentRect = null;
-
-				// disable drawing mode
-				this.map.dragging.enable();
-				// this.map.on('click', this.clearSelection);
-			}
-		},
-		onMouseMove(event: MouseEvent) {
-			if (this.currentRect) {
-				const offset = $(this.map.getContainer()).offset();
-				const latLng = this.map.containerPointToLatLng({
-					x: event.pageX - offset.left,
-					y: event.pageY - offset.top
-				});
-				const bounds = [this.startingLatLng, latLng];
-				this.currentRect.setBounds(bounds);
-			}
-		},
-		onEsc() {
-			if (this.currentRect) {
-				this.clearSelectionRect();
-				// disable drawing mode
-				this.map.dragging.enable();
-			}
-		},
-		setSelection(rect) {
-			this.clearSelection();
-
-			this.selectedRect = rect;
-			const $selected = $(this.selectedRect._path);
-			$selected.addClass('selected');
-
-			const ne = rect.getBounds().getNorthEast();
-			const sw = rect.getBounds().getSouthWest();
-			const icon = leaflet.divIcon({
-				className: CLOSE_BUTTON_CLASS,
-				iconSize: null,
-				html: `<i class='fa ${CLOSE_ICON_CLASS}'></i>`
-			});
-			this.closeButton = leaflet.marker([ne.lat, ne.lng], {
-				icon: icon
-			});
-			this.closeButton.addTo(this.map);
-			this.createHighlight({
-				minX: sw.lng,
-				maxX: ne.lng,
-				minY: sw.lat,
-				maxY: ne.lat
-			});
-		},
-		clearSelection() {
-			if (this.selectedRect) {
-				$(this.selectedRect._path).removeClass('selected');
-				clearHighlight(this.$router);
-			}
-			if (this.closeButton) {
-				this.closeButton.remove();
-			}
-		},
-		createHighlight(value: {
-			minX: number;
-			maxX: number;
-			minY: number;
-			maxY: number;
-		}) {
-			if (
-				this.highlight &&
-				this.highlight.value.minX === value.minX &&
-				this.highlight.value.maxX === value.maxX &&
-				this.highlight.value.minY === value.minY &&
-				this.highlight.value.maxY === value.maxY
-			) {
-				// dont push existing highlight
-				return;
-			}
-
-			// TODO: support filtering multiple vars?
-			const fieldSpec = this.fieldSpecs[0];
-			const key =
-				fieldSpec.type === SINGLE_FIELD
-					? fieldSpec.field
-					: this.fieldHash(fieldSpec);
-
-			updateHighlight(this.$router, {
-				context: this.instanceName,
-				dataset: this.dataset,
-				key: key,
-				value: value
-			});
-		},
-		drawHighlight() {
-			if (
-				this.highlight &&
-				this.highlight.value.minX !== undefined &&
-				this.highlight.value.maxX !== undefined &&
-				this.highlight.value.minY !== undefined &&
-				this.highlight.value.maxY !== undefined
-			) {
-				const rect = leaflet.rectangle(
-					[
-						[this.highlight.value.minY, this.highlight.value.minX],
-						[this.highlight.value.maxY, this.highlight.value.maxX]
-					],
-					{
-						color: '#00c6e1',
-						weight: 1,
-						bubblingMouseEvents: false
-					}
-				);
-				rect.on('click', e => {
-					this.setSelection(e.target);
-				});
-				rect.addTo(this.map);
-
-				this.setSelection(rect);
-			}
-		},
-		drawFilters() {
-			// TODO: impl this
-		},
-
-		lngValue(fieldSpec: GeoField, row: TableRow): number {
-			if (fieldSpec.type === SINGLE_FIELD) {
-				return row[fieldSpec.field].Elements[0].Float;
-			}
-			return row[fieldSpec.lngField];
-		},
-
-		latValue(fieldSpec: GeoField, row: TableRow): number {
-			if (fieldSpec.type === SINGLE_FIELD) {
-				return row[fieldSpec.field].Elements[1].Float;
-			}
-			return row[fieldSpec.latField];
-		},
-
-		fieldHash(fieldSpec: GeoField): string {
-			if (fieldSpec.type === SINGLE_FIELD) {
-				return fieldSpec.field;
-			}
-			return fieldSpec.lngField + ':' + fieldSpec.latField;
-		},
-
-		clear() {
-			if (this.selectedRect) {
-				this.selectedRect.remove();
-				this.selectedRect = null;
-			}
-			if (this.currentRect) {
-				this.currentRect.remove();
-				this.currentRect = null;
-			}
-			if (this.closeButton) {
-				this.closeButton.remove();
-				this.closeButton = null;
-			}
-			_.forIn(this.markers, markerLayer => {
-				markerLayer.removeFrom(this.map);
-			});
-			this.markers = {};
-			this.startingLatLng = null;
-		},
-
-		toggleSelection(event) {
-			const marker = event.target;
-			const row = marker.options.row;
-			if (!isRowSelected(this.rowSelection, row[D3M_INDEX_FIELD])) {
-				addRowSelection(
-					this.$router,
-					this.instanceName,
-					this.rowSelection,
-					row[D3M_INDEX_FIELD]
-				);
-			} else {
-				removeRowSelection(
-					this.$router,
-					this.instanceName,
-					this.rowSelection,
-					row[D3M_INDEX_FIELD]
-				);
-			}
-		},
-
-		updateMarkerSelection(markers) {
-			markers.forEach(marker => {
-				const row = marker.options.row;
-				const markerElem = marker.getElement();
-				const isSelected = isRowSelected(
-					this.rowSelection,
-					row[D3M_INDEX_FIELD]
-				);
-				markerElem.classList.toggle('selected', isSelected);
-			});
-		},
-
-		createPointGroup(points) {
-			const count = points.length;
-			const features = [];
-			for (let i = 0; i < count; i++) {
-				features.push(helpers.point(points[i]));
-			}
-			return helpers.featureCollection(features);
-		},
 		paint() {
 			if (!this.map) {
 				// NOTE: this component re-mounts on any change, so do everything in here
@@ -568,18 +141,6 @@ export default Vue.extend({
 					zoomControl: false,
 				});
 				// this.map.dragging.disable();
-				if (this.mapZoom) {
-					this.map.setZoom(this.mapZoom, { animate: true });
-				}
-				if (this.mapCenter) {
-					this.map.panTo(
-						{
-							lat: this.mapCenter[1],
-							lng: this.mapCenter[0]
-						},
-						{ animate: true }
-					);
-				}
 
 				this.baseLayer = leaflet.tileLayer(
 					'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
@@ -587,48 +148,10 @@ export default Vue.extend({
 				this.baseLayer.addTo(this.map);
 			}
 
-			this.clear();
-
 			const bounds = this.featureBounds;
 			const northEast = leaflet.latLng(bounds[3], bounds[2]);
 			const southWest = leaflet.latLng(bounds[1], bounds[0]);
 			this.bounds = leaflet.latLngBounds(northEast, southWest);
-
-			// const pointLength = this.pointGroups.length;
-
-			// this.pointGroups.forEach(group => {
-			// 	const hash = this.fieldHash(group.field);
-
-			// 	const layer = leaflet.layerGroup([]);
-
-			// 	group.points.forEach(p => {
-			// 		const marker = leaflet.marker(p, { row: p.row });
-			// 		this.bounds.extend([p.lat, p.lng]);
-			// 		marker.bindTooltip(() => {
-			// 			const target = p.row[this.target];
-			// 			const values = [];
-			// 			const MAX_VALUES = 5;
-			// 			this.getTopVariables.forEach(v => {
-			// 				if (p.row[v] && values.length <= MAX_VALUES) {
-			// 					values.push(
-			// 						`<b>${_.capitalize(v)}:</b> ${p.row[v]}`
-			// 					);
-			// 				}
-			// 			});
-			// 			return [`<b>${_.capitalize(target)}</b>`]
-			// 				.concat(values)
-			// 				.join('<br>');
-			// 		});
-
-			// 		marker.on('click', this.toggleSelection);
-
-			// 		layer.addLayer(marker);
-			// 	});
-			// 	this.markers[hash] = layer;
-			// 	layer.on('add', () =>
-			// 		this.updateMarkerSelection(layer.getLayers())
-			// 	);
-			// });
 
 			if (this.bounds.isValid()) {
 				this.map.fitBounds(this.bounds);
@@ -641,25 +164,22 @@ export default Vue.extend({
 				);
 				const scaleColors = scaleThreshold().range(PALETTE as any).domain(domain);
 
-				const gridLayer = leaflet
-					.geoJSON(this.featureCollection, {
-						style: feature => {
-							return {
-								fillColor: scaleColors(
-									feature.properties.count
-								),
-								weight: 2,
-								opacity: 1,
-								color: 'rgba(0,0,0,0)',
-								dashArray: '3',
-								fillOpacity: 0.7
-							};
-						}
-					})
-					.addTo(this.map);
+				leaflet.geoJSON(this.features, {
+					style: feature => {
+						return {
+							fillColor: scaleColors(
+								feature.properties.count
+							),
+							weight: 2,
+							opacity: 1,
+							color: 'rgba(0,0,0,0)',
+							dashArray: '3',
+							fillOpacity: 0.7
+						};
+					}
+				})
+				.addTo(this.map);
 			}
-			this.drawHighlight();
-			this.drawFilters();
 		}
 	},
 
@@ -667,12 +187,6 @@ export default Vue.extend({
 		dataItems() {
 			this.paint();
 		},
-		rowSelection() {
-			const markers = _.map(this.markers, markerLayer =>
-				markerLayer.getLayers()
-			).reduce((prev, cur) => [...prev, ...cur], []);
-			this.updateMarkerSelection(markers);
-		}
 	},
 
 	mounted() {
@@ -774,13 +288,6 @@ path.selected {
 
 .geo-plot .leaflet-marker-icon.selected {
 	filter: hue-rotate(150deg);
-}
-
-.leaflet-tooltip {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	max-width: 300px !important;
 }
 
 .geo-close-button {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,1172 +10,25 @@
     consola "^2.3.0"
     node-fetch "^2.3.0"
 
-"@turf/along@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/along/-/along-5.1.5.tgz#61d6e6a6584acddab56ac5584e07bf8cbe5f8beb"
-  integrity sha1-YdbmplhKzdq1asVYTge/jL5fi+s=
-  dependencies:
-    "@turf/bearing" "^5.1.5"
-    "@turf/destination" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-
-"@turf/area@5.1.x", "@turf/area@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/area/-/area-5.1.5.tgz#efd899bfd260cdbd1541b2a3c155f8a5d2eefa1d"
-  integrity sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/bbox-clip@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz#3364b5328dff9f3cf41d9e02edaff374d150cc84"
-  integrity sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    lineclip "^1.1.5"
-
-"@turf/bbox-polygon@5.1.x", "@turf/bbox-polygon@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz#6aeba4ed51d85d296e0f7c38b88c339f01eee024"
-  integrity sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/bbox@5.1.x", "@turf/bbox@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-5.1.5.tgz#3051df514ad4c50f4a4f9b8a2d15fd8b6840eda3"
-  integrity sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/bearing@5.1.x", "@turf/bearing@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-5.1.5.tgz#7a0b790136c4ef4797f0246305d45cbe2d27b3f7"
-  integrity sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/bearing@6.x":
+"@turf/bbox@^6.0.1":
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.0.1.tgz#8da5d17092e571f170cde7bfb2e5b0d74923c92d"
-  integrity sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
+  integrity sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==
   dependencies:
     "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
+    "@turf/meta" "6.x"
 
-"@turf/bezier-spline@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz#59a27bba5d7b97ef15ab3fd5a40fbd2387049bca"
-  integrity sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/boolean-clockwise@5.1.x", "@turf/boolean-clockwise@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz#3302b7dac62c5e291a0789e29af7283387fa9deb"
-  integrity sha1-MwK32sYsXikaB4nimvcoM4f6nes=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/boolean-contains@5.1.x", "@turf/boolean-contains@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz#596d63aee636f7ad53ee99f9ff24c96994a0ef14"
-  integrity sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/boolean-point-on-line" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/boolean-crosses@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz#01bfaea2596f164de4a4d325094dc7c255c715d6"
-  integrity sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=
-  dependencies:
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/line-intersect" "^5.1.5"
-    "@turf/polygon-to-line" "^5.1.5"
-
-"@turf/boolean-disjoint@5.1.x":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-disjoint/-/boolean-disjoint-5.1.6.tgz#3fbd87084b269133f5fd15725deb3c6675fb8a9d"
-  integrity sha512-KHvUS6SBNYHBCLIJEJrg04pF5Oy+Fqn8V5G9U+9pti5vI9tyX7Ln2g7RSB7iJ1Cxsz8QAi6OukhXjEF2/8ZpGg==
-  dependencies:
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/line-intersect" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/polygon-to-line" "^5.1.5"
-
-"@turf/boolean-equal@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz#29f8f6d60bb84507dfd765b32254db8e72c938a4"
-  integrity sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=
-  dependencies:
-    "@turf/clean-coords" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    geojson-equality "0.1.6"
-
-"@turf/boolean-overlap@5.1.x", "@turf/boolean-overlap@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz#0d4e64c52c770a28e93d9efcdf8a8b8373acce75"
-  integrity sha1-DU5kxSx3CijpPZ7834qLg3OsznU=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/line-intersect" "^5.1.5"
-    "@turf/line-overlap" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    geojson-equality "0.1.6"
-
-"@turf/boolean-parallel@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz#739358475ea5b65c7e1827a3c3e0e8a687d3a85d"
-  integrity sha1-c5NYR16ltlx+GCejw+DopofTqF0=
-  dependencies:
-    "@turf/clean-coords" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/line-segment" "^5.1.5"
-    "@turf/rhumb-bearing" "^5.1.5"
-
-"@turf/boolean-point-in-polygon@5.1.x", "@turf/boolean-point-in-polygon@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz#f01cc194d1e030a548bfda981cba43cfd62941b7"
-  integrity sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/boolean-point-on-line@5.1.x", "@turf/boolean-point-on-line@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz#f633c5ff802ad24bb8f158dadbaf6ff4a023dd7b"
-  integrity sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/boolean-within@5.1.x", "@turf/boolean-within@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/boolean-within/-/boolean-within-5.1.5.tgz#47105d56d0752a9d0fbfcd43c36a5f9149dc8697"
-  integrity sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/boolean-point-on-line" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/buffer@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/buffer/-/buffer-5.1.5.tgz#841c9627cfb974b122ac4e1a956f0466bc0231c4"
-  integrity sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/center" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/projection" "^5.1.5"
-    d3-geo "1.7.1"
-    turf-jsts "*"
-
-"@turf/center-mean@5.1.x", "@turf/center-mean@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/center-mean/-/center-mean-5.1.5.tgz#8c8e9875391e5f09f0e6e78f5d661b88b2108a0a"
-  integrity sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/center-median@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/center-median/-/center-median-5.1.5.tgz#bb461bfe7a2a48601d8a4727685718723a14a872"
-  integrity sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=
-  dependencies:
-    "@turf/center-mean" "^5.1.5"
-    "@turf/centroid" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/center-of-mass@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz#4d3bd79d88498dbab8324d4f69f0322f6520b9ca"
-  integrity sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=
-  dependencies:
-    "@turf/centroid" "^5.1.5"
-    "@turf/convex" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/center@5.1.x", "@turf/center@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/center/-/center-5.1.5.tgz#44ab2cd954f63c0d37757f7158a99c3ef5114b80"
-  integrity sha1-RKss2VT2PA03dX9xWKmcPvURS4A=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-
-"@turf/centroid@5.1.x", "@turf/centroid@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-5.1.5.tgz#778ada74216335021ad8fd0e7a65a8349d53c769"
-  integrity sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/circle@5.1.x", "@turf/circle@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/circle/-/circle-5.1.5.tgz#9b1577835508ab52fb1c10b2a5065cba2b87b6a5"
-  integrity sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=
-  dependencies:
-    "@turf/destination" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-
-"@turf/clean-coords@5.1.x", "@turf/clean-coords@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/clean-coords/-/clean-coords-5.1.5.tgz#12800a98a78c9a452a72ec428493c43acf2ada1f"
-  integrity sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/clone@5.1.x", "@turf/clone@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-5.1.5.tgz#253e8d35477181976e33adfab50a0f02a7f0e367"
-  integrity sha1-JT6NNUdxgZduM636tQoPAqfw42c=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/clone@6.x":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-6.0.2.tgz#7563cebbb3e2e19f361599bb244467e0dcc205c9"
-  integrity sha512-UVpYPnW3wRj3bPncR6Z2PRbowBk+nEdVWgGewPxrKKLfvswtVtG9n/OIyvbU3E3ZOadBVxTH2uAMEMOz4800FA==
-  dependencies:
-    "@turf/helpers" "6.x"
-
-"@turf/clusters-dbscan@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz#5781fb4e656c747a0b8e9937df73181c0309e26f"
-  integrity sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=
-  dependencies:
-    "@turf/clone" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    density-clustering "1.3.0"
-
-"@turf/clusters-kmeans@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz#fd6dfea8b133ba8bdc2370ac3cacee1587a302f1"
-  integrity sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=
-  dependencies:
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    skmeans "0.9.7"
-
-"@turf/clusters@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/clusters/-/clusters-5.1.5.tgz#673a5e5f1b19c9cababc57c908eeadd682224dd4"
-  integrity sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/collect@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/collect/-/collect-5.1.5.tgz#fe98c9a8c218ecf24ffc33d7029517b7c19b2a3e"
-  integrity sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    rbush "^2.0.1"
-
-"@turf/combine@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/combine/-/combine-5.1.5.tgz#bb14bdefa55504357195fc1a124cd7d53a8c8905"
-  integrity sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/concave@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/concave/-/concave-5.1.5.tgz#23bbaac387d034b96574a1bd70d059237a9d2110"
-  integrity sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=
-  dependencies:
-    "@turf/clone" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/tin" "^5.1.5"
-    topojson-client "3.x"
-    topojson-server "3.x"
-
-"@turf/convex@5.1.x", "@turf/convex@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/convex/-/convex-5.1.5.tgz#0df9377dd002216ce9821b07f705e037dae3e01d"
-  integrity sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    concaveman "*"
-
-"@turf/destination@5.1.x", "@turf/destination@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-5.1.5.tgz#ed35381bdce83bbddcbd07a2e2bce2bddffbcc26"
-  integrity sha1-7TU4G9zoO73cvQei4rzivd/7zCY=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/difference@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-5.1.5.tgz#a24d690a7bca803f1090a9ee3b9d906fc4371f42"
-  integrity sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=
-  dependencies:
-    "@turf/area" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    turf-jsts "*"
-
-"@turf/dissolve@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/dissolve/-/dissolve-5.1.5.tgz#2cf133a9021d2163831c3d7a958d6507f9d81938"
-  integrity sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=
-  dependencies:
-    "@turf/boolean-overlap" "^5.1.5"
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/line-intersect" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/union" "^5.1.5"
-    geojson-rbush "2.1.0"
-    get-closest "*"
-
-"@turf/distance@5.1.x", "@turf/distance@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-5.1.5.tgz#39cf18204bbf87587d707e609a60118909156409"
-  integrity sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/distance@6.x":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.0.1.tgz#0761f28784286e7865a427c4e7e3593569c2dea8"
-  integrity sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==
-  dependencies:
-    "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
-
-"@turf/ellipse@5.1.x", "@turf/ellipse@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/ellipse/-/ellipse-5.1.5.tgz#d57cab853985920cde60228a78d80458025c54be"
-  integrity sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/rhumb-destination" "^5.1.5"
-    "@turf/transform-rotate" "^5.1.5"
-
-"@turf/envelope@5.1.x", "@turf/envelope@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/envelope/-/envelope-5.1.5.tgz#5013309c53fdd43dfaf4b588a65c3fed7dbc108a"
-  integrity sha1-UBMwnFP91D369LWIplw/7X28EIo=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/bbox-polygon" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-
-"@turf/explode@5.1.x", "@turf/explode@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/explode/-/explode-5.1.5.tgz#b12b2f774004a1b48f62ba95b20a1c655a3de118"
-  integrity sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/flatten@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/flatten/-/flatten-5.1.5.tgz#da2927067133ed6169b0b9d607b9215688aa1358"
-  integrity sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/flip@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/flip/-/flip-5.1.5.tgz#436f643a722f0ca53b9fce638e4693db3608a68a"
-  integrity sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=
-  dependencies:
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/great-circle@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/great-circle/-/great-circle-5.1.5.tgz#debfb671ce475509cb637301c15fcfccfa359a93"
-  integrity sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/helpers@*", "@turf/helpers@6.x":
+"@turf/helpers@6.x", "@turf/helpers@^6.1.4":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.1.4.tgz#d6fd7ebe6782dd9c87dca5559bda5c48ae4c3836"
   integrity sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==
 
-"@turf/helpers@5.1.x", "@turf/helpers@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
-  integrity sha1-FTQFInq5M9AEpbuWQantmZ/L4M8=
-
-"@turf/hex-grid@5.1.x", "@turf/hex-grid@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/hex-grid/-/hex-grid-5.1.5.tgz#9b7ba5fecf5051f1e85892f713fce5c550502a6a"
-  integrity sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=
-  dependencies:
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/intersect" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/interpolate@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/interpolate/-/interpolate-5.1.5.tgz#0f12f0ab756d6dd10afb290ca6e877bdef013eaa"
-  integrity sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/centroid" "^5.1.5"
-    "@turf/clone" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/hex-grid" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/point-grid" "^5.1.5"
-    "@turf/square-grid" "^5.1.5"
-    "@turf/triangle-grid" "^5.1.5"
-
-"@turf/intersect@5.1.x", "@turf/intersect@^5.1.5":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/@turf/intersect/-/intersect-5.1.6.tgz#13ffcceb7a529c2a7e5d6681ab3ba671f868e95f"
-  integrity sha512-KXyNv/GXdoGAOy03qZF53rgtXC2tNhF/4jLwTKiVRrBQH6kcEpipGStdJ+QkYIlarQPa8f7I9UlVAB19et4MfQ==
-  dependencies:
-    "@turf/clean-coords" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/truncate" "^5.1.5"
-    turf-jsts "*"
-
-"@turf/invariant@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.1.5.tgz#f59f4fefa09224b15dce1651f903c868d57a24e1"
-  integrity sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/invariant@6.x":
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.1.2.tgz#6013ed6219f9ac2edada9b31e1dfa5918eb0a2f7"
-  integrity sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==
-  dependencies:
-    "@turf/helpers" "6.x"
-
-"@turf/invariant@^5.1.5":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
-  integrity sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/isobands@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/isobands/-/isobands-5.1.5.tgz#6b44cef584d551a31304187af23b4a1582e3f08d"
-  integrity sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=
-  dependencies:
-    "@turf/area" "^5.1.5"
-    "@turf/bbox" "^5.1.5"
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/explode" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/isolines@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/isolines/-/isolines-5.1.5.tgz#8ab4e7f42bb3dfc54614e5bf155967f7e55d2de1"
-  integrity sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/kinks@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/kinks/-/kinks-5.1.5.tgz#8abb6961d9bb0107213baddf2c2c2640d0256980"
-  integrity sha1-irtpYdm7AQchO63fLCwmQNAlaYA=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/length@5.1.x", "@turf/length@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/length/-/length-5.1.5.tgz#f3a5f864c2b996a8bb471794535a1faf12eebefb"
-  integrity sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=
-  dependencies:
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/line-arc@5.1.x", "@turf/line-arc@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-arc/-/line-arc-5.1.5.tgz#0078a7447835a12ae414a211f9a64d1186150e15"
-  integrity sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=
-  dependencies:
-    "@turf/circle" "^5.1.5"
-    "@turf/destination" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-
-"@turf/line-chunk@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-chunk/-/line-chunk-5.1.5.tgz#910a85c05c06d9d0f9c38977a05e0818d5085c42"
-  integrity sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/length" "^5.1.5"
-    "@turf/line-slice-along" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/line-intersect@5.1.x", "@turf/line-intersect@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-5.1.5.tgz#0e29071ae403295e491723bc49f5cfac8d11ddf3"
-  integrity sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/line-segment" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    geojson-rbush "2.1.0"
-
-"@turf/line-offset@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-offset/-/line-offset-5.1.5.tgz#2ab5b2f089f8c913e231d994378e79dca90b5a1e"
-  integrity sha1-KrWy8In4yRPiMdmUN4553KkLWh4=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/line-overlap@5.1.x", "@turf/line-overlap@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-overlap/-/line-overlap-5.1.5.tgz#943c6f87a0386dc43dfac11d2b3ff9c112cd3f60"
-  integrity sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=
-  dependencies:
-    "@turf/boolean-point-on-line" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/line-segment" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/nearest-point-on-line" "^5.1.5"
-    geojson-rbush "2.1.0"
-
-"@turf/line-segment@5.1.x", "@turf/line-segment@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-segment/-/line-segment-5.1.5.tgz#3207aaee546ab24c3d8dc3cc63f91c770b8013e5"
-  integrity sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/line-slice-along@5.1.x", "@turf/line-slice-along@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz#eddad0a21ef479f2968a11bd2dd7289a2132e9a5"
-  integrity sha1-7drQoh70efKWihG9LdcomiEy6aU=
-  dependencies:
-    "@turf/bearing" "^5.1.5"
-    "@turf/destination" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-
-"@turf/line-slice@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-slice/-/line-slice-5.1.5.tgz#1ecfce1462a378579754cedf4464cde26829f2b5"
-  integrity sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/nearest-point-on-line" "^5.1.5"
-
-"@turf/line-split@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-split/-/line-split-5.1.5.tgz#5b2df4c37619b72ef725b5163cf9926d5540acb7"
-  integrity sha1-Wy30w3YZty73JbUWPPmSbVVArLc=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/line-intersect" "^5.1.5"
-    "@turf/line-segment" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/nearest-point-on-line" "^5.1.5"
-    "@turf/square" "^5.1.5"
-    "@turf/truncate" "^5.1.5"
-    geojson-rbush "2.1.0"
-
-"@turf/line-to-polygon@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz#213cf41a68f8224778ba39d3187dec3e8b81865a"
-  integrity sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/mask@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/mask/-/mask-5.1.5.tgz#9ab0fef1a272c98fe3ef492f9ffb618206b242d5"
-  integrity sha1-mrD+8aJyyY/j70kvn/thggayQtU=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/union" "^5.1.5"
-    rbush "^2.0.1"
-
-"@turf/meta@*", "@turf/meta@6.x":
+"@turf/meta@6.x":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.0.2.tgz#eb92951126d24a613ac1b7b99d733fcc20fd30cf"
   integrity sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==
   dependencies:
     "@turf/helpers" "6.x"
-
-"@turf/meta@5.1.x":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-5.1.6.tgz#c20a863eded0869fb28548dee889341bccb46a46"
-  integrity sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/meta@^5.1.5":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-5.2.0.tgz#3b1ad485ee0c3b0b1775132a32c384d53e4ba53d"
-  integrity sha1-OxrUhe4MOwsXdRMqMsOE1T5LpT0=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/midpoint@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/midpoint/-/midpoint-5.1.5.tgz#e261f6b2b0ea8124cceff552a262dd465c9d05f0"
-  integrity sha1-4mH2srDqgSTM7/VSomLdRlydBfA=
-  dependencies:
-    "@turf/bearing" "^5.1.5"
-    "@turf/destination" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-
-"@turf/nearest-point-on-line@5.1.x", "@turf/nearest-point-on-line@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz#5606ae297f15947524bea51a2a9ef51ec1bf9c36"
-  integrity sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=
-  dependencies:
-    "@turf/bearing" "^5.1.5"
-    "@turf/destination" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/line-intersect" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/nearest-point-to-line@5.1.x":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.6.tgz#d30b7606e56a3dce97f4db6d45d352470e0b3f88"
-  integrity sha512-ZSvDIEiHhifn/vNwLXZI/E8xmEz5yBPqfUR7BVHRZrB1cP7jLhKZvkbidjG//uW8Fr1Ulc+PFOXczLspIcx/lw==
-  dependencies:
-    "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
-    "@turf/meta" "6.x"
-    "@turf/point-to-line-distance" "^5.1.5"
-    object-assign "*"
-
-"@turf/nearest-point@5.1.x", "@turf/nearest-point@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/nearest-point/-/nearest-point-5.1.5.tgz#12050de41c398443224c7978de0f6213900d34fb"
-  integrity sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=
-  dependencies:
-    "@turf/clone" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/planepoint@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/planepoint/-/planepoint-5.1.5.tgz#18bbdf006f759def5e42c6a006c9f9de81b2b7ff"
-  integrity sha1-GLvfAG91ne9eQsagBsn53oGyt/8=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/point-grid@5.1.x", "@turf/point-grid@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/point-grid/-/point-grid-5.1.5.tgz#305141248f50bafe36ce7e66ba4b97e7ab236887"
-  integrity sha1-MFFBJI9Quv42zn5mukuX56sjaIc=
-  dependencies:
-    "@turf/boolean-within" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/point-on-feature@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz#30c7f032430277c6418d96d289e45b6bfb213fe7"
-  integrity sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=
-  dependencies:
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/center" "^5.1.5"
-    "@turf/explode" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/nearest-point" "^5.1.5"
-
-"@turf/point-to-line-distance@5.1.x", "@turf/point-to-line-distance@^5.1.5":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/@turf/point-to-line-distance/-/point-to-line-distance-5.1.6.tgz#954f6cb68546420a030d8480392503264970d2d8"
-  integrity sha512-PE3hiTeeDEi4ZLPtI8XAzFYW9nHo1EVsZGm/4ZVV8jo39d3X1oLVHxY3e1PkCmWwRapXy4QLqvnTQ7nU4wspNw==
-  dependencies:
-    "@turf/bearing" "6.x"
-    "@turf/distance" "6.x"
-    "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
-    "@turf/meta" "6.x"
-    "@turf/projection" "6.x"
-    "@turf/rhumb-bearing" "6.x"
-    "@turf/rhumb-distance" "6.x"
-
-"@turf/points-within-polygon@5.1.x", "@turf/points-within-polygon@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz#2b855a5df3aada57c2ee820a0754ab94928a2337"
-  integrity sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=
-  dependencies:
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/polygon-tangents@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz#2bf00991473025b178e250dc7cb9ae5409bbd652"
-  integrity sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/polygon-to-line@5.1.x", "@turf/polygon-to-line@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz#23bb448d84dc4c651999ac611a36d91c5925036a"
-  integrity sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/polygonize@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/polygonize/-/polygonize-5.1.5.tgz#0493fa11879f39d10b9ad02ce6a23e942d08aa32"
-  integrity sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=
-  dependencies:
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/envelope" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/projection@5.1.x", "@turf/projection@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-5.1.5.tgz#24517eeeb2f36816ba9f712e7ae6d6a368edf757"
-  integrity sha1-JFF+7rLzaBa6n3EueubWo2jt91c=
-  dependencies:
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/projection@6.x":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-6.0.1.tgz#bde70ae8441b9cefddf26d71c7db74bc3d9792b1"
-  integrity sha512-Y3RvGT6I53MjYKLG69e9sMk45wJXcLbrEO1t6P3WQQQGqA2gYhhMJyV41vE2Z2llrJpvs2dDx/tIeQzGd0HHMQ==
-  dependencies:
-    "@turf/clone" "6.x"
-    "@turf/helpers" "6.x"
-    "@turf/meta" "6.x"
-
-"@turf/random@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/random/-/random-5.1.5.tgz#b32efc934560ae8ba57e8ebb51f241c39fba2e7b"
-  integrity sha1-sy78k0Vgroulfo67UfJBw5+6Lns=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/rewind@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/rewind/-/rewind-5.1.5.tgz#9ea3db4a68b73c1fd1dd11f57631b143cfefa1c9"
-  integrity sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=
-  dependencies:
-    "@turf/boolean-clockwise" "^5.1.5"
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/rhumb-bearing@5.1.x", "@turf/rhumb-bearing@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz#acf6a502427eb8c49e18cda6ae0effab0c5ddcd2"
-  integrity sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/rhumb-bearing@6.x":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz#182c4c21fe951e097fb468ae128dc22ef6078f3f"
-  integrity sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==
-  dependencies:
-    "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
-
-"@turf/rhumb-destination@5.1.x", "@turf/rhumb-destination@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz#b1b2aeb921547f2ac0c1a994b6a130f92463c742"
-  integrity sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/rhumb-distance@5.1.x", "@turf/rhumb-distance@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz#1806857625f4225384dad413e69f39538ff5f765"
-  integrity sha1-GAaFdiX0IlOE2tQT5p85U4/192U=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/rhumb-distance@6.x":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz#ae1c5c823b4b04f75cd7fc240f7f93647db8bdd4"
-  integrity sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==
-  dependencies:
-    "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
-
-"@turf/sample@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/sample/-/sample-5.1.5.tgz#e9cb448a4789cc56ee3de2dd6781e2343435b411"
-  integrity sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/sector@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/sector/-/sector-5.1.5.tgz#ac2bb94c13edd6034f6fdc2b67008135d20f5e07"
-  integrity sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=
-  dependencies:
-    "@turf/circle" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/line-arc" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/shortest-path@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/shortest-path/-/shortest-path-5.1.5.tgz#854ae8096f6bc3e1300faca77f3e8f67d8f935ab"
-  integrity sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/bbox-polygon" "^5.1.5"
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/clean-coords" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/transform-scale" "^5.1.5"
-
-"@turf/simplify@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/simplify/-/simplify-5.1.5.tgz#0ac8f27a2eb4218183edd9998c3275abe408b926"
-  integrity sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=
-  dependencies:
-    "@turf/clean-coords" "^5.1.5"
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/square-grid@5.1.x", "@turf/square-grid@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/square-grid/-/square-grid-5.1.5.tgz#1bd5f7b9eb14f0b60bc231fefe7351d1a32f1a51"
-  integrity sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=
-  dependencies:
-    "@turf/boolean-contains" "^5.1.5"
-    "@turf/boolean-overlap" "^5.1.5"
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/intersect" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/square@5.1.x", "@turf/square@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/square/-/square-5.1.5.tgz#aa7b21e6033cc9252c3a5bd6f3d88dabd6fed180"
-  integrity sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=
-  dependencies:
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-
-"@turf/standard-deviational-ellipse@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz#85cd283b5e1aca58f21bd66412e414b56d852324"
-  integrity sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=
-  dependencies:
-    "@turf/center-mean" "^5.1.5"
-    "@turf/ellipse" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/points-within-polygon" "^5.1.5"
-
-"@turf/tag@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/tag/-/tag-5.1.5.tgz#d1ee1a5088ecfd4a1411019c98239ccf2a497d20"
-  integrity sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=
-  dependencies:
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/tesselate@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/tesselate/-/tesselate-5.1.5.tgz#32a594e9c21a00420a9f90d2c43df3e1166061cd"
-  integrity sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    earcut "^2.0.0"
-
-"@turf/tin@5.1.x", "@turf/tin@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/tin/-/tin-5.1.5.tgz#28223eafc5fbe9ae9acca81cdcfea5d1424c917d"
-  integrity sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-
-"@turf/transform-rotate@5.1.x", "@turf/transform-rotate@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz#d096edd9e300fe315069d54d8e458c409221edfb"
-  integrity sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=
-  dependencies:
-    "@turf/centroid" "^5.1.5"
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/rhumb-bearing" "^5.1.5"
-    "@turf/rhumb-destination" "^5.1.5"
-    "@turf/rhumb-distance" "^5.1.5"
-
-"@turf/transform-scale@5.1.x", "@turf/transform-scale@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/transform-scale/-/transform-scale-5.1.5.tgz#70fd3ae01856cf7bae9f15ad561cdfe8f89001b9"
-  integrity sha1-cP064BhWz3uunxWtVhzf6PiQAbk=
-  dependencies:
-    "@turf/bbox" "^5.1.5"
-    "@turf/center" "^5.1.5"
-    "@turf/centroid" "^5.1.5"
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/rhumb-bearing" "^5.1.5"
-    "@turf/rhumb-destination" "^5.1.5"
-    "@turf/rhumb-distance" "^5.1.5"
-
-"@turf/transform-translate@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/transform-translate/-/transform-translate-5.1.5.tgz#530a257fb1dc7268dadcab34e67901eb2a3dec63"
-  integrity sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=
-  dependencies:
-    "@turf/clone" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    "@turf/rhumb-destination" "^5.1.5"
-
-"@turf/triangle-grid@5.1.x", "@turf/triangle-grid@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz#7b36762108554c14f28caff3c48b1cfc82c8dc81"
-  integrity sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=
-  dependencies:
-    "@turf/distance" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/intersect" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-
-"@turf/truncate@5.1.x", "@turf/truncate@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/truncate/-/truncate-5.1.5.tgz#9eedfb3b18ba81f2c98d3ead09431cca1884ad89"
-  integrity sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-
-"@turf/turf@^5.1.6":
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/@turf/turf/-/turf-5.1.6.tgz#c3122592887ed234b75468b8a8c45bf886fbf8f6"
-  integrity sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=
-  dependencies:
-    "@turf/along" "5.1.x"
-    "@turf/area" "5.1.x"
-    "@turf/bbox" "5.1.x"
-    "@turf/bbox-clip" "5.1.x"
-    "@turf/bbox-polygon" "5.1.x"
-    "@turf/bearing" "5.1.x"
-    "@turf/bezier-spline" "5.1.x"
-    "@turf/boolean-clockwise" "5.1.x"
-    "@turf/boolean-contains" "5.1.x"
-    "@turf/boolean-crosses" "5.1.x"
-    "@turf/boolean-disjoint" "5.1.x"
-    "@turf/boolean-equal" "5.1.x"
-    "@turf/boolean-overlap" "5.1.x"
-    "@turf/boolean-parallel" "5.1.x"
-    "@turf/boolean-point-in-polygon" "5.1.x"
-    "@turf/boolean-point-on-line" "5.1.x"
-    "@turf/boolean-within" "5.1.x"
-    "@turf/buffer" "5.1.x"
-    "@turf/center" "5.1.x"
-    "@turf/center-mean" "5.1.x"
-    "@turf/center-median" "5.1.x"
-    "@turf/center-of-mass" "5.1.x"
-    "@turf/centroid" "5.1.x"
-    "@turf/circle" "5.1.x"
-    "@turf/clean-coords" "5.1.x"
-    "@turf/clone" "5.1.x"
-    "@turf/clusters" "5.1.x"
-    "@turf/clusters-dbscan" "5.1.x"
-    "@turf/clusters-kmeans" "5.1.x"
-    "@turf/collect" "5.1.x"
-    "@turf/combine" "5.1.x"
-    "@turf/concave" "5.1.x"
-    "@turf/convex" "5.1.x"
-    "@turf/destination" "5.1.x"
-    "@turf/difference" "5.1.x"
-    "@turf/dissolve" "5.1.x"
-    "@turf/distance" "5.1.x"
-    "@turf/ellipse" "5.1.x"
-    "@turf/envelope" "5.1.x"
-    "@turf/explode" "5.1.x"
-    "@turf/flatten" "5.1.x"
-    "@turf/flip" "5.1.x"
-    "@turf/great-circle" "5.1.x"
-    "@turf/helpers" "5.1.x"
-    "@turf/hex-grid" "5.1.x"
-    "@turf/interpolate" "5.1.x"
-    "@turf/intersect" "5.1.x"
-    "@turf/invariant" "5.1.x"
-    "@turf/isobands" "5.1.x"
-    "@turf/isolines" "5.1.x"
-    "@turf/kinks" "5.1.x"
-    "@turf/length" "5.1.x"
-    "@turf/line-arc" "5.1.x"
-    "@turf/line-chunk" "5.1.x"
-    "@turf/line-intersect" "5.1.x"
-    "@turf/line-offset" "5.1.x"
-    "@turf/line-overlap" "5.1.x"
-    "@turf/line-segment" "5.1.x"
-    "@turf/line-slice" "5.1.x"
-    "@turf/line-slice-along" "5.1.x"
-    "@turf/line-split" "5.1.x"
-    "@turf/line-to-polygon" "5.1.x"
-    "@turf/mask" "5.1.x"
-    "@turf/meta" "5.1.x"
-    "@turf/midpoint" "5.1.x"
-    "@turf/nearest-point" "5.1.x"
-    "@turf/nearest-point-on-line" "5.1.x"
-    "@turf/nearest-point-to-line" "5.1.x"
-    "@turf/planepoint" "5.1.x"
-    "@turf/point-grid" "5.1.x"
-    "@turf/point-on-feature" "5.1.x"
-    "@turf/point-to-line-distance" "5.1.x"
-    "@turf/points-within-polygon" "5.1.x"
-    "@turf/polygon-tangents" "5.1.x"
-    "@turf/polygon-to-line" "5.1.x"
-    "@turf/polygonize" "5.1.x"
-    "@turf/projection" "5.1.x"
-    "@turf/random" "5.1.x"
-    "@turf/rewind" "5.1.x"
-    "@turf/rhumb-bearing" "5.1.x"
-    "@turf/rhumb-destination" "5.1.x"
-    "@turf/rhumb-distance" "5.1.x"
-    "@turf/sample" "5.1.x"
-    "@turf/sector" "5.1.x"
-    "@turf/shortest-path" "5.1.x"
-    "@turf/simplify" "5.1.x"
-    "@turf/square" "5.1.x"
-    "@turf/square-grid" "5.1.x"
-    "@turf/standard-deviational-ellipse" "5.1.x"
-    "@turf/tag" "5.1.x"
-    "@turf/tesselate" "5.1.x"
-    "@turf/tin" "5.1.x"
-    "@turf/transform-rotate" "5.1.x"
-    "@turf/transform-scale" "5.1.x"
-    "@turf/transform-translate" "5.1.x"
-    "@turf/triangle-grid" "5.1.x"
-    "@turf/truncate" "5.1.x"
-    "@turf/union" "5.1.x"
-    "@turf/unkink-polygon" "5.1.x"
-    "@turf/voronoi" "5.1.x"
-
-"@turf/union@5.1.x", "@turf/union@^5.1.5":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/union/-/union-5.1.5.tgz#53285b6094047fc58d96aac0ea90865ec34d454b"
-  integrity sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    turf-jsts "*"
-
-"@turf/unkink-polygon@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz#7b01847c50fb574ae2579e19e44cba8526d213c3"
-  integrity sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=
-  dependencies:
-    "@turf/area" "^5.1.5"
-    "@turf/boolean-point-in-polygon" "^5.1.5"
-    "@turf/helpers" "^5.1.5"
-    "@turf/meta" "^5.1.5"
-    rbush "^2.0.1"
-
-"@turf/voronoi@5.1.x":
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/@turf/voronoi/-/voronoi-5.1.5.tgz#e856e9406dcc2f25d66ddc898584e27c2ebfca66"
-  integrity sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=
-  dependencies:
-    "@turf/helpers" "^5.1.5"
-    "@turf/invariant" "^5.1.5"
-    d3-voronoi "1.1.2"
 
 "@types/d3-array@*":
   version "1.2.6"
@@ -2183,17 +1036,6 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concaveman@*:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/concaveman/-/concaveman-1.1.1.tgz#6c2482580b2523cef82fc2bec00a0415e6e68162"
-  integrity sha1-bCSCWAslI874L8K+wAoEFebmgWI=
-  dependencies:
-    monotone-convex-hull-2d "^1.0.1"
-    point-in-polygon "^1.0.1"
-    rbush "^2.0.1"
-    robust-orientation "^1.1.3"
-    tinyqueue "^1.1.0"
-
 consola@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.4.1.tgz#ad7209c306a2b6fa955b776f88f87bf92f491aa8"
@@ -2595,13 +1437,6 @@ d3-geo@1:
   dependencies:
     d3-array "1"
 
-d3-geo@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.7.1.tgz#44bbc7a218b1fd859f3d8fd7c443ca836569ce99"
-  integrity sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==
-  dependencies:
-    d3-array "1"
-
 d3-hierarchy@1:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz#7a6317bd3ed24e324641b6f1e76e978836b008cc"
@@ -2684,11 +1519,6 @@ d3-transition@1:
 d3-voronoi@1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
-
-d3-voronoi@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
-  integrity sha1-Fodmfo8TotFYyAwUgMWinLDYlzw=
 
 d3-zoom@1:
   version "1.7.3"
@@ -2774,11 +1604,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
-deep-equal@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
-
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -2811,11 +1636,6 @@ define-property@^2.0.2:
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
-
-density-clustering@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/density-clustering/-/density-clustering-1.3.0.tgz#dc9f59c8f0ab97e1624ac64930fd3194817dcac5"
-  integrity sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU=
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -2911,11 +1731,6 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
-
-earcut@^2.0.0:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.5.tgz#829280a9a3a0f5fee0529f0a47c3e4eff09b21e4"
-  integrity sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA==
 
 electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.30:
   version "1.3.113"
@@ -3243,30 +2058,9 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-geojson-equality@0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/geojson-equality/-/geojson-equality-0.1.6.tgz#a171374ef043e5d4797995840bae4648e0752d72"
-  integrity sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=
-  dependencies:
-    deep-equal "^1.0.0"
-
-geojson-rbush@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/geojson-rbush/-/geojson-rbush-2.1.0.tgz#3bd73be391fc10b0ae693d9b8acea2aae0b83a8d"
-  integrity sha1-O9c745H8ELCuaT2bis6iquC4Oo0=
-  dependencies:
-    "@turf/helpers" "*"
-    "@turf/meta" "*"
-    rbush "*"
-
 get-caller-file@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
-
-get-closest@*:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/get-closest/-/get-closest-0.0.4.tgz#269ac776d1e6022aa0fd586dd708e8a7d32269af"
-  integrity sha1-JprHdtHmAiqg/Vht1wjop9Miaa8=
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -3835,11 +2629,6 @@ leaflet@^1.3.4:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.4.0.tgz#d5f56eeb2aa32787c24011e8be4c77e362ae171b"
 
-lineclip@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/lineclip/-/lineclip-1.1.5.tgz#2bf26067d94354feabf91e42768236db5616fd13"
-  integrity sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM=
-
 loader-runner@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -4100,13 +2889,6 @@ moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
 
-monotone-convex-hull-2d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz#47f5daeadf3c4afd37764baa1aa8787a40eee08c"
-  integrity sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=
-  dependencies:
-    robust-orientation "^1.1.3"
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -4290,7 +3072,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@*, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4533,11 +3315,6 @@ pleeease-filters@^4.0.0:
   dependencies:
     onecolor "^3.0.4"
     postcss "^6.0.1"
-
-point-in-polygon@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/point-in-polygon/-/point-in-polygon-1.0.1.tgz#d59b64e8fee41c49458aac82b56718c5957b2af7"
-  integrity sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc=
 
 popper.js@^1.15.0:
   version "1.15.0"
@@ -5189,16 +3966,6 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
-quickselect@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-1.1.1.tgz#852e412ce418f237ad5b660d70cffac647ae94c2"
-  integrity sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==
-
-quickselect@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
-  integrity sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -5211,20 +3978,6 @@ randomfill@^1.0.3:
   dependencies:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
-
-rbush@*:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/rbush/-/rbush-3.0.0.tgz#6ba5ee1e7d8218f7ac219f5e5b145a8a7113ff72"
-  integrity sha512-hb6ViijtI77X4lyhfYDsjOc6icrJPVdHsxf44vYiGctsrWJNXoPtR6Uzvo8F562mJZysjn8YRI9jNKvDPK4ozQ==
-  dependencies:
-    quickselect "^2.0.0"
-
-rbush@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/rbush/-/rbush-2.0.2.tgz#bb6005c2731b7ba1d5a9a035772927d16a614605"
-  integrity sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==
-  dependencies:
-    quickselect "^1.0.1"
 
 rc@^1.2.7:
   version "1.2.8"
@@ -5422,34 +4175,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-robust-orientation@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/robust-orientation/-/robust-orientation-1.1.3.tgz#daff5b00d3be4e60722f0e9c0156ef967f1c2049"
-  integrity sha1-2v9bANO+TmByLw6cAVbvln8cIEk=
-  dependencies:
-    robust-scale "^1.0.2"
-    robust-subtract "^1.0.0"
-    robust-sum "^1.0.0"
-    two-product "^1.0.2"
-
-robust-scale@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/robust-scale/-/robust-scale-1.0.2.tgz#775132ed09542d028e58b2cc79c06290bcf78c32"
-  integrity sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=
-  dependencies:
-    two-product "^1.0.2"
-    two-sum "^1.0.0"
-
-robust-subtract@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/robust-subtract/-/robust-subtract-1.0.0.tgz#e0b164e1ed8ba4e3a5dda45a12038348dbed3e9a"
-  integrity sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo=
-
-robust-sum@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/robust-sum/-/robust-sum-1.0.0.tgz#16646e525292b4d25d82757a286955e0bbfa53d9"
-  integrity sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k=
-
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
@@ -5550,11 +4275,6 @@ simple-swizzle@^0.2.2:
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
   dependencies:
     is-arrayish "^0.3.1"
-
-skmeans@0.9.7:
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/skmeans/-/skmeans-0.9.7.tgz#72670cebb728508f56e29c0e10d11e623529ce5d"
-  integrity sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==
 
 slash@^1.0.0:
   version "1.0.0"
@@ -5860,11 +4580,6 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
 
-tinyqueue@^1.1.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-1.2.3.tgz#b6a61de23060584da29f82362e45df1ec7353f3d"
-  integrity sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==
-
 to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
@@ -5890,20 +4605,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-topojson-client@3.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.0.0.tgz#1f99293a77ef42a448d032a81aa982b73f360d2f"
-  integrity sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=
-  dependencies:
-    commander "2"
-
-topojson-server@3.x:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/topojson-server/-/topojson-server-3.0.0.tgz#378e78e87c3972a7b5be2c5d604369b6bae69c5e"
-  integrity sha1-N4546Hw5cqe1vixdYENptrrmnF4=
-  dependencies:
-    commander "2"
 
 toposort@^1.0.0:
   version "1.0.7"
@@ -5959,21 +4660,6 @@ tsutils@^2.27.2:
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
-
-turf-jsts@*:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/turf-jsts/-/turf-jsts-1.2.3.tgz#59757f542afbff9a577bbf411f183b8f48d38aa4"
-  integrity sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA==
-
-two-product@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/two-product/-/two-product-1.0.2.tgz#67d95d4b257a921e2cb4bd7af9511f9088522eaa"
-  integrity sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo=
-
-two-sum@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/two-sum/-/two-sum-1.0.0.tgz#31d3f32239e4f731eca9df9155e2b297f008ab64"
-  integrity sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q=
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
Fixes #1197, fixes #1199.

Server updates:
1. Bucket count is now a parameter rather than being a constant value
1. Coordinate summaries are now generated by computing the mix/max for the data, and creating buckets within that range (similar to numeric summary)
1. Filters no longer drive the view bounds.

Client updates:
1. Heatmap buckets now render directly from the data supplied by the server.
1. User ability to pan/zoom has been removed - the view will be fixed, and filtering will be applied by drag-selecting an area on the map (will be done as follow-on work)
1.  Code that was cloned from the geo-plot component that is not used has been removed.