### PR TITLE
Magnifying glass fix #1219

### DIFF
--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -58,10 +58,8 @@ export default Vue.extend({
 		};
 	},
 
-	updated: function () {
-		this.$nextTick(function () {
-			this.injectZoomedImage();
-		});
+	updated() {
+		this.$nextTick(this.injectZoomedImage);
 	},
 
 	computed: {

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -58,6 +58,12 @@ export default Vue.extend({
 		};
 	},
 
+	updated: function () {
+		this.$nextTick(function () {
+			this.injectZoomedImage();
+		});
+	},
+
 	computed: {
 		files(): Dictionary<any> {
 			return datasetGetters.getFiles(this.$store);
@@ -110,12 +116,15 @@ export default Vue.extend({
 			}
 		},
 
-		showZoomedImage() {
-			if (this.image) {
-				const $elem = this.$refs.imageElemZoom as any;
+		injectZoomedImage () {
+			const $elem = this.$refs.imageElemZoom as any;
+			if (this.image && $elem) {
 				$elem.innerHTML = '';
 				$elem.appendChild(this.clonedImageElement(this.zoomedWidth, this.zoomedHeight));
 			}
+		},
+
+		showZoomedImage() {
 			this.zoomImage = true;
 		},
 


### PR DESCRIPTION
In the facet refactor, missed was the issue of the ImagePreview vue component's attempts to find conditional dom elements immediately after state had been updated by the magnify action to inject a copied dom element via jQuery. I'm not entirely convinced this code even with this fix is ideal as it's basically trying to avoid an extra image load for the magnified image by copying a dom element  from a facet or list that already contains the image into the modal. However, long term, I don't think we'd want the full images loading for the thumbnail sized views in the facets, we'd want actual thumbnails to save bandwidth/load time, then only load the full version when we open the modal. Still, this returns functionality to the expected state.