### PR TITLE
image preview fixes #1220

### DIFF
--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -49,8 +49,8 @@ export default Vue.extend({
 	watch: {
 		imageUrl(newUrl, oldUrl) {
 			if (newUrl !== oldUrl) {
-				this.clearImage();
 				if (!this.image) {
+					this.clearImage();
 					this.requestImage();
 				} else {
 					this.injectImage();
@@ -150,8 +150,8 @@ export default Vue.extend({
 			return img as HTMLImageElement;
 		},
 
-		clearImage () {
-			const $elem = this.$refs.imageElem as any;
+		clearImage (elem?: any) {
+			const $elem = elem || this.$refs.imageElem as any;
 			if ($elem) {
 				$elem.innerHTML = '';
 			}
@@ -163,7 +163,7 @@ export default Vue.extend({
 			}
 			const elem = this.$refs.imageElem as any;
 			if (elem) {
-				elem.innerHTML = '';
+				this.clearImage(elem);
 				elem.appendChild(this.clonedImageElement(this.width, this.height));
 				const icon = document.createElement('i');
 				icon.className += 'fa fa-search-plus zoom-icon';

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -46,6 +46,19 @@ export default Vue.extend({
 		onClick: Function
 	},
 
+	watch: {
+		imageUrl(newUrl, oldUrl) {
+			if (newUrl !== oldUrl) {
+				this.clearImage();
+				if (!this.image) {
+					this.requestImage();
+				} else {
+					this.injectImage();
+				}
+			}
+		}
+	},
+
 	data() {
 		return {
 			zoomImage: false,
@@ -135,6 +148,13 @@ export default Vue.extend({
 			$(img).css('max-width', `${width}px`);
 			$(img).css('max-height', `${height}px`);
 			return img as HTMLImageElement;
+		},
+
+		clearImage () {
+			const $elem = this.$refs.imageElem as any;
+			if ($elem) {
+				$elem.innerHTML = '';
+			}
 		},
 
 		injectImage() {


### PR DESCRIPTION
Due to some quirks in the caching optimizations made for image loading, the imageUrl property could change for a rendered image preview component instance without triggering a redraw of the underlying image, as seen in the defect. By watching the imageUrl prop, we can catch changes, clear the existing image and request the image if it isn't yet loaded in the store, or load it from the store.