### PR TITLE
Date filtering min

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,11 +91,11 @@
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-compute"
-  branch = "master"
+  branch = "date-filtering-min"
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-ingest"
-  branch = "master"
+  branch = "date-filtering-min"
 
 [[constraint]]
   name = "github.com/unchartedsoftware/plog"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,11 +91,11 @@
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-compute"
-  branch = "date-filtering-min"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-ingest"
-  branch = "date-filtering-min"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/unchartedsoftware/plog"

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -18,6 +18,7 @@ package model
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -176,6 +177,34 @@ func parseFilter(filter map[string]interface{}) (*model.Filter, error) {
 	}
 
 	// TODO: update to a switch statement with a default to error
+
+	// datetine
+	if typ == model.DatetimeFilter {
+		key, ok := json.String(filter, "key")
+		if !ok {
+			return nil, errors.Errorf("no `key` provided for filter")
+		}
+
+		minStr, ok := json.String(filter, "min")
+		if !ok {
+			return nil, errors.Errorf("no `min` provided for filter")
+		}
+		min, err := time.Parse("2006/01/02", minStr)
+		if err != nil {
+			return nil, err
+		}
+
+		maxStr, ok := json.String(filter, "max")
+		if !ok {
+			return nil, errors.Errorf("no `max` provided for filter")
+		}
+		max, err := time.Parse("2006/01/02", maxStr)
+		if err != nil {
+			return nil, err
+		}
+
+		return model.NewDatetimeFilter(key, mode, float64(min.Unix()), float64(max.Unix())), nil
+	}
 
 	// numeric
 	if typ == model.NumericalFilter {

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -18,7 +18,6 @@ package model
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -184,26 +183,16 @@ func parseFilter(filter map[string]interface{}) (*model.Filter, error) {
 		if !ok {
 			return nil, errors.Errorf("no `key` provided for filter")
 		}
-
-		minStr, ok := json.String(filter, "min")
+		min, ok := json.Float(filter, "min")
 		if !ok {
 			return nil, errors.Errorf("no `min` provided for filter")
 		}
-		min, err := time.Parse("2006/01/02", minStr)
-		if err != nil {
-			return nil, err
-		}
-
-		maxStr, ok := json.String(filter, "max")
+		max, ok := json.Float(filter, "max")
 		if !ok {
 			return nil, errors.Errorf("no `max` provided for filter")
 		}
-		max, err := time.Parse("2006/01/02", maxStr)
-		if err != nil {
-			return nil, err
-		}
 
-		return model.NewDatetimeFilter(key, mode, float64(min.Unix()), float64(max.Unix())), nil
+		return model.NewDatetimeFilter(key, mode, min, max), nil
 	}
 
 	// numeric

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -269,11 +269,6 @@ func (f *DateTimeField) parseHistogram(rows *pgx.Rows, extrema *api.Extrema, num
 			keyString = strconv.Itoa(int(key))
 		}
 
-		//dateString, err := f.parseValueToDateString(keyString)
-		//if err != nil {
-		//	return nil, err
-		//}
-
 		buckets[i] = &api.Bucket{
 			Key:   keyString,
 			Count: 0,

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -94,6 +94,14 @@ func (s *Storage) buildIncludeFilter(wheres []string, params []interface{}, filt
 	name := s.formatFilterKey(filter.Key)
 
 	switch filter.Type {
+	case model.DatetimeFilter:
+		// datetime
+		// extract epoch for comparison
+		where := fmt.Sprintf("cast(extract(epoch from %s) as integer) >= $%d AND cast(extract(epoch from %s) as integer) <= $%d", name, len(params)+1, name, len(params)+2)
+		wheres = append(wheres, where)
+		params = append(params, *filter.Min)
+		params = append(params, *filter.Max)
+
 	case model.NumericalFilter:
 		// numerical
 		// cast to double precision in case of string based representation

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -97,7 +97,7 @@ func (s *Storage) buildIncludeFilter(wheres []string, params []interface{}, filt
 	case model.DatetimeFilter:
 		// datetime
 		// extract epoch for comparison
-		where := fmt.Sprintf("cast(extract(epoch from %s) as integer) >= $%d AND cast(extract(epoch from %s) as integer) <= $%d", name, len(params)+1, name, len(params)+2)
+		where := fmt.Sprintf("cast(extract(epoch from %s) as double precision) >= $%d AND cast(extract(epoch from %s) as double precision) <= $%d", name, len(params)+1, name, len(params)+2)
 		wheres = append(wheres, where)
 		params = append(params, *filter.Min)
 		params = append(params, *filter.Max)
@@ -166,8 +166,17 @@ func (s *Storage) buildExcludeFilter(wheres []string, params []interface{}, filt
 	name := s.formatFilterKey(filter.Key)
 
 	switch filter.Type {
+	case model.DatetimeFilter:
+		// datetime
+		// extract epoch for comparison
+		where := fmt.Sprintf("cast(extract(epoch from %s) as double precision) < $%d OR cast(extract(epoch from %s) as double precision) > $%d", name, len(params)+1, name, len(params)+2)
+		wheres = append(wheres, where)
+		params = append(params, *filter.Min)
+		params = append(params, *filter.Max)
+
 	case model.NumericalFilter:
 		// numerical
+		//TODO: WHY DOES THIS QUERY NOT CAST TO DOUBLE LIKE THE INCLUDE???
 		where := fmt.Sprintf("(%s < $%d OR %s > $%d)", name, len(params)+1, name, len(params)+2)
 		wheres = append(wheres, where)
 		params = append(params, *filter.Min)

--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -12,7 +12,7 @@ import Vue from 'vue';
 import IconFork from './icons/IconFork';
 import IconBookmark from './icons/IconBookmark';
 import { createIcon } from '../util/icon';
-import { CATEGORICAL_FILTER, NUMERICAL_FILTER, BIVARIATE_FILTER, FEATURE_FILTER, TIMESERIES_FILTER, INCLUDE_FILTER } from '../util/filters';
+import { CATEGORICAL_FILTER, NUMERICAL_FILTER, DATETIME_FILTER, BIVARIATE_FILTER, FEATURE_FILTER, TIMESERIES_FILTER, INCLUDE_FILTER } from '../util/filters';
 import { createGroup, Group, CategoricalFacet, isCategoricalFacet, getCategoricalChunkSize, isNumericalFacet, isSparklineFacet } from '../util/facets';
 import { VariableSummary, Highlight, RowSelection, Row } from '../store/dataset/index';
 import { Dictionary } from '../util/dict';
@@ -79,8 +79,9 @@ export default Vue.extend({
 
 		this.facets.on('facet-histogram:rangechangeduser', (event: Event, key: string, value: any, facet: any) => {
 			const range = {
-				from: _.toNumber(value.from.label[0]),
-				to: _.toNumber(value.to.label[0])
+				from: _.isNumber(value.from.label[0]) ? _.toNumber(value.from.label[0]) : Date.parse(value.from.label[0]) / 1000,
+				to: _.isNumber(value.to.label[0]) ? _.toNumber(value.to.label[0]) : Date.parse(value.to.label[0]) / 1000,
+				type: _.isNumber(value.from.label[0]) ? NUMERICAL_FILTER : DATETIME_FILTER
 			};
 			component.$emit('range-change', this.instanceName, this.groupSpec.colName, range, facet.dataset);
 		});
@@ -290,9 +291,9 @@ export default Vue.extend({
 						const first = slices[0];
 						const last = slices[slices.length - 1];
 						const range = {
-							from: _.toNumber(first.label),
-							to: _.toNumber(last.toLabel),
-							type: NUMERICAL_FILTER
+							from: _.isNumber(first.label) ? _.toNumber(first.label) : Date.parse(first.label) / 1000,
+							to: _.isNumber(last.toLabel) ? _.toNumber(last.toLabel) : Date.parse(last.toLabel) / 1000,
+							type: _.isNumber(first.label) ? NUMERICAL_FILTER : DATETIME_FILTER
 						};
 						this.$emit('numerical-click', this.instanceName, group.colName, range, group.dataset);
 
@@ -323,8 +324,9 @@ export default Vue.extend({
 						const first = slices[0];
 						const last = slices[slices.length - 1];
 						const range = {
-							from: _.toNumber(first.label),
-							to: _.toNumber(last.toLabel)
+							from: _.isNumber(first.label) ? _.toNumber(first.label) : Date.parse(first.label) / 1000,
+							to: _.isNumber(last.toLabel) ? _.toNumber(last.toLabel) : Date.parse(last.toLabel) / 1000,
+							type: _.isNumber(first.label) ? NUMERICAL_FILTER : DATETIME_FILTER
 						};
 						this.$emit('numerical-click', this.instanceName, group.colName, range, group.dataset);
 

--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -12,6 +12,7 @@ import Vue from 'vue';
 import IconFork from './icons/IconFork';
 import IconBookmark from './icons/IconBookmark';
 import { createIcon } from '../util/icon';
+import { CATEGORICAL_FILTER, NUMERICAL_FILTER, BIVARIATE_FILTER, FEATURE_FILTER, TIMESERIES_FILTER, INCLUDE_FILTER } from '../util/filters';
 import { createGroup, Group, CategoricalFacet, isCategoricalFacet, getCategoricalChunkSize, isNumericalFacet, isSparklineFacet } from '../util/facets';
 import { VariableSummary, Highlight, RowSelection, Row } from '../store/dataset/index';
 import { Dictionary } from '../util/dict';
@@ -290,7 +291,8 @@ export default Vue.extend({
 						const last = slices[slices.length - 1];
 						const range = {
 							from: _.toNumber(first.label),
-							to: _.toNumber(last.toLabel)
+							to: _.toNumber(last.toLabel),
+							type: NUMERICAL_FILTER
 						};
 						this.$emit('numerical-click', this.instanceName, group.colName, range, group.dataset);
 

--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -605,7 +605,7 @@ export default Vue.extend({
 			// if the dataset of the highlight does not match the dataset of this
 			// facet, deemphasis the group
 
-			if (!highlight || !highlight || highlight.dataset === group.dataset) {
+			if (!highlight || !group || highlight.dataset === group.dataset) {
 				group._element.removeClass('deemphasis');
 				return;
 			}

--- a/public/components/FilterBadge.vue
+++ b/public/components/FilterBadge.vue
@@ -4,6 +4,9 @@
 		<span v-if="filter.type===NUMERICAL_FILTER">
 			{{filter.min.toFixed(2)}} : {{filter.max.toFixed(2)}}
 		</span>
+		<span v-if="filter.type===DATETIME_FILTER">
+			{{formatDate(filter.min * 1000)}} : {{formatDate(filter.max * 1000)}}
+		</span>
 		<span v-if="filter.type===BIVARIATE_FILTER">
 			[{{filter.minX.toFixed(2)}}, {{filter.minY.toFixed(2)}}] to [{{filter.maxX.toFixed(2)}}, {{filter.maxY.toFixed(2)}}]
 		</span>
@@ -20,7 +23,8 @@
 <script lang="ts">
 
 import Vue from 'vue';
-import { removeFilterFromRoute, Filter, NUMERICAL_FILTER, BIVARIATE_FILTER, CATEGORICAL_FILTER, FEATURE_FILTER, CLUSTER_FILTER } from '../util/filters';
+import moment from 'moment';
+import { removeFilterFromRoute, Filter, NUMERICAL_FILTER, DATETIME_FILTER, BIVARIATE_FILTER, CATEGORICAL_FILTER, FEATURE_FILTER, CLUSTER_FILTER } from '../util/filters';
 import { clearHighlight } from '../util/highlights';
 import { getVarType, isFeatureType, removeFeaturePrefix, isClusterType, removeClusterPrefix } from '../util/types';
 
@@ -46,6 +50,9 @@ export default Vue.extend({
 		NUMERICAL_FILTER(): string {
 			return NUMERICAL_FILTER;
 		},
+		DATETIME_FILTER(): string {
+			return DATETIME_FILTER;
+		},
 		CATEGORICAL_FILTER(): string {
 			return CATEGORICAL_FILTER;
 		},
@@ -67,6 +74,10 @@ export default Vue.extend({
 			} else {
 				clearHighlight(this.$router);
 			}
+		},
+
+		formatDate(epochTime: number): string {
+			return moment(epochTime).format('YYYY/MM/DD');
 		}
 	}
 });

--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -237,7 +237,7 @@ export default Vue.extend({
 			this.$emit('categorical-click', key);
 		},
 
-		onNumericalClick(context: string, key: string, value: { from: number, to: number }, dataset: string) {
+		onNumericalClick(context: string, key: string, value: { from: number, to: number, type: string }, dataset: string) {
 			if (this.enableHighlighting) {
 				if (!this.highlight || this.highlight.key !== key) {
 					updateHighlight(this.$router, {

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -365,9 +365,9 @@ function getHistogramSlices(summary: VariableSummary) {
 		let from: any, to: any;
 		if (summary.varType === DATE_TIME_TYPE) {
 			from = bucket.key;
-			to = (i < buckets.length - 1) ? buckets[i + 1].key : buckets[i].key;
-			from = moment(from).format('YYYY/MM/DD');
-			to = moment(to).format('YYYY/MM/DD');
+			to = (i < buckets.length - 1) ? buckets[i + 1].key : extrema.max;
+			from = moment.unix(_.toNumber(from)).utc().format('YYYY/MM/DD');
+			to = moment.unix(_.toNumber(to)).utc().format('YYYY/MM/DD');
 		} else {
 			from = _.toNumber(bucket.key);
 			to = (i < buckets.length - 1) ? _.toNumber(buckets[i + 1].key) : extrema.max;

--- a/public/util/filters.ts
+++ b/public/util/filters.ts
@@ -19,6 +19,13 @@ export const CATEGORICAL_FILTER = 'categorical';
 export const NUMERICAL_FILTER = 'numerical';
 
 /**
+ * Datetime filter, omitting documents that do not fall within the provided
+ * variable range.
+ * @constant {string}
+ */
+export const DATETIME_FILTER = 'datetime';
+
+/**
  * Bivariate filter, omitting documents that do not fall within the provided
  * variable range.
  * @constant {string}

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -80,7 +80,7 @@ export function createFilterFromHighlight(highlight: Highlight, mode: string): F
 
 		return {
 			key: key,
-			type: NUMERICAL_FILTER,
+			type: highlight.value.type,
 			mode: mode,
 			min: highlight.value.from,
 			max: highlight.value.to

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -8,6 +8,7 @@ export const FEATURE_PREFIX = '_feature_';
 export const CLUSTER_PREFIX = '_cluster_';
 export const GEOCODED_LAT_PREFIX = '_lat_';
 export const GEOCODED_LON_PREFIX = '_lon_';
+export const DATETIME_UNIX_ADJUSTMENT = 1000;
 
 // NOTE: these are copied from `distil-compute/model/schema_types.go` and
 // should be kept up to date in case of changes.


### PR DESCRIPTION
Fixes #1060 and #1059 

Datetime facets were not handling the string nature of the labels properly. The queries were also not using the proper extrema. Removed the rounding used by other data types when querying for summaries, and added a new datetime filter type that is used when generating where clauses.