### PR TITLE
Server side task resolution

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -423,7 +423,7 @@ func persistOriginalData(params *persistedDataParams) (string, string, error) {
 	dataPath := path.Join(params.SourceDataFolder, mainDR.ResPath)
 	trainDataFile := path.Join(trainFolder, mainDR.ResPath)
 	testDataFile := path.Join(testFolder, mainDR.ResPath)
-	if params.TaskType == compute.TaskTypeTimeseries {
+	if params.TaskType == compute.TimeseriesForecastingTask {
 		err = splitTrainTestTimeseries(dataPath, trainDataFile, testDataFile, true, params.TimeseriesFieldIndex)
 	} else {
 		config, err = env.LoadConfig()

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -607,7 +607,6 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 	// make sure that we include all non-generated variables in our persisted
 	// dataset - the column removal preprocessing step will mark them for
 	// removal by ta2
-
 	allVarFilters := s.Filters.Clone()
 	allVarFilters.Variables = []string{}
 	var timeseriesField *model.Variable
@@ -648,6 +647,14 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 
 	// add dataset name to path
 	datasetInputDir := env.ResolvePath(datasetInput.Source, datasetInput.Folder)
+
+	// compute the task and subtask from the target and dataset
+	task, err := ResolveTask(dataStorage, dataset.Metadata.StorageName, targetVariable)
+	if err != nil {
+		return err
+	}
+	s.Task = task.Task
+	s.SubTask = task.SubTask
 
 	// when dealing with categorical data we want to stratify
 	stratify := false

--- a/api/compute/task.go
+++ b/api/compute/task.go
@@ -1,0 +1,73 @@
+package compute
+
+import (
+	"errors"
+
+	"github.com/uncharted-distil/distil-compute/model"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
+	api "github.com/uncharted-distil/distil/api/model"
+)
+
+// Task provides a task and subtask field.  These are mapped to string definitions
+// derfined by the LL d3m problem schema.
+type Task struct {
+	Task    string `json:"task"`
+	SubTask string `json:"subtask"`
+}
+
+// ResolveTask will determine the task and subtask given training and target variables, and the ability of the underlying target labels.
+func ResolveTask(storage api.DataStorage, datasetStorageName string, targetVariable *model.Variable) (*Task, error) {
+	// Given the target variable and dataset, compute the task and subtask.
+	// If there's no target variable, we'll treat this as an unsupervised clustering task.
+	if targetVariable == nil {
+		return &Task{compute.ClusteringTask, compute.NoneSubTask}, nil
+	}
+
+	// If this is a timeseries target type the task will be a forecasting
+	if model.IsTimeSeries(targetVariable.Type) {
+		return &Task{compute.TimeseriesForecastingTask, compute.NoneSubTask}, nil
+	}
+
+	// If this is numerical target type we'll treat this a regression task.
+	if model.IsNumerical(targetVariable.Type) {
+		// Numerical regression.  Currently no support for multivariate, so we default
+		// to univariate.
+		return &Task{compute.RegressionTask, compute.UnivariateSubTask}, nil
+	}
+
+	// Classification.  This can be binary, multiclass, or semi-supervised depending on what we have for
+	// label distribution.
+	if model.IsCategorical(targetVariable.Type) {
+		task := compute.ClassificationTask
+		subTask := compute.MultiClassSubTask
+
+		// Fetch the counts for each category
+		targetCounts, err := storage.FetchCategoryCounts(datasetStorageName, targetVariable)
+		if err != nil {
+			return nil, err
+		}
+
+		// If more than 10% of the labels are empty, treat this as a semi-supervised learning task
+		total := 0
+		for _, count := range targetCounts {
+			total += count
+		}
+		if emptyCount, ok := targetCounts[""]; ok {
+			if float32(emptyCount)/float32(total) > 0.1 {
+				task = compute.SemiSupervisedClassificationTask
+			}
+			// If there are 3 labels (2 + empty), update this as a binary classification task
+			if len(targetCounts) == 2 {
+				subTask = compute.BinarySubTask
+			}
+			return &Task{task, subTask}, nil
+		}
+
+		// If there are only two labels, update this as a binary classification task
+		if len(targetCounts) == 2 {
+			subTask = compute.BinarySubTask
+		}
+		return &Task{task, subTask}, nil
+	}
+	return nil, errors.New("failed to determine task from dataset and target")
+}

--- a/api/compute/task.go
+++ b/api/compute/task.go
@@ -15,6 +15,8 @@ type Task struct {
 	SubTask string `json:"subtask"`
 }
 
+const semiSupervisedThreshold = 0.1
+
 // ResolveTask will determine the task and subtask given training and target variables, and the ability of the underlying target labels.
 func ResolveTask(storage api.DataStorage, datasetStorageName string, targetVariable *model.Variable) (*Task, error) {
 	// Given the target variable and dataset, compute the task and subtask.
@@ -53,7 +55,7 @@ func ResolveTask(storage api.DataStorage, datasetStorageName string, targetVaria
 			total += count
 		}
 		if emptyCount, ok := targetCounts[""]; ok {
-			if float32(emptyCount)/float32(total) > 0.1 {
+			if float32(emptyCount)/float32(total) > semiSupervisedThreshold {
 				task = compute.SemiSupervisedClassificationTask
 			}
 			// If there are 3 labels (2 + empty), update this as a binary classification task

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -45,6 +45,8 @@ type DataStorage interface {
 	FetchTimeseriesSummary(dataset string, storageName string, xColName string, yColName string, interval int, filterParams *FilterParams, invert bool) (*VariableSummary, error)
 	FetchTimeseriesSummaryByResult(dataset string, storageName string, xColName string, yColName string, interval int, resultURI string, filterParams *FilterParams) (*VariableSummary, error)
 	FetchForecastingSummary(dataset string, storageName string, xColName string, yColName string, interval int, resultURI string, filterParams *FilterParams) (*VariableSummary, error)
+	FetchCategoryCounts(storageName string, variable *model.Variable) (map[string]int, error)
+
 	// Dataset manipulation
 	IsValidDataType(dataset string, storageName string, varName string, varType string) (bool, error)
 	SetDataType(dataset string, storageName string, varName string, varType string) error

--- a/api/routes/config.go
+++ b/api/routes/config.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
-	"github.com/unchartedsoftware/plog"
+	log "github.com/unchartedsoftware/plog"
 
 	"github.com/uncharted-distil/distil/api/compute"
 	"github.com/uncharted-distil/distil/api/env"
@@ -31,8 +31,6 @@ func ConfigHandler(config env.Config, version string, timestamp string, problemP
 
 		target := "unknown"
 		dataset := "unknown"
-		taskType := "unknown"
-		taskSubType := "unknown"
 		var metrics []string
 
 		if config.IsTask1 {
@@ -70,25 +68,18 @@ func ConfigHandler(config env.Config, version string, timestamp string, problemP
 						}
 					}
 				}
-				// get task types
-				if problem.About != nil {
-					taskType = problem.About.TaskType
-					taskSubType = problem.About.TaskSubType
-				}
 			}
 		}
 
 		// marshal version
 		err := handleJSON(w, map[string]interface{}{
-			"version":     version,
-			"timestamp":   timestamp,
-			"isTask1":     config.IsTask1,
-			"isTask2":     config.IsTask2,
-			"dataset":     dataset,
-			"target":      target,
-			"taskType":    taskType,
-			"taskSubType": taskSubType,
-			"metrics":     metrics,
+			"version":   version,
+			"timestamp": timestamp,
+			"isTask1":   config.IsTask1,
+			"isTask2":   config.IsTask2,
+			"dataset":   dataset,
+			"target":    target,
+			"metrics":   metrics,
 		})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal version into JSON and write response"))

--- a/api/routes/task.go
+++ b/api/routes/task.go
@@ -1,0 +1,70 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"net/http"
+
+	"goji.io/pat"
+
+	"github.com/pkg/errors"
+	"github.com/uncharted-distil/distil-compute/model"
+	apiCompute "github.com/uncharted-distil/distil/api/compute"
+	api "github.com/uncharted-distil/distil/api/model"
+)
+
+// TaskHandler determines modeling task based on dataset and target variable.
+func TaskHandler(dataCtor api.DataStorageCtor, esMetaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		dataset := pat.Param(r, "dataset")
+		variableName := pat.Param(r, "variable")
+		storageName := model.NormalizeDatasetID(dataset)
+
+		// initialize the storage
+		metaStorage, err := esMetaCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		dataStorage, err := dataCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// look up the target variable
+		variable, err := metaStorage.FetchVariable(storageName, variableName)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// resolve the task based on the dataset and target
+		task, err := apiCompute.ResolveTask(dataStorage, storageName, variable)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// marshal data
+		err = handleJSON(w, task)
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal dataset result into JSON"))
+			return
+		}
+	}
+}

--- a/api/routes/task.go
+++ b/api/routes/task.go
@@ -30,7 +30,7 @@ import (
 func TaskHandler(dataCtor api.DataStorageCtor, esMetaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		dataset := pat.Param(r, "dataset")
-		variableName := pat.Param(r, "variable")
+		variableName := pat.Param(r, "target")
 		storageName := model.NormalizeDatasetID(dataset)
 
 		// initialize the storage
@@ -47,7 +47,7 @@ func TaskHandler(dataCtor api.DataStorageCtor, esMetaCtor api.MetadataStorageCto
 		}
 
 		// look up the target variable
-		variable, err := metaStorage.FetchVariable(storageName, variableName)
+		variable, err := metaStorage.FetchVariable(dataset, variableName)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/main.go
+++ b/main.go
@@ -301,6 +301,7 @@ func main() {
 	registerRoute(mux, "/distil/residuals-extrema/:dataset/:target", routes.ResidualsExtremaHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoute(mux, "/distil/export/:solution-id", routes.ExportHandler(solutionClient, config.D3MOutputDir))
 	registerRoute(mux, "/distil/config", routes.ConfigHandler(config, version, timestamp, problemPath, datasetDocPath))
+	registerRoute(mux, "/distil/task/:dataset/:target", routes.TaskHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor))
 
 	// POST

--- a/public/components/AvailableTargetVariables.vue
+++ b/public/components/AvailableTargetVariables.vue
@@ -92,14 +92,16 @@ export default Vue.extend({
 						}
 					}
 
-					const entry = createRouteEntry(SELECT_TRAINING_ROUTE, {
+					const routeArgs = {
 						target: group.colName,
 						dataset: routeGetters.getRouteDataset(this.$store),
 						filters: routeGetters.getRouteFilters(this.$store),
 						timeseriesAnalysis: routeGetters.getRouteTimeseriesAnalysis(this.$store),
 						training: training.join(',')
-					});
+					};
+					const entry = createRouteEntry(SELECT_TRAINING_ROUTE, routeArgs);
 					this.$router.push(entry);
+					datasetActions.fetchTask(this.$store, {dataset: routeArgs.dataset, targetName: routeArgs.target});
 				});
 				container.appendChild(targetElem);
 				return container;

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -83,10 +83,9 @@ import { getters as routeGetters } from '../store/route/module';
 import { RESULTS_ROUTE } from '../store/route/index';
 import { actions as solutionActions } from '../store/solutions/module';
 import { Solution, NUM_SOLUTIONS } from '../store/solutions/index';
-import { Variable } from '../store/dataset/index';
+import { Variable, TaskTypes, TaskSubTypes } from '../store/dataset/index';
 import { TIMESERIES_TYPE } from '../util/types';
 import { FilterParams } from '../util/filters';
-import { TIMESERIES_FORECASTING_TASK } from '../util/solutions';
 import Vue from 'vue';
 
 export default Vue.extend({
@@ -128,22 +127,6 @@ export default Vue.extend({
 		metrics(): string[] {
 			if (this.isTask2) {
 				return appGetters.getProblemMetrics(this.$store);
-			}
-			return null;
-		},
-		taskType(): string {
-			if (this.isTask2) {
-				return appGetters.getProblemTaskType(this.$store);
-			} else if (!!routeGetters.getRouteTimeseriesAnalysis(this.$store)) {
-				return TIMESERIES_FORECASTING_TASK.schemaName;
-			} else if (this.targetVariable.colType === TIMESERIES_TYPE) {
-				return TIMESERIES_FORECASTING_TASK.schemaName;
-			}
-			return null;
-		},
-		taskSubType(): string {
-			if (this.isTask2) {
-				return appGetters.getProblemTaskSubType(this.$store);
 			}
 			return null;
 		},
@@ -199,8 +182,6 @@ export default Vue.extend({
 				dataset: this.dataset,
 				filters: this.filterParams,
 				target: routeGetters.getRouteTargetVariable(this.$store),
-				task: this.taskType,
-				subTask: this.taskSubType,
 				timestampField: routeGetters.getRouteTimeseriesAnalysis(this.$store),
 				metrics: this.metrics,
 				maxSolutions: NUM_SOLUTIONS,

--- a/public/components/ResultFacets.vue
+++ b/public/components/ResultFacets.vue
@@ -43,6 +43,7 @@ import { REQUEST_COMPLETED, REQUEST_ERRORED } from '../store/solutions/index';
 import { getters as resultsGetters } from '../store/results/module';
 import { getters as routeGetters } from '../store/route/module';
 import { getters as solutionGetters, actions as solutionActions } from '../store/solutions/module';
+import { getters as datasetGetters } from '../store/dataset/module';
 import { getRequestIndex } from '../util/solutions';
 
 interface SummaryGroup {
@@ -85,7 +86,7 @@ export default Vue.extend({
 		},
 
 		residualSummaries(): VariableSummary[] {
-			return this.regression || solutionGetters.isForecasting ? resultsGetters.getResidualsSummaries(this.$store) : [];
+			return this.regression || datasetGetters.getTask(this.$store) ? resultsGetters.getResidualsSummaries(this.$store) : [];
 		},
 
 		correctnessSummaries(): VariableSummary[] {

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -51,7 +51,7 @@ import { getters as routeGetters } from '../store/route/module';
 import { getters as solutionGetters } from '../store/solutions/module';
 import { actions as appActions, getters as appGetters } from '../store/app/module';
 import { EXPORT_SUCCESS_ROUTE, ROOT_ROUTE } from '../store/route/index';
-import { Variable } from '../store/dataset/index';
+import { Variable, TaskTypes } from '../store/dataset/index';
 import vueSlider from 'vue-slider-component';
 import Vue from 'vue';
 import { Solution } from '../store/solutions/index';
@@ -89,7 +89,7 @@ export default Vue.extend({
 		},
 
 		regressionEnabled(): boolean {
-			return solutionGetters.isRegression(this.$store);
+			return datasetGetters.getTask(this.$store).task === TaskTypes.REGRESSION;
 		},
 
 		solutionId(): string {

--- a/public/components/ResultsComparison.vue
+++ b/public/components/ResultsComparison.vue
@@ -42,7 +42,7 @@ import { getters as resultsGetters } from '../store/results/module';
 import { getters as routeGetters } from '../store/route/module';
 import { getters as solutionGetters } from '../store/solutions/module';
 import { Solution } from '../store/solutions/index';
-import { Variable, TableRow, TableColumn } from '../store/dataset/index';
+import { Variable, TableRow, TableColumn, TaskTypes } from '../store/dataset/index';
 
 const TABLE_VIEW = 'table';
 const TIMESERIES_VIEW = 'timeseries';
@@ -161,7 +161,7 @@ export default Vue.extend({
 		},
 
 		regressionEnabled(): boolean {
-			return solutionGetters.isRegression(this.$store);
+			return datasetGetters.getTask(this.$store).task === TaskTypes.REGRESSION;
 		},
 
 		numRows(): number {
@@ -170,7 +170,7 @@ export default Vue.extend({
 
 
 		isForecasting(): boolean {
-			return solutionGetters.isForecasting(this.$store);
+			return datasetGetters.getTask(this.$store).task === TaskTypes.TIME_SERIES_FORECASTING;
 		},
 
 		topSlotTitle(): string {

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -67,7 +67,7 @@ import IconFork from './icons/IconFork';
 import FixedHeaderTable from './FixedHeaderTable';
 import SparklinePreview from './SparklinePreview';
 import ImagePreview from './ImagePreview';
-import { Extrema, TableRow, TableColumn, D3M_INDEX_FIELD, Grouping, Variable, RowSelection } from '../store/dataset/index';
+import { Extrema, TableRow, TableColumn, D3M_INDEX_FIELD, Grouping, Variable, RowSelection, TaskTypes } from '../store/dataset/index';
 import { getters as datasetGetters } from '../store/dataset/module';
 import { getters as resultsGetters } from '../store/results/module';
 import { getters as routeGetters } from '../store/route/module';
@@ -201,7 +201,7 @@ export default Vue.extend({
 		},
 
 		isRegression(): boolean {
-			return solutionGetters.isRegression(this.$store);
+			return datasetGetters.getTask(this.$store).task === TaskTypes.REGRESSION;
 		},
 
 		sortingByResidualError(): boolean {

--- a/public/components/SparklineTimeseriesView.vue
+++ b/public/components/SparklineTimeseriesView.vue
@@ -68,7 +68,7 @@ import SparklineRow from './SparklineRow';
 import SparklineVariable from './SparklineVariable';
 import { Dictionary } from '../util/dict';
 import { Filter } from '../util/filters';
-import { TableRow, TableColumn, TimeseriesExtrema, Variable, Histogram, Bucket, VariableSummary, Grouping, RowSelection, Highlight } from '../store/dataset/index';
+import { TableRow, TableColumn, TimeseriesExtrema, Variable, Histogram, Bucket, VariableSummary, Grouping, RowSelection, Highlight, TaskTypes } from '../store/dataset/index';
 import { getters as routeGetters } from '../store/route/module';
 import { getters as datasetGetters } from '../store/dataset/module';
 import { getters as resultsGetters } from '../store/results/module';
@@ -147,7 +147,7 @@ export default Vue.extend({
 		},
 
 		isForecasting(): boolean {
-			return solutionGetters.isForecasting(this.$store);
+			return datasetGetters.getTask(this.$store).task === TaskTypes.TIME_SERIES_FORECASTING;
 		},
 
 		showPredicted(): boolean {

--- a/public/store/app/actions.ts
+++ b/public/store/app/actions.ts
@@ -56,8 +56,6 @@ export const actions = {
 				mutations.setIsTask2(context, response.data.isTask2);
 				mutations.setProblemDataset(context, response.data.dataset);
 				mutations.setProblemTarget(context, response.data.target);
-				mutations.setProblemTaskType(context, response.data.taskType);
-				mutations.setProblemTaskSubType(context, response.data.taskSubType);
 				mutations.setProblemMetrics(context, response.data.metrics);
 			})
 			.catch((err: string) => {

--- a/public/store/app/getters.ts
+++ b/public/store/app/getters.ts
@@ -26,14 +26,6 @@ export const getters = {
 		return state.isTask2;
 	},
 
-	getProblemTaskType(state: AppState): string {
-		return state.problemTaskType;
-	},
-
-	getProblemTaskSubType(state: AppState): string {
-		return state.problemTaskSubType;
-	},
-
 	getProblemMetrics(state: AppState): string[] {
 		return state.problemMetrics;
 	},

--- a/public/store/app/index.ts
+++ b/public/store/app/index.ts
@@ -7,8 +7,6 @@ export interface AppState {
 	isTask2: boolean;
 	problemDataset: string;
 	problemTarget: string;
-	problemTaskType: string;
-	problemTaskSubType: string;
 	problemMetrics: string[];
 	statusPanelState: StatusPanelState;
 }
@@ -26,8 +24,6 @@ export const state: AppState = {
 	isTask2: false,
 	problemDataset: 'unknown',
 	problemTarget: 'unknown',
-	problemTaskType: 'unknown',
-	problemTaskSubType: 'unknown',
 	problemMetrics: [],
 	statusPanelState: {
 		contentType: undefined,

--- a/public/store/app/module.ts
+++ b/public/store/app/module.ts
@@ -23,8 +23,6 @@ export const getters = {
 	isTask2: read(moduleGetters.isTask2),
 	getProblemDataset: read(moduleGetters.getProblemDataset),
 	getProblemTarget: read(moduleGetters.getProblemTarget),
-	getProblemTaskType: read(moduleGetters.getProblemTaskType),
-	getProblemTaskSubType: read(moduleGetters.getProblemTaskSubType),
 	getProblemMetrics: read(moduleGetters.getProblemMetrics),
 	getStatusPanelState: read(moduleGetters.getStatusPanelState)
 };
@@ -46,8 +44,6 @@ export const mutations = {
 	setIsTask2: commit(moduleMutations.setIsTask2),
 	setProblemDataset: commit(moduleMutations.setProblemDataset),
 	setProblemTarget: commit(moduleMutations.setProblemTarget),
-	setProblemTaskType: commit(moduleMutations.setProblemTaskType),
-	setProblemTaskSubType: commit(moduleMutations.setProblemTaskSubType),
 	setProblemMetrics: commit(moduleMutations.setProblemMetrics),
 	setStatusPanelContentType: commit(moduleMutations.setStatusPanelContentType),
 	openStatusPanel: commit(moduleMutations.openStatusPanel),

--- a/public/store/app/mutations.ts
+++ b/public/store/app/mutations.ts
@@ -27,14 +27,6 @@ export const mutations = {
 		state.problemTarget = target;
 	},
 
-	setProblemTaskType(state: AppState, task: string) {
-		state.problemTaskType = task;
-	},
-
-	setProblemTaskSubType(state: AppState, subtask: string) {
-		state.problemTaskSubType = subtask;
-	},
-
 	setProblemMetrics(state: AppState, metrics: string[]) {
 		state.problemMetrics = metrics;
 	},

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -14,6 +14,7 @@ import {
 	GeocodingPendingRequest,
 	JoinSuggestionPendingRequest,
 	JoinDatasetImportPendingRequest,
+	Task,
 } from './index';
 import { mutations } from './module';
 import { DistilState } from '../store';
@@ -923,6 +924,19 @@ export const actions = {
 			.catch(error => {
 				console.error(error);
 				mutator(context, createEmptyTableData());
+			});
+	},
+
+	fetchTask(context: DatasetContext, args: {dataset: string, targetName: string}) {
+		return axios.get<Task>(`/distil/task/${args.dataset}/${args.targetName}`)
+			.then(response => {
+				if (!response.data) {
+					return;
+				}
+				mutations.updateTask(context, response.data);
+			})
+			.catch(error => {
+				console.error(error);
 			});
 	}
 

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -1,6 +1,7 @@
-import { Variable, Extrema, TimeseriesExtrema, DatasetState, Dataset, VariableSummary, TimeseriesSummary, TableData, TableRow, TableColumn } from './index';
+import { Variable, Extrema, TimeseriesExtrema, DatasetState, Dataset, VariableSummary, TimeseriesSummary, TableData, TableRow, TableColumn, Task } from './index';
 import { Dictionary } from '../../util/dict';
 import { getTableDataItems, getTableDataFields } from '../../util/data';
+import { getTask } from '../../util/solutions';
 
 export const getters = {
 
@@ -141,7 +142,12 @@ export const getters = {
 	getExcludedTableDataFields(state: DatasetState, getters: any): Dictionary<TableColumn> {
 		return getTableDataFields(state.excludedSet.tableData);
 	},
+
 	getGeocoordinateTypes(state: DatasetState): string[] {
 		return state.isGeocoordinateFacet;
+	},
+
+	getTask(state: DatasetState): Task {
+		return state.task;
 	}
 };

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -1,7 +1,6 @@
 import { Variable, Extrema, TimeseriesExtrema, DatasetState, Dataset, VariableSummary, TimeseriesSummary, TableData, TableRow, TableColumn, Task } from './index';
 import { Dictionary } from '../../util/dict';
 import { getTableDataItems, getTableDataFields } from '../../util/data';
-import { getTask } from '../../util/solutions';
 
 export const getters = {
 

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -172,6 +172,11 @@ export interface TimeseriesExtrema {
 	sum?: number;
 }
 
+export interface Task {
+	task: string;
+	subTask: string;
+}
+
 export enum DatasetPendingRequestType {
 	VARIABLE_RANKING = 'VARIABLE_RANKING',
 	GEOCODING = 'GEOCODING',
@@ -238,6 +243,7 @@ export interface DatasetState {
 	excludedSet: WorkingSet;
 	pendingRequests: DatasetPendingRequest[];
 	isGeocoordinateFacet: string[];
+	task: Task;
 }
 
 export interface WorkingSet {
@@ -275,5 +281,11 @@ export const state: DatasetState = {
 	// pending requests for the active dataset
 	pendingRequests: [],
 
-	isGeocoordinateFacet: []
+	isGeocoordinateFacet: [],
+
+	// task information
+	task: {
+		task: '',
+		subTask: ''
+	},
 };

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -172,9 +172,39 @@ export interface TimeseriesExtrema {
 	sum?: number;
 }
 
+
+// task string definitions - should mirror those defined in the MIT/LL d3m problem schema
+export enum TaskTypes {
+	CLASSIFICATION = 'classification',
+	REGRESSION = 'regression',
+	CLUSTERING = 'clustering',
+	LINK_PREDICTION = 'linkPrediction',
+	VERTEX_NOMINATION = 'vertexNomination',
+	VERTEX_CLASSIFICATION = 'vertexClassification',
+	COMMUNITY_DETECTION = 'communityDetection',
+	GRAPH_MATCHING = 'graphMatching',
+	TIME_SERIES_FORECASTING = 'timeSeriesForecasting',
+	COLLABORATIVE_FILTERING = 'collaborativeFiltering',
+	OBJECT_DETECTION = 'objectDetection',
+	SEMISUPERVISED_CLASSIFICATION = 'semiSupervisedClassification',
+	SEMISUPERVISED_REGRESSION = 'semiSupervisedRegression'
+}
+
+// sub-task string definitions - should mirror those defined in the MIT/LL d3m problem schema
+export enum TaskSubTypes {
+	NONE = 'none',
+	BINARY = 'binary',
+	MULTICLASS = 'multiclass',
+	MULTILABEL = 'multilabel',
+	UNIVARIATE = 'univariate',
+	MULTIVARIATE = 'multivariate',
+	OVERLAPPING = 'overlapping',
+	NONOVERLAPPING = 'nonOverlapping'
+}
+
 export interface Task {
-	task: string;
-	subTask: string;
+	task: TaskTypes;
+	subTask: TaskSubTypes;
 }
 
 export enum DatasetPendingRequestType {
@@ -285,7 +315,7 @@ export const state: DatasetState = {
 
 	// task information
 	task: {
-		task: '',
-		subTask: ''
+		task: TaskTypes.CLASSIFICATION,
+		subTask: TaskSubTypes.NONE
 	},
 };

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -52,7 +52,9 @@ export const getters = {
 	getExcludedTableData: read(moduleGetters.getExcludedTableData),
 	getExcludedTableDataNumRows: read(moduleGetters.getExcludedTableDataNumRows),
 	getExcludedTableDataItems: read(moduleGetters.getExcludedTableDataItems),
-	getExcludedTableDataFields: read(moduleGetters.getExcludedTableDataFields)
+	getExcludedTableDataFields: read(moduleGetters.getExcludedTableDataFields),
+	// task info
+	getTask: read(moduleGetters.getTask),
 };
 
 // Typed actions
@@ -98,6 +100,8 @@ export const actions = {
 	// included / excluded table data
 	fetchIncludedTableData: dispatch(moduleActions.fetchIncludedTableData),
 	fetchExcludedTableData: dispatch(moduleActions.fetchExcludedTableData),
+	// task info
+	fetchTask: dispatch(moduleActions.fetchTask),
 };
 
 // Typed mutations
@@ -126,4 +130,6 @@ export const mutations = {
 	clearJoinDatasetsTableData: commit(moduleMutations.clearJoinDatasetsTableData),
 	setIncludedTableData: commit(moduleMutations.setIncludedTableData),
 	setExcludedTableData: commit(moduleMutations.setExcludedTableData),
+	// task
+	updateTask: commit(moduleMutations.updateTask),
 };

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Vue from 'vue';
 import { Dictionary } from '../../util/dict';
-import { DatasetState, Variable, Dataset, VariableSummary, TimeseriesSummary, TableData, DatasetPendingRequest, VariableRankingPendingRequest, GeocodingPendingRequest } from './index';
+import { DatasetState, Variable, Dataset, VariableSummary, TimeseriesSummary, TableData, DatasetPendingRequest, VariableRankingPendingRequest, GeocodingPendingRequest, Task } from './index';
 import { updateSummaries, isDatamartProvenance } from '../../util/data';
 import { GEOCOORDINATE_TYPE, LONGITUDE_TYPE, LATITUDE_TYPE } from '../../util/types';
 
@@ -250,6 +250,9 @@ export const mutations = {
 	// sets the current excluded data into the store
 	setExcludedTableData(state: DatasetState, tableData: TableData) {
 		state.excludedSet.tableData = tableData;
-	}
+	},
 
+	updateTask(state: DatasetState, task: Task) {
+		state.task = task;
+	}
 };

--- a/public/store/solutions/actions.ts
+++ b/public/store/solutions/actions.ts
@@ -8,6 +8,8 @@ import { mutations } from './module';
 import { getWebSocketConnection } from '../../util/ws';
 import { FilterParams } from '../../util/filters';
 import { actions as resultsActions } from '../results/module';
+import { getters as datasetGetters } from '../dataset/module';
+import { TaskTypes } from '../dataset';
 
 const CREATE_SOLUTIONS = 'CREATE_SOLUTIONS';
 const STOP_SOLUTIONS = 'STOP_SOLUTIONS';
@@ -15,8 +17,6 @@ const STOP_SOLUTIONS = 'STOP_SOLUTIONS';
 interface CreateSolutionRequest {
 	dataset: string;
 	target: string;
-	task?: string;
-	subTask?: string;
 	timestampField?: string;
 	metrics: string[];
 	maxSolutions: number;
@@ -36,9 +36,9 @@ interface SolutionStatus {
 export type SolutionContext = ActionContext<SolutionState, DistilState>;
 
 function updateCurrentSolutionResults(context: SolutionContext, req: CreateSolutionRequest, res: SolutionStatus) {
-	const isRegression = context.getters.isRegression;
-	const isClassification = context.getters.isClassification;
-	const isForecasting = context.getters.isForecasting;
+	const isRegression = datasetGetters.getTask(store).task === TaskTypes.REGRESSION;
+	const isClassification = datasetGetters.getTask(store).task === TaskTypes.CLASSIFICATION;
+	const isForecasting = datasetGetters.getTask(store).task === TaskTypes.TIME_SERIES_FORECASTING;
 
 	resultsActions.fetchResultTableData(store, {
 		dataset: req.dataset,
@@ -87,9 +87,9 @@ function updateCurrentSolutionResults(context: SolutionContext, req: CreateSolut
 }
 
 function updateSolutionResults(context: SolutionContext, req: CreateSolutionRequest, res: SolutionStatus) {
-	const isRegression = context.getters.isRegression;
-	const isClassification = context.getters.isClassification;
-	const isForecasting = context.getters.isForecasting;
+	const isRegression = datasetGetters.getTask(store).task === TaskTypes.REGRESSION;
+	const isClassification = datasetGetters.getTask(store).task === TaskTypes.CLASSIFICATION;
+	const isForecasting = datasetGetters.getTask(store).task === TaskTypes.TIME_SERIES_FORECASTING;
 
 	// if current solutionId, pull result summaries
 	resultsActions.fetchPredictedSummary(store, {
@@ -184,7 +184,6 @@ function handleProgress(context: SolutionContext, request: CreateSolutionRequest
 }
 
 export const actions = {
-
 	fetchSolutionRequests(context: SolutionContext, args: { dataset?: string, target?: string, solutionId?: string }) {
 		if (!args.dataset) {
 			args.dataset = null;
@@ -268,9 +267,7 @@ export const actions = {
 				type: CREATE_SOLUTIONS,
 				dataset: request.dataset,
 				target: request.target,
-				task: request.task,
 				timestampField: request.timestampField,
-				subTask: request.subTask,
 				metrics: request.metrics,
 				maxSolutions: request.maxSolutions,
 				maxTime: request.maxTime,

--- a/public/store/solutions/getters.ts
+++ b/public/store/solutions/getters.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import moment from 'moment';
 import { Variable } from '../dataset/index';
-import { REGRESSION_TASK, CLASSIFICATION_TASK, TIMESERIES_FORECASTING_TASK, getTask } from '../../util/solutions';
 import { SolutionState, Solution, SolutionRequest, SOLUTION_RUNNING, SOLUTION_ERRORED, SOLUTION_COMPLETED } from './index';
 import { Dictionary } from '../../util/dict';
 import { Stream } from '../../util/ws';
@@ -117,52 +116,6 @@ export const getters = {
 		const target = getters.getRouteTargetVariable;
 		const variables = getters.getVariables;
 		return variables.filter(variable => variable.colName === target);
-	},
-
-	isRegression(state: SolutionState, getters: any): boolean {
-		const variables = getters.getVariables;
-		const target = getters.getRouteTargetVariable;
-		const targetVariable = variables.find(s => _.toLower(s.colName) === _.toLower(target));
-		if (!targetVariable) {
-			return false;
-		}
-		const task = getTask(targetVariable.colType);
-		if (!task) {
-			console.error('NULL task for regression task type check - defaulting to FALSE.  This should not happen.');
-			return false;
-		}
-		return !getters.isForecasting && task.schemaName === REGRESSION_TASK.schemaName;
-	},
-
-	isClassification(state: SolutionState, getters: any): boolean {
-		const variables = getters.getVariables;
-		const target = getters.getRouteTargetVariable;
-		const targetVariable = variables.find(s => _.toLower(s.colName) === _.toLower(target));
-		if (!targetVariable) {
-			return false;
-		}
-		const task = getTask(targetVariable.colType);
-		if (!task) {
-			console.error('NULL task for classification task type check - defaulting to FALSE.  This should not happen.');
-			return false;
-		}
-		return !getters.isForecasting && task.schemaName === CLASSIFICATION_TASK.schemaName;
-	},
-
-	isForecasting(state: SolutionState, getters: any): boolean {
-
-		const variables = getters.getVariables;
-		const target = getters.getRouteTargetVariable;
-		const targetVariable = variables.find(s => _.toLower(s.colName) === _.toLower(target));
-		if (!targetVariable) {
-			return false;
-		}
-		const task = getTask(targetVariable.colType);
-		if (!task) {
-			console.error('NULL task for forecasting task type check - defaulting to FALSE.  This should not happen.');
-			return false;
-		}
-		return task.schemaName === TIMESERIES_FORECASTING_TASK.schemaName;
 	},
 
 	getRequestStreams(state: SolutionState, getters: any): Dictionary<Stream> {

--- a/public/store/solutions/module.ts
+++ b/public/store/solutions/module.ts
@@ -25,9 +25,6 @@ export const getters = {
 	getActiveSolution: read(moduleGetters.getActiveSolution),
 	getActiveSolutionTrainingVariables: read(moduleGetters.getActiveSolutionTrainingVariables),
 	getActiveSolutionTargetVariable: read(moduleGetters.getActiveSolutionTargetVariable),
-	isRegression: read(moduleGetters.isRegression),
-	isClassification: read(moduleGetters.isClassification),
-	isForecasting: read(moduleGetters.isForecasting),
 	getRequestStreams: read(moduleGetters.getRequestStreams),
 };
 

--- a/public/util/solutions.ts
+++ b/public/util/solutions.ts
@@ -10,11 +10,6 @@ export interface NameInfo {
 	schemaName: string;
 }
 
-export interface Task {
-	displayName: string;
-	schemaName: string;
-}
-
 export function getSolutionIndex(solutionId: string) {
 	const solutions = solutionGetters.getRelevantSolutions(store);
 	const index = _.findIndex(solutions, solution => {
@@ -76,51 +71,3 @@ export function isTopSolutionByScore(state: SolutionState, requestId: string, so
 		return sol.solutionId === solutionId;
 	});
 }
-
-// Gets a task object based on a variable type.
-export function getTask(varType: string): Task {
-	const lowerType = _.toLower(varType);
-	return _.get(TASKS_BY_VARIABLES, lowerType);
-}
-
-// classification task info
-export const CLASSIFICATION_TASK: Task = {
-	displayName: 'Classification',
-	schemaName: 'classification'
-};
-
-// regression task info
-export const REGRESSION_TASK: Task = {
-	displayName: 'Regression',
-	schemaName: 'regression'
-};
-
-export const TIMESERIES_FORECASTING_TASK: Task = {
-	displayName: 'Time Series Forecasting',
-	schemaName: 'timeSeriesForecasting'
-};
-
-// variable type to task mappings
-const TASKS_BY_VARIABLES: Dictionary<Task> = {
-	float:  REGRESSION_TASK,
-	real:  REGRESSION_TASK,
-	latitude:  REGRESSION_TASK,
-	longitude:  REGRESSION_TASK,
-	integer: REGRESSION_TASK,
-	image: CLASSIFICATION_TASK,
-	timeseries: TIMESERIES_FORECASTING_TASK,
-	categorical: CLASSIFICATION_TASK,
-	ordinal: CLASSIFICATION_TASK,
-	address: CLASSIFICATION_TASK,
-	city: CLASSIFICATION_TASK,
-	state: CLASSIFICATION_TASK,
-	country: CLASSIFICATION_TASK,
-	email: CLASSIFICATION_TASK,
-	phone: CLASSIFICATION_TASK,
-	postal_code: CLASSIFICATION_TASK,
-	uri: CLASSIFICATION_TASK,
-	datetime: CLASSIFICATION_TASK,
-	string: CLASSIFICATION_TASK,
-	unknown: CLASSIFICATION_TASK,
-	boolean: CLASSIFICATION_TASK
-};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,
         "target": "es6",
-        "noUnusedLocals": true,
         "noImplicitThis": true,
         "noImplicitAny": false,
         "noUnusedParameters": false,


### PR DESCRIPTION
Fixes #1232.  Requires uncharted-distil/distil-compute#76.

Moves determination of task/subtask type from the client to the server.  The server has access to the underlying datasets and metadata, and can leverage that information to better determine the type of problem being solved.  In the case of semi-supervised problems, as was originally discussed in the bug, the server can now query the dataset to determine how many labels are missing, and will set the task to `semiSupervisedClassification` when a threshold count is surpassed.

A new `task` route has been added to the server that will perform the task resolution based on a given dataset and target.  The client now fetches the task when the target is set and writes that value to the store.  Code related to determining the task client side has been removed, and the client no longer sends the task/substask information up to the server as part of the solution search request (server can resolve on its own).  This is also simplifies the `Task2` case, where the problem spec is predetermined, as client will fetch the task when started in Task2 mode.