### PR TITLE
Cut return feature when image selected #1216

### DIFF
--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -140,14 +140,6 @@ func GetFilterVariables(filterVariables []string, variables []*model.Variable) [
 		}
 
 		filtered = append(filtered, v)
-		// check for feature var type
-		if model.HasFeatureVar(v.Type) {
-			featureVarName := fmt.Sprintf("%s%s", model.FeatureVarPrefix, variable)
-			featureVar, ok := variableLookup[featureVarName]
-			if ok {
-				filtered = append(filtered, featureVar)
-			}
-		}
 		// check for cluster var type
 		if model.HasClusterVar(v.Type) {
 			clusterVarName := fmt.Sprintf("%s%s", model.ClusterVarPrefix, variable)


### PR DESCRIPTION
Cut some code that for some reason always returned label with image code (Kevin made the added code cut here as part of time series stuff in March, he would know best as to why we did this even though it has no impact on modelling.) Removing that code fixes the regression in the bug report.