### PR TITLE
Remove pipeline-runner container dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ The application requires:
 - ElasticSearch
 - PostgreSQL
 - TA2 Pipeline Server Stub
-- TA2 Pipeline Runner
-- D3M Resource Server
 
 Docker images for each are available at the following registry:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,17 +42,3 @@ postgres:
 #    - $D3MSTATICDIR:$D3MSTATICDIR
 #   ports:
 #     - "45042:45042"
-
-runner:
-  image:
-    docker.uncharted.software/distil-pipeline-runner:latest
-  ports:
-    - "50051:50051"
-  environment:
-    - D3MOUTPUTDIR=$D3MOUTPUTDIR
-    - D3MSTATICDIR=$D3MSTATICDIR
-    - DATAMART_URL_NYU=https://auctus.vida-nyu.org
-  volumes:
-    - $D3MINPUTDIR:$D3MINPUTDIR
-    - $D3MOUTPUTDIR:$D3MOUTPUTDIR
-    - $D3MSTATICDIR:$D3MSTATICDIR

--- a/run.sh
+++ b/run.sh
@@ -16,7 +16,6 @@ export SKIP_INGEST=true
 export SOLUTION_SEARCH_MAX_TIME=3
 export SOLUTION_COMPUTE_PULL_MAX=900
 export SOLUTION_COMPUTE_TIMEOUT=600
-export USE_TA2_RUNNER=true #false
 export DATAMART_URL_NYU=https://auctus.vida-nyu.org
 
 witch --cmd="make compile && make fmt && go run main.go" --watch="main.go,api/**/*.go" --ignore=""


### PR DESCRIPTION
Fixes #1240.  Updates config to use the TA2 for fully specified pipelines rather than the pipeline-runner, and updates the compose file to with the TA2 only.  Switch and code to use the pipeline-runner will be left in as a back up until we're certain other TA2 systems we pair with are compliant.