### PR TITLE
Add image view in results section #1233

### DIFF
--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -1,6 +1,6 @@
 <template>
 
-	<div class="select-image-mosaic">
+	<div class="image-mosaic">
 		<template v-for="imageField in imageFields">
 			<template v-for="item in items">
 				<div class="image-tile">
@@ -37,7 +37,7 @@ import { addRowSelection, removeRowSelection, isRowSelected, updateTableRowSelec
 import { IMAGE_TYPE } from '../util/types';
 
 export default Vue.extend({
-	name: 'select-image-mosaic',
+	name: 'image-mosaic',
 
 	components: {
 		ImagePreview
@@ -104,7 +104,7 @@ export default Vue.extend({
 
 <style>
 
-.select-image-mosaic {
+.image-mosaic {
 	display: flex;
 	overflow: auto;
 	flex-flow: wrap;

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -16,7 +16,7 @@
 				<results-data-table v-if="viewType===TABLE_VIEW" :data-fields="dataFields" :data-items="dataItems" :instance-name="instanceName"></results-data-table>
 				<results-timeseries-view v-if="viewType===TIMESERIES_VIEW" :fields="dataFields" :items="dataItems" :instance-name="instanceName"></results-timeseries-view>
 				<results-geo-plot v-if="viewType===GEO_VIEW" :data-fields="dataFields" :data-items="dataItems"  :instance-name="instanceName"></results-geo-plot>
-				<select-image-mosaic v-if="viewType===IMAGE_VIEW" :included-active="includedActive" :instance-name="instanceName" :data-fields="dataFields" :data-items="dataItems"></select-image-mosaic>
+				<image-mosaic v-if="viewType===IMAGE_VIEW" :included-active="includedActive" :instance-name="instanceName" :data-fields="dataFields" :data-items="dataItems"></image-mosaic>
 			</template>
 		</div>
 	</div>
@@ -27,7 +27,7 @@
 import Vue from 'vue';
 import _ from 'lodash';
 import ResultsDataTable from './ResultsDataTable';
-import SelectImageMosaic from './SelectImageMosaic';
+import ImageMosaic from './ImageMosaic';
 import ResultsTimeseriesView from './ResultsTimeseriesView';
 import ResultsGeoPlot from './ResultsGeoPlot';
 import { spinnerHTML } from '../util/spinner';
@@ -52,7 +52,7 @@ export default Vue.extend({
 		ResultsDataTable,
 		ResultsTimeseriesView,
 		ResultsGeoPlot,
-		SelectImageMosaic
+		ImageMosaic
 	},
 
 	props: {

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -16,6 +16,7 @@
 				<results-data-table v-if="viewType===TABLE_VIEW" :data-fields="dataFields" :data-items="dataItems" :instance-name="instanceName"></results-data-table>
 				<results-timeseries-view v-if="viewType===TIMESERIES_VIEW" :fields="dataFields" :items="dataItems" :instance-name="instanceName"></results-timeseries-view>
 				<results-geo-plot v-if="viewType===GEO_VIEW" :data-fields="dataFields" :data-items="dataItems"  :instance-name="instanceName"></results-geo-plot>
+				<select-image-mosaic v-if="viewType===IMAGE_VIEW" :included-active="includedActive" :instance-name="instanceName" :data-fields="dataFields" :data-items="dataItems"></select-image-mosaic>
 			</template>
 		</div>
 	</div>
@@ -26,6 +27,7 @@
 import Vue from 'vue';
 import _ from 'lodash';
 import ResultsDataTable from './ResultsDataTable';
+import SelectImageMosaic from './SelectImageMosaic';
 import ResultsTimeseriesView from './ResultsTimeseriesView';
 import ResultsGeoPlot from './ResultsGeoPlot';
 import { spinnerHTML } from '../util/spinner';
@@ -49,7 +51,8 @@ export default Vue.extend({
 	components: {
 		ResultsDataTable,
 		ResultsTimeseriesView,
-		ResultsGeoPlot
+		ResultsGeoPlot,
+		SelectImageMosaic
 	},
 
 	props: {

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -39,7 +39,7 @@
 			</div>
 			<template>
 				<select-data-table v-if="viewType===TABLE_VIEW" :included-active="includedActive" :instance-name="instanceName"></select-data-table>
-				<select-image-mosaic v-if="viewType===IMAGE_VIEW" :included-active="includedActive" :instance-name="instanceName"></select-image-mosaic>
+				<image-mosaic v-if="viewType===IMAGE_VIEW" :included-active="includedActive" :instance-name="instanceName"></image-mosaic>
 				<select-graph-view v-if="viewType===GRAPH_VIEW" :included-active="includedActive" :instance-name="instanceName"></select-graph-view>
 				<select-geo-plot v-if="viewType===GEO_VIEW" :included-active="includedActive" :instance-name="instanceName"></select-geo-plot>
 				<select-timeseries-view v-if="viewType===TIMESERIES_VIEW" :included-active="includedActive" :instance-name="instanceName"></select-timeseries-view>
@@ -54,7 +54,7 @@
 import Vue from 'vue';
 import { spinnerHTML } from '../util/spinner';
 import SelectDataTable from './SelectDataTable';
-import SelectImageMosaic from './SelectImageMosaic';
+import ImageMosaic from './ImageMosaic';
 import SelectTimeseriesView from './SelectTimeseriesView';
 import SelectGeoPlot from './SelectGeoPlot';
 import SelectGraphView from './SelectGraphView';
@@ -80,7 +80,7 @@ export default Vue.extend({
 	components: {
 		FilterBadge,
 		SelectDataTable,
-		SelectImageMosaic,
+		ImageMosaic,
 		SelectGraphView,
 		SelectGeoPlot,
 		SelectTimeseriesView,

--- a/public/components/SelectImageMosaic.vue
+++ b/public/components/SelectImageMosaic.vue
@@ -45,7 +45,9 @@ export default Vue.extend({
 
 	props: {
 		instanceName: String as () => string,
-		includedActive: Boolean as () => boolean
+		includedActive: Boolean as () => boolean,
+		dataItems: Array as () => any[],
+		dataFields: Object as () => Dictionary<TableColumn>,
 	},
 
 	data() {
@@ -58,11 +60,17 @@ export default Vue.extend({
 	computed: {
 
 		items(): TableRow[] {
+			if (this.dataItems) {
+				return this.dataItems;
+			}
 			const items = this.includedActive ? datasetGetters.getIncludedTableDataItems(this.$store) : datasetGetters.getExcludedTableDataItems(this.$store);
 			return updateTableRowSelection(items, this.rowSelection, this.instanceName);
 		},
 
 		fields(): Dictionary<TableColumn> {
+			if (this.dataFields) {
+				return this.dataFields;
+			}
 			return this.includedActive ? datasetGetters.getIncludedTableDataFields(this.$store) : datasetGetters.getExcludedTableDataFields(this.$store);
 		},
 
@@ -120,5 +128,6 @@ export default Vue.extend({
 	background-color: #424242;
 	color: #fff;
 	padding: 0 4px;
+	z-index: 1;
 }
 </style>


### PR DESCRIPTION
With minor modifications to pass down and use information from results data slot in select image mosaic (when said props are set) and by calling select image from results data view, the image mosaic now shows up in the results vue as expected with out breaking the existing use in the create model view. Also, renamed select image mosaic to image mosaic to reflect it's more general use case.