### PR TITLE
Catch Empty Terms/Keys #1232

### DIFF
--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -407,6 +407,9 @@ func (f *CategoricalField) parseHistogram(rows *pgx.Rows) (*api.Histogram, error
 			if err != nil {
 				return nil, errors.Wrap(err, fmt.Sprintf("no %s histogram aggregation found", termsAggName))
 			}
+			if len(term) < 1 {
+				term = "&lt;empty&gt;"
+			}
 
 			buckets = append(buckets, &api.Bucket{
 				Key:   term,


### PR DESCRIPTION
If the bucket has a term/key of length 0 returned from the DB, we substitute in the string `<empty>` so it's not blank in the api return and thus not blank in the front end facets.