### PR TITLE
Add var description

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,11 +91,11 @@
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-compute"
-  branch = "master"
+  branch = "add-var-description"
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-ingest"
-  branch = "master"
+  branch = "add-var-description"
 
 [[constraint]]
   name = "github.com/unchartedsoftware/plog"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,11 +91,11 @@
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-compute"
-  branch = "add-var-description"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-ingest"
-  branch = "add-var-description"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/unchartedsoftware/plog"

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -222,6 +222,7 @@ func (s *Storage) updateVariables(dataset string, variables []*model.Variable) e
 			model.VarSelectedRoleField:     v.SelectedRole,
 			model.VarTypeField:             v.Type,
 			model.VarOriginalTypeField:     v.OriginalType,
+			model.VarDescriptionField:      v.Description,
 			model.VarImportanceField:       v.Importance,
 			model.VarSuggestedTypesField:   v.SuggestedTypes,
 			model.VarOriginalVariableField: v.OriginalVariable,

--- a/api/model/storage/elastic/variable.go
+++ b/api/model/storage/elastic/variable.go
@@ -42,6 +42,10 @@ func (s *Storage) parseRawVariable(child map[string]interface{}) (*model.Variabl
 	if !ok {
 		return nil, errors.New("unable to parse original type from variable data")
 	}
+	description, ok := json.String(child, model.VarDescriptionField)
+	if !ok {
+		description = ""
+	}
 	importance, ok := json.Int(child, model.VarImportanceField)
 	if !ok {
 		importance = 0
@@ -107,6 +111,7 @@ func (s *Storage) parseRawVariable(child map[string]interface{}) (*model.Variabl
 		Index:            index,
 		Type:             typ,
 		OriginalType:     originalType,
+		Description:      description,
 		Importance:       importance,
 		Role:             role,
 		SelectedRole:     selectedRole,

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -120,7 +120,7 @@ func addD3MIndex(schemaFile string, meta *model.Metadata, data [][]string) (*mod
 	// add the d3m index variable to the metadata
 	dr := meta.DataResources[0]
 	name := model.D3MIndexFieldName
-	v := model.NewVariable(len(dr.Variables), name, name, name, model.IntegerType, model.IntegerType, []string{"index"}, model.VarRoleIndex, nil, dr.Variables, false)
+	v := model.NewVariable(len(dr.Variables), name, name, name, model.IntegerType, model.IntegerType, "required index field", []string{"index"}, model.VarRoleIndex, nil, dr.Variables, false)
 	dr.Variables = append(dr.Variables, v)
 
 	// parse the raw output and write the line out

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -89,9 +89,11 @@ func GeocodeForwardDataset(datasetSource metadata.DatasetSource, schemaFile stri
 	fields := make(map[string][]*model.Variable)
 	for _, field := range geocodedData {
 		latName, lonName := getLatLonVariableNames(field[0].SourceField)
+		latDesc := fmt.Sprintf("latitude obtained from field %s", field[0].SourceField)
+		lonDesc := fmt.Sprintf("longitude obtained from field %s", field[0].SourceField)
 		fields[field[0].SourceField] = []*model.Variable{
-			model.NewVariable(len(mainDR.Variables), latName, "label", latName, model.LatitudeType, model.LatitudeType, []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false),
-			model.NewVariable(len(mainDR.Variables)+1, lonName, "label", lonName, model.LongitudeType, model.LongitudeType, []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false),
+			model.NewVariable(len(mainDR.Variables), latName, "label", latName, model.LatitudeType, model.LatitudeType, latDesc, []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false),
+			model.NewVariable(len(mainDR.Variables)+1, lonName, "label", lonName, model.LongitudeType, model.LongitudeType, lonDesc, []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false),
 		}
 		mainDR.Variables = append(mainDR.Variables, fields[field[0].SourceField]...)
 		for _, gc := range field {

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -178,9 +178,10 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	}
 	log.Infof("finished ingesting the dataset")
 
+	// updating extremas is optional
 	err = UpdateExtremas(datasetID, metaStorage, dataStorage)
 	if err != nil {
-		return errors.Wrap(err, "unable to update extremas ranked data")
+		log.Errorf("unable to update extremas ranked data: %v", err)
 	}
 	log.Infof("finished updating extremas")
 

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -85,7 +85,7 @@ func Merge(datasetSource metadata.DatasetSource, schemaFile string, index string
 		v := vars[field]
 		if v == nil {
 			// create new variables (ex: series_id)
-			v = model.NewVariable(i, field, field, field, model.StringType, model.StringType, []string{"attribute"}, model.VarRoleData, nil, outputMeta.DataResources[0].Variables, false)
+			v = model.NewVariable(i, field, field, field, model.StringType, model.StringType, "", []string{"attribute"}, model.VarRoleData, nil, outputMeta.DataResources[0].Variables, false)
 		}
 		v.Index = i
 		outputMeta.DataResources[0].Variables = append(outputMeta.DataResources[0].Variables, v)

--- a/api/task/pipelines.go
+++ b/api/task/pipelines.go
@@ -131,7 +131,7 @@ func getFeatureVariables(meta *model.Metadata, prefix string) ([]*FeatureRequest
 				indexName := fmt.Sprintf("%s%s", prefix, v.Name)
 
 				// add the feature variable
-				v := model.NewVariable(len(mainDR.Variables), indexName, "label", v.Name, model.StringType, model.StringType, []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false)
+				v := model.NewVariable(len(mainDR.Variables), indexName, "label", v.Name, model.StringType, model.StringType, "", []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false)
 
 				// create the required pipeline
 				step, err := description.CreateCrocPipeline("leather", "", []string{denormFieldName}, []string{indexName})
@@ -171,7 +171,7 @@ func getClusterVariables(meta *model.Metadata, prefix string) ([]*FeatureRequest
 
 				// add the feature variable
 				v := model.NewVariable(len(mainDR.Variables), indexName, "group", v.Name, model.CategoricalType,
-					model.CategoricalType, []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false)
+					model.CategoricalType, "", []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false)
 
 				// create the required pipeline
 				var step *pipeline.PipelineDescription


### PR DESCRIPTION
Fixes #1259 

Adds a field for the variable description. This field is stored in ES on ingest and returned to the client when a dataset is pulled from ES.