### PR TITLE
facet header and table truncation with basic tooltips #1261 

### DIFF
--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -333,6 +333,8 @@ export default Vue.extend({
 					}
 				}
 			});
+			// inject type icon in group header
+			this.wrapGroupHeaderText(group, $elem);
 
 			// inject type icon in group header
 			this.injectTypeIcon(group, $elem);
@@ -850,6 +852,15 @@ export default Vue.extend({
 			const $group = this.facets.getGroup(group.key)._element;
 			const isImportant = this.ranking > IMPORTANT_VARIABLE_RANKING_THRESHOLD;
 			$group.toggleClass('important', Boolean(isImportant));
+		},
+
+		// wrap group header text
+		wrapGroupHeaderText(group: Group, $elem: JQuery) {
+			const $headerElement = $elem.find('.group-header');
+			const headerText = $headerElement.text();
+			$headerElement.empty();
+			const $headerTextWrapped = $(`<div class="header-text" v-b-tooltip.hover title=${headerText}>${headerText}</div>`);
+			$headerElement.append($headerTextWrapped);
 		},
 
 		// inject type icon

--- a/public/components/FixedHeaderTable.vue
+++ b/public/components/FixedHeaderTable.vue
@@ -35,6 +35,7 @@ export default Vue.extend({
 			}
 
 			const headTargetCells = [];
+			const maxCellWidth = Math.ceil(this.tbody.clientWidth / theadCells.length);
 
 			// reset element style so that table renders with initial layout set by css
 			for (let i = 0; i < theadCells.length; i++) {
@@ -59,10 +60,24 @@ export default Vue.extend({
 			// get body and header cell width again from computed table header cells
 			const bodyCells = [];
 			const headCells = [];
+			const allRows =  this.tbody && this.tbody.querySelectorAll('tr');
+			const allBodyCellsAsRows = [];
+
+			allRows.forEach(row => {
+				const rowCells = row.querySelectorAll('td');
+				allBodyCellsAsRows.push(rowCells);
+			});
+			let remainingCellWidth = this.tbody.clientWidth;
 			for (let i = 0; i < theadCells.length; i++) {
-				const headCellWidth = theadCells[i].offsetWidth;
+				const cellOffsetWidth = theadCells[i].offsetWidth;
+				const headCellWidth = i + 1 === theadCells.length ?
+					(cellOffsetWidth > remainingCellWidth ? cellOffsetWidth : remainingCellWidth) :
+					(cellOffsetWidth < maxCellWidth ? cellOffsetWidth : maxCellWidth);
+				remainingCellWidth = remainingCellWidth - headCellWidth;
 				headCells.push({ elem: theadCells[i], width: headCellWidth });
-				bodyCells.push({ elem: tbodyCells[i], width: headCellWidth });
+				allBodyCellsAsRows.forEach(row => {
+					bodyCells.push({ elem: row[i], width: headCellWidth });
+				});
 			}
 			// set new cell width
 			headCells.forEach(setCellWidth);
@@ -85,12 +100,12 @@ export default Vue.extend({
 			const target = event.target;
 			if (!target) { return; }
 
-			const isTd = target.tagName === 'TD';
+			const isCell = target.tagName === 'TD' || target.tagName === 'TH';
 			const isLeafNode = target.childElementCount === 0;
 			const text = target.innerText;
 			const title = target.getAttribute('title');
 
-			if (isTd && isLeafNode && text && !title) {
+			if (isCell && isLeafNode && text && !title) {
 				// set title for displaying full text on hover
 				target.setAttribute('title', text);
 			}
@@ -112,6 +127,7 @@ export default Vue.extend({
 
 		this.tbody.addEventListener('scroll', this.onScroll);
 		this.tbody.addEventListener('mouseover', this.onMouseOverTableCell);
+		this.thead.addEventListener('mouseover', this.onMouseOverTableCell);
 
 		window.addEventListener('resize', this.resizeTableCells);
 
@@ -160,6 +176,9 @@ export default Vue.extend({
 	width: 100%;
 }
 .fixed-header-table thead th {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	flex-shrink: 0;
 	flex-grow: 1;
 }
@@ -172,6 +191,5 @@ export default Vue.extend({
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	max-width: 300px
 }
 </style>

--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -311,12 +311,37 @@ button {
 	transition: box-shadow 0.3s ease-in-out;
 }
 .variable-facets-container .facets-root-container .facets-group-container .facets-group .group-header {
-	padding: 4px 8px 6px 8px;
+	margin: 0px !important;
+	padding: 0 0 4px !important;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-content: center;
+    align-items: stretch;
+}
+.variable-facets-container .facets-root-container .facets-group-container .facets-group .group-header .header-text {
+    order: 0;
+    flex: 1 1 auto;
+    align-self: auto;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin: 0 0 0 .5rem;
+	height: 20px;
+	white-space: nowrap;
+}
+.variable-facets-container .facets-root-container .facets-group-container .facets-group .group-header .fa-info {
+	margin: 5px 10px 5px 5px;
+    order: 1;
+    flex: 30 1 auto;
+    align-self: auto;
+	text-align: left;
 }
 .variable-facets-container .facets-root-container .facets-group-container .facets-group .group-header .type-change-menu {
-	float: right;
-	margin-top: -4px;
-	margin-right: -8px;
+    order: 2;
+    flex: none;
+    align-self: auto;
+	text-align: right;
 }
 .facet-filters {
 	margin: 0 -10px 4px -10px;


### PR DESCRIPTION
- added revised CSS to variable facets component to provide truncation of long titles, then modified the facet-entry component to rewrap the facet header text in a div such that the revised css will work and so that the bootstrap vue tooltip directive can be leveraged to show the full header text in a tooltip. 

- modified the CSS and JS in the fixed header table component to resize column widths for content larger than total width * 1/n of the table such that longer content will be truncated rather than auto expanded, and that content will show up in a tooltip both for header and body cells. 