### PR TITLE
uses ID for geocoordinate rather than (incorrect) hardcoded value

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -526,7 +526,7 @@ func (s *Storage) filterIncludesIndex(filterParams *api.FilterParams) bool {
 // categories.
 func (s *Storage) FetchData(dataset string, storageName string, filterParams *api.FilterParams, invert bool) (*api.FilteredData, error) {
 
-	variables, err := s.metadata.FetchVariables(dataset, true, true, false)
+	variables, err := s.metadata.FetchVariables(dataset, true, true, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not pull variables from ES")
 	}

--- a/public/components/GeocoordinateFacet.vue
+++ b/public/components/GeocoordinateFacet.vue
@@ -258,18 +258,18 @@ export default Vue.extend({
 		selectFeature() {
 			const training = routeGetters.getDecodedTrainingVariableNames(this.$store);
 			const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
-				training: training.concat([ 'Longitude' ]).join(',')
+				training: training.concat([ this.summary.key ]).join(',')
 			});
 			this.$router.push(entry);
 		},
 		removeFeature() {
 			const training = routeGetters.getDecodedTrainingVariableNames(this.$store);
-			training.splice(training.indexOf('Longitude'), 1);
+			training.splice(training.indexOf(this.summary.key), 1);
 			const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
 				training: training.join(',')
 			});
 			this.$router.push(entry);
-			removeFiltersByName(this.$router, 'Longitude');
+			removeFiltersByName(this.$router, this.summary.key);
 		},
 		clearSelectionRect() {
 			if (this.selectedRect) {


### PR DESCRIPTION
Small fix to ensure that the correct ID for the geocoordinate is used rather than a hardcoded value.  Also reverses a temporary fix to block hidden variables that was a placeholder until the root cause (now addressed) was found.