### PR TITLE
adds function to replace NaN values in data prior to JSON encoding

### DIFF
--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -17,6 +17,7 @@ package model
 
 import (
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -322,4 +323,43 @@ func ParseFilterParamsFromJSON(params map[string]interface{}) (*FilterParams, er
 	})
 
 	return filterParams, nil
+}
+
+// NaNReplacement defines the type of replacement value to use for NaNs
+type NaNReplacement int
+
+const (
+	// Null replaces NaN values with Nil, which will result in 'null' being encoded into the JSON structure
+	Null NaNReplacement = iota + 1
+	// EmptyString replaces NaN values with an empty string, which will result in "" being encoded into the JSON structure
+	EmptyString
+)
+
+// ReplaceNaNs replaces NaN values found in numerical columns with empty values.  This allows
+// for downstream JSON encoding, as the Go JSON encoder doesn't properly handle NaN values.
+func ReplaceNaNs(data *FilteredData, replacementType NaNReplacement) *FilteredData {
+	// go does not marshal NaN values properly so make them empty
+	numericColumns := make([]int, 0)
+	for i, c := range data.Columns {
+		if model.IsNumerical(c.Type) {
+			numericColumns = append(numericColumns, i)
+		}
+	}
+
+	if len(numericColumns) > 0 {
+		for _, r := range data.Values {
+			for _, nc := range numericColumns {
+				f, ok := r[nc].(float64)
+				if ok && math.IsNaN(f) {
+					if replacementType == Null {
+						r[nc] = nil
+					} else if replacementType == EmptyString {
+						r[nc] = ""
+					}
+				}
+			}
+		}
+	}
+
+	return data
 }

--- a/api/routes/data.go
+++ b/api/routes/data.go
@@ -64,6 +64,8 @@ func DataHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataStorageCt
 			return
 		}
 
+		// replace NaNs with an empty string to make them JSON encodable
+		data = api.ReplaceNaNs(data, api.EmptyString)
 		// marshal output into JSON
 		bytes, err := json.Marshal(data)
 		if err != nil {

--- a/api/routes/results.go
+++ b/api/routes/results.go
@@ -16,7 +16,6 @@
 package routes
 
 import (
-	"math"
 	"net/http"
 	"net/url"
 
@@ -107,25 +106,8 @@ func ResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.DataStora
 			return
 		}
 
-		// go does not marshal NaN values properly so make them empty
-		numericColumns := make([]int, 0)
-		for i, c := range results.Columns {
-			if model.IsNumerical(c.Type) {
-				numericColumns = append(numericColumns, i)
-			}
-		}
-
-		if len(numericColumns) > 0 {
-			for _, r := range results.Values {
-				for _, nc := range numericColumns {
-					f, ok := r[nc].(float64)
-					if ok && math.IsNaN(f) {
-						r[nc] = ""
-					}
-				}
-			}
-		}
-
+		// replace any NaN values with an empty string
+		results = api.ReplaceNaNs(results, api.EmptyString)
 		// marshal data and sent the response back
 		err = handleJSON(w, results)
 		if err != nil {


### PR DESCRIPTION
fixes #1271 - Added a new function to replace NaN values with an empty string or a null value.  Empty strings result in a `""` being stored in the JSON, null results in a `null` value being stored in the outgoing JSON.  Currently uses the empty string since what the client expects.