### PR TITLE
#1261 Minimum Table Column Width

### DIFF
--- a/public/components/FixedHeaderTable.vue
+++ b/public/components/FixedHeaderTable.vue
@@ -35,7 +35,9 @@ export default Vue.extend({
 			}
 
 			const headTargetCells = [];
-			const maxCellWidth = Math.ceil(this.tbody.clientWidth / theadCells.length);
+			const minCellWidth = 100;
+			const evenCellWidth = Math.ceil(this.tbody.clientWidth / theadCells.length);
+			const maxCellWidth = minCellWidth > evenCellWidth ? minCellWidth : evenCellWidth;
 
 			// reset element style so that table renders with initial layout set by css
 			for (let i = 0; i < theadCells.length; i++) {


### PR DESCRIPTION
Added a fallback to 100px on column width so we don't have over compacted tables. If dividing the table up evenly has wider columns, it'll prefer that, otherwise, it has a backstop at 100px.