### PR TITLE
Modify sparkline chart modal dimensions #1234

### DIFF
--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -16,10 +16,10 @@ export default Vue.extend({
 		margin: {
 			type: Object as () => any,
 			default: () => ({
-				top: 40,
-				right: 0,
+				top: 24,
+				right: 48,
 				bottom: 16,
-				left: 32
+				left: 48
 			})
 		},
 		timeseries: {
@@ -50,7 +50,7 @@ export default Vue.extend({
 		height(): number {
 			const $svg = this.$refs.svg as any;
 			const dims = $svg.getBoundingClientRect();
-			return dims.width / 8;
+			return dims.height - this.margin.top - this.margin.bottom;
 		},
 		minX(): number {
 			const min = d3.min(this.timeseries, d => d[0]);
@@ -85,6 +85,7 @@ export default Vue.extend({
 			const xDomain = _.uniq(this.timeseries.map(d => d[0]).concat(this.forecast ? this.forecast.map(d => d[0]) : []));
 
 			this.xScale.domain(xDomain);
+
 
 			this.yScale = d3.scaleLinear()
 				.domain([this.minY, this.maxY])
@@ -122,7 +123,7 @@ export default Vue.extend({
 				.attr('class', 'axis-title')
 				.attr('transform', 'rotate(-90)')
 				.attr('x', -(this.height / 2))
-				.attr('y', -this.margin.left / 2)
+				.attr('y', -this.margin.left - 8)
 				.style('text-anchor', 'middle')
 				.text(this.yAxisTitle);
 		},

--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -123,7 +123,7 @@ export default Vue.extend({
 				.attr('class', 'axis-title')
 				.attr('transform', 'rotate(-90)')
 				.attr('x', -(this.height / 2))
-				.attr('y', -this.margin.left - 8)
+				.attr('y', -this.margin.left + 8)
 				.style('text-anchor', 'middle')
 				.text(this.yAxisTitle);
 		},

--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -16,8 +16,8 @@ export default Vue.extend({
 		margin: {
 			type: Object as () => any,
 			default: () => ({
-				top: 16,
-				right: 32,
+				top: 40,
+				right: 0,
 				bottom: 16,
 				left: 32
 			})
@@ -50,7 +50,7 @@ export default Vue.extend({
 		height(): number {
 			const $svg = this.$refs.svg as any;
 			const dims = $svg.getBoundingClientRect();
-			return dims.height - this.margin.top - this.margin.bottom;
+			return dims.width / 8;
 		},
 		minX(): number {
 			const min = d3.min(this.timeseries, d => d[0]);
@@ -101,7 +101,7 @@ export default Vue.extend({
 			// Create x-axis
 			const svgXAxis = this.svg.append('g')
 				.attr('class', 'x axis')
-				.attr('transform', `translate(${this.margin.left}, ${-this.margin.bottom + this.height})`)
+				.attr('transform', `translate(${this.margin.left}, ${this.height})`)
 				.call(xAxis);
 
 			svgXAxis.append('text')
@@ -115,7 +115,7 @@ export default Vue.extend({
 			// Create y-axis
 			const svgYAxis = this.svg.append('g')
 				.attr('class', 'y axis')
-				.attr('transform', `translate(${this.margin.left}, ${-this.margin.bottom})`)
+				.attr('transform', `translate(${this.margin.left}, 0)`)
 				.call(yAxis);
 
 			svgYAxis.append('text')
@@ -133,7 +133,7 @@ export default Vue.extend({
 				.curve(d3.curveLinear);
 
 			const g = this.svg.append('g')
-				.attr('transform', `translate(${this.margin.left}, ${-this.margin.bottom})`)
+				.attr('transform', `translate(${this.margin.left}, 0)`)
 				.attr('class', 'line-chart');
 
 			g.datum(this.timeseries);
@@ -150,7 +150,7 @@ export default Vue.extend({
 				.curve(d3.curveLinear);
 
 			const g = this.svg.append('g')
-				.attr('transform', `translate(${this.margin.left}, ${-this.margin.bottom})`)
+				.attr('transform', `translate(${this.margin.left}, 0)`)
 				.attr('class', 'line-chart');
 
 			g.datum(this.forecast);
@@ -197,7 +197,6 @@ export default Vue.extend({
 
 .line-chart-big {
 	position: relative;
-	height: 512px;
 	width: 100%;
 	border: 1px solid rgba(0,0,0,0);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,7 +10,7 @@
     consola "^2.3.0"
     node-fetch "^2.3.0"
 
-"@turf/bbox@^6.0.1":
+"@turf/bbox@6.x", "@turf/bbox@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
   integrity sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==
@@ -18,10 +18,44 @@
     "@turf/helpers" "6.x"
     "@turf/meta" "6.x"
 
+"@turf/boolean-contains@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-contains/-/boolean-contains-6.0.1.tgz#c3c583215fc5bda47ede51cf52d735ffdc1006a5"
+  integrity sha512-usAexEdWu7dV43paowGSFEM0PljexnlOuj09HF/VDZwO3FKelwUovF2ymetYatuG7KcIYcexeNEkQ5qQnGExlw==
+  dependencies:
+    "@turf/bbox" "6.x"
+    "@turf/boolean-point-in-polygon" "6.x"
+    "@turf/boolean-point-on-line" "6.x"
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/boolean-point-in-polygon@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz#5836677afd77d2ee391af0056a0c29b660edfa32"
+  integrity sha512-FKLOZ124vkJhjzNSDcqpwp2NvfnsbYoUOt5iAE7uskt4svix5hcjIEgX9sELFTJpbLGsD1mUbKdfns8tZxcMNg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/boolean-point-on-line@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-on-line/-/boolean-point-on-line-6.0.1.tgz#d943c242a5fdcde03f8ad0221750fd1aacf06223"
+  integrity sha512-Vl724Tzh4CF/13kgblOAQnMcHagromCP1EfyJ9G/8SxpSoTYeY2G6FmmcpbW51GqKxC7xgM9+Pck50dun7oYkg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
 "@turf/helpers@6.x", "@turf/helpers@^6.1.4":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.1.4.tgz#d6fd7ebe6782dd9c87dca5559bda5c48ae4c3836"
   integrity sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==
+
+"@turf/invariant@6.x":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.1.2.tgz#6013ed6219f9ac2edada9b31e1dfa5918eb0a2f7"
+  integrity sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/meta@6.x":
   version "6.0.2"


### PR DESCRIPTION
The various time-series line charts aren't in perfect lock step scale, but the line chart in the modal is now set up to be more of a long, narrow display like the sparklines. If we want to lock this in tighter, we'll probably to consider the resizing bug (IE: line charts don't redraw on resize,) too.