### PR TITLE
Moves the task type to the route

### DIFF
--- a/public/App.vue
+++ b/public/App.vue
@@ -66,12 +66,13 @@ export default Vue.extend({
 				const taskPromise = datasetActions.fetchTask(this.$store, {
 					dataset: dataset,
 					targetName: target
-				}).then(() => {
+				}).then(response => {
 					let training = [];
 					let promise = Promise.resolve();
+					const task = response.data;
 
 					// TASK 2 hack
-					if (datasetGetters.getTask(this.$store).task === 'timeSeriesForecasting') {
+					if ( task.task === 'timeSeriesForecasting') {
 						promise = datasetActions.fetchVariables(this.$store, {
 							dataset: dataset
 						}).then(() => {
@@ -137,7 +138,8 @@ export default Vue.extend({
 						const entry = createRouteEntry(SELECT_TRAINING_ROUTE, {
 							dataset: dataset,
 							target: target,
-							training: training.join(',')
+							training: training.join(','),
+							task: task.task
 						});
 						this.$router.push(entry);
 					});

--- a/public/App.vue
+++ b/public/App.vue
@@ -29,6 +29,7 @@ import './styles/main.css';
 
 // DEBUG: this is a mocked graph until we support actual graph data
 import './assets/graphs/G1.gml';
+import { TaskTypes } from './store/dataset';
 
 Vue.use(BootstrapVue);
 Vue.use(VueObserveVisibility);
@@ -72,7 +73,7 @@ export default Vue.extend({
 					const task = response.data;
 
 					// TASK 2 hack
-					if ( task.task === 'timeSeriesForecasting') {
+					if (routeGetters.getRouteTask(this.$store) === TaskTypes.TIME_SERIES_FORECASTING) {
 						promise = datasetActions.fetchVariables(this.$store, {
 							dataset: dataset
 						}).then(() => {

--- a/public/components/AvailableTargetVariables.vue
+++ b/public/components/AvailableTargetVariables.vue
@@ -92,15 +92,23 @@ export default Vue.extend({
 						}
 					}
 
-					const routeArgs = {
-						target: group.colName,
-						dataset: routeGetters.getRouteDataset(this.$store),
-						filters: routeGetters.getRouteFilters(this.$store),
-						training: training.join(',')
-					};
-					const entry = createRouteEntry(SELECT_TRAINING_ROUTE, routeArgs);
-					this.$router.push(entry);
-					datasetActions.fetchTask(this.$store, {dataset: routeArgs.dataset, targetName: routeArgs.target});
+					// kick off the fetch task and wait for the result - when we've got it, update the route with info
+					const dataset = routeGetters.getRouteDataset(this.$store);
+					datasetActions.fetchTask(this.$store, {dataset: dataset, targetName: group.colName})
+						.then(response => {
+							const routeArgs = {
+								target: group.colName,
+								dataset: dataset,
+								filters: routeGetters.getRouteFilters(this.$store),
+								training: training.join(','),
+								task: response.data.task
+							};
+							const entry = createRouteEntry(SELECT_TRAINING_ROUTE, routeArgs);
+							this.$router.push(entry);
+						})
+						.catch(error => {
+							console.error(error);
+						});
 				});
 				container.appendChild(targetElem);
 				return container;

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -185,7 +185,8 @@ export default Vue.extend({
 				const entry = createRouteEntry(RESULTS_ROUTE, {
 					dataset: routeGetters.getRouteDataset(this.$store),
 					target: routeGetters.getRouteTargetVariable(this.$store),
-					solutionId: res.solutionId
+					solutionId: res.solutionId,
+					task: routeGetters.getRouteTask(this.$store)
 				});
 				this.$router.push(entry);
 			}).catch(err => {

--- a/public/components/ResultFacets.vue
+++ b/public/components/ResultFacets.vue
@@ -86,7 +86,7 @@ export default Vue.extend({
 		},
 
 		residualSummaries(): VariableSummary[] {
-			return this.regression || datasetGetters.getTask(this.$store) ? resultsGetters.getResidualsSummaries(this.$store) : [];
+			return this.regression || routeGetters.getRouteTask(this.$store) ? resultsGetters.getResidualsSummaries(this.$store) : [];
 		},
 
 		correctnessSummaries(): VariableSummary[] {

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
 		},
 
 		regressionEnabled(): boolean {
-			return routeGetters.getRouteTask(this.$store).task === TaskTypes.REGRESSION;
+			return routeGetters.getRouteTask(this.$store) === TaskTypes.REGRESSION;
 		},
 
 		solutionId(): string {

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
 		},
 
 		regressionEnabled(): boolean {
-			return datasetGetters.getTask(this.$store).task === TaskTypes.REGRESSION;
+			return routeGetters.getRouteTask(this.$store).task === TaskTypes.REGRESSION;
 		},
 
 		solutionId(): string {

--- a/public/components/ResultsComparison.vue
+++ b/public/components/ResultsComparison.vue
@@ -154,7 +154,7 @@ export default Vue.extend({
 		},
 
 		regressionEnabled(): boolean {
-			return datasetGetters.getTask(this.$store).task === TaskTypes.REGRESSION;
+			return routeGetters.getRouteTask(this.$store).task === TaskTypes.REGRESSION;
 		},
 
 		numRows(): number {
@@ -163,7 +163,7 @@ export default Vue.extend({
 
 
 		isForecasting(): boolean {
-			return datasetGetters.getTask(this.$store).task === TaskTypes.TIME_SERIES_FORECASTING;
+			return routeGetters.getRouteTask(this.$store).task === TaskTypes.TIME_SERIES_FORECASTING;
 		},
 
 		topSlotTitle(): string {

--- a/public/components/ResultsComparison.vue
+++ b/public/components/ResultsComparison.vue
@@ -154,7 +154,7 @@ export default Vue.extend({
 		},
 
 		regressionEnabled(): boolean {
-			return routeGetters.getRouteTask(this.$store).task === TaskTypes.REGRESSION;
+			return routeGetters.getRouteTask(this.$store) === TaskTypes.REGRESSION;
 		},
 
 		numRows(): number {
@@ -163,7 +163,7 @@ export default Vue.extend({
 
 
 		isForecasting(): boolean {
-			return routeGetters.getRouteTask(this.$store).task === TaskTypes.TIME_SERIES_FORECASTING;
+			return routeGetters.getRouteTask(this.$store) === TaskTypes.TIME_SERIES_FORECASTING;
 		},
 
 		topSlotTitle(): string {

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -201,7 +201,7 @@ export default Vue.extend({
 		},
 
 		isRegression(): boolean {
-			return routeGetters.getRouteTask(this.$store).task === TaskTypes.REGRESSION;
+			return routeGetters.getRouteTask(this.$store) === TaskTypes.REGRESSION;
 		},
 
 		sortingByResidualError(): boolean {

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -201,7 +201,7 @@ export default Vue.extend({
 		},
 
 		isRegression(): boolean {
-			return datasetGetters.getTask(this.$store).task === TaskTypes.REGRESSION;
+			return routeGetters.getRouteTask(this.$store).task === TaskTypes.REGRESSION;
 		},
 
 		sortingByResidualError(): boolean {

--- a/public/components/SparklineTimeseriesView.vue
+++ b/public/components/SparklineTimeseriesView.vue
@@ -116,7 +116,7 @@ export default Vue.extend({
 		},
 
 		isForecasting(): boolean {
-			return datasetGetters.getTask(this.$store).task === TaskTypes.TIME_SERIES_FORECASTING;
+			return routeGetters.getRouteTask(this.$store).task === TaskTypes.TIME_SERIES_FORECASTING;
 		},
 
 		showPredicted(): boolean {

--- a/public/components/SparklineTimeseriesView.vue
+++ b/public/components/SparklineTimeseriesView.vue
@@ -116,7 +116,7 @@ export default Vue.extend({
 		},
 
 		isForecasting(): boolean {
-			return routeGetters.getRouteTask(this.$store).task === TaskTypes.TIME_SERIES_FORECASTING;
+			return routeGetters.getRouteTask(this.$store) === TaskTypes.TIME_SERIES_FORECASTING;
 		},
 
 		showPredicted(): boolean {

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import { Dictionary } from '../../util/dict';
 import { ActionContext } from 'vuex';
 import {
@@ -927,17 +927,7 @@ export const actions = {
 			});
 	},
 
-	fetchTask(context: DatasetContext, args: {dataset: string, targetName: string}) {
-		return axios.get<Task>(`/distil/task/${args.dataset}/${args.targetName}`)
-			.then(response => {
-				if (!response.data) {
-					return;
-				}
-				mutations.updateTask(context, response.data);
-			})
-			.catch(error => {
-				console.error(error);
-			});
+	fetchTask(context: DatasetContext, args: {dataset: string, targetName: string}): Promise<AxiosResponse<Task>> {
+		return axios.get<Task>(`/distil/task/${args.dataset}/${args.targetName}`);
 	}
-
 };

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -112,9 +112,5 @@ export const getters = {
 
 	getGeocoordinateTypes(state: DatasetState): string[] {
 		return state.isGeocoordinateFacet;
-	},
-
-	getTask(state: DatasetState): Task {
-		return state.task;
 	}
 };

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -49,8 +49,6 @@ export const getters = {
 	getExcludedTableDataNumRows: read(moduleGetters.getExcludedTableDataNumRows),
 	getExcludedTableDataItems: read(moduleGetters.getExcludedTableDataItems),
 	getExcludedTableDataFields: read(moduleGetters.getExcludedTableDataFields),
-	// task info
-	getTask: read(moduleGetters.getTask),
 };
 
 // Typed actions
@@ -126,6 +124,4 @@ export const mutations = {
 	clearJoinDatasetsTableData: commit(moduleMutations.clearJoinDatasetsTableData),
 	setIncludedTableData: commit(moduleMutations.setIncludedTableData),
 	setExcludedTableData: commit(moduleMutations.setExcludedTableData),
-	// task
-	updateTask: commit(moduleMutations.updateTask),
 };

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -1,4 +1,4 @@
-import { Variable, VariableSummary, Highlight, RowSelection } from '../dataset/index';
+import { Variable, VariableSummary, Highlight, RowSelection, Task, TaskTypes, TaskSubTypes } from '../dataset/index';
 import { JOINED_VARS_INSTANCE_PAGE, AVAILABLE_TARGET_VARS_INSTANCE_PAGE,
 	AVAILABLE_TRAINING_VARS_INSTANCE_PAGE, TRAINING_VARS_INSTANCE_PAGE,
 	RESULT_TRAINING_VARS_INSTANCE_PAGE } from '../route/index';
@@ -9,6 +9,7 @@ import { Dictionary } from '../../util/dict';
 import { buildLookup } from '../../util/lookup';
 import { Route } from 'vue-router';
 import _ from 'lodash';
+import { getCategoricalChunkSize } from '../../util/facets';
 
 export const getters = {
 	getRoute(state: Route): Route {
@@ -324,5 +325,12 @@ export const getters = {
 	},
 	getGroupingType(state: Route): string {
 		return state.query.groupingType as string;
+	},
+	getRouteTask(state: Route, getters: any): string {
+		const task = state.query.task as string;
+		if (!task) {
+			return null;
+		}
+		return task;
 	}
 };

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -54,5 +54,6 @@ export const getters = {
 	getActiveSolutionIndex: read(moduleGetters.getActiveSolutionIndex),
 	getGeoCenter: read(moduleGetters.getGeoCenter),
 	getGeoZoom: read(moduleGetters.getGeoZoom),
-	getGroupingType: read(moduleGetters.getGroupingType)
+	getGroupingType: read(moduleGetters.getGroupingType),
+	getRouteTask: read(moduleGetters.getRouteTask)
 };

--- a/public/store/solutions/actions.ts
+++ b/public/store/solutions/actions.ts
@@ -8,7 +8,7 @@ import { mutations } from './module';
 import { getWebSocketConnection } from '../../util/ws';
 import { FilterParams } from '../../util/filters';
 import { actions as resultsActions } from '../results/module';
-import { getters as datasetGetters } from '../dataset/module';
+import { getters as routeGetters } from '../route/module';
 import { TaskTypes } from '../dataset';
 
 const CREATE_SOLUTIONS = 'CREATE_SOLUTIONS';
@@ -35,9 +35,9 @@ interface SolutionStatus {
 export type SolutionContext = ActionContext<SolutionState, DistilState>;
 
 function updateCurrentSolutionResults(context: SolutionContext, req: CreateSolutionRequest, res: SolutionStatus) {
-	const isRegression = datasetGetters.getTask(store).task === TaskTypes.REGRESSION;
-	const isClassification = datasetGetters.getTask(store).task === TaskTypes.CLASSIFICATION;
-	const isForecasting = datasetGetters.getTask(store).task === TaskTypes.TIME_SERIES_FORECASTING;
+	const isRegression = routeGetters.getRouteTask(store).task === TaskTypes.REGRESSION;
+	const isClassification = routeGetters.getRouteTask(store).task === TaskTypes.CLASSIFICATION;
+	const isForecasting = routeGetters.getRouteTask(store).task === TaskTypes.TIME_SERIES_FORECASTING;
 
 	resultsActions.fetchResultTableData(store, {
 		dataset: req.dataset,
@@ -86,9 +86,9 @@ function updateCurrentSolutionResults(context: SolutionContext, req: CreateSolut
 }
 
 function updateSolutionResults(context: SolutionContext, req: CreateSolutionRequest, res: SolutionStatus) {
-	const isRegression = datasetGetters.getTask(store).task === TaskTypes.REGRESSION;
-	const isClassification = datasetGetters.getTask(store).task === TaskTypes.CLASSIFICATION;
-	const isForecasting = datasetGetters.getTask(store).task === TaskTypes.TIME_SERIES_FORECASTING;
+	const isRegression = routeGetters.getRouteTask(store).task === TaskTypes.REGRESSION;
+	const isClassification = routeGetters.getRouteTask(store).task === TaskTypes.CLASSIFICATION;
+	const isForecasting = routeGetters.getRouteTask(store).task === TaskTypes.TIME_SERIES_FORECASTING;
 
 	// if current solutionId, pull result summaries
 	resultsActions.fetchPredictedSummary(store, {

--- a/public/store/solutions/actions.ts
+++ b/public/store/solutions/actions.ts
@@ -35,9 +35,9 @@ interface SolutionStatus {
 export type SolutionContext = ActionContext<SolutionState, DistilState>;
 
 function updateCurrentSolutionResults(context: SolutionContext, req: CreateSolutionRequest, res: SolutionStatus) {
-	const isRegression = routeGetters.getRouteTask(store).task === TaskTypes.REGRESSION;
-	const isClassification = routeGetters.getRouteTask(store).task === TaskTypes.CLASSIFICATION;
-	const isForecasting = routeGetters.getRouteTask(store).task === TaskTypes.TIME_SERIES_FORECASTING;
+	const isRegression = routeGetters.getRouteTask(store) === TaskTypes.REGRESSION;
+	const isClassification = routeGetters.getRouteTask(store) === TaskTypes.CLASSIFICATION;
+	const isForecasting = routeGetters.getRouteTask(store) === TaskTypes.TIME_SERIES_FORECASTING;
 
 	resultsActions.fetchResultTableData(store, {
 		dataset: req.dataset,
@@ -86,9 +86,9 @@ function updateCurrentSolutionResults(context: SolutionContext, req: CreateSolut
 }
 
 function updateSolutionResults(context: SolutionContext, req: CreateSolutionRequest, res: SolutionStatus) {
-	const isRegression = routeGetters.getRouteTask(store).task === TaskTypes.REGRESSION;
-	const isClassification = routeGetters.getRouteTask(store).task === TaskTypes.CLASSIFICATION;
-	const isForecasting = routeGetters.getRouteTask(store).task === TaskTypes.TIME_SERIES_FORECASTING;
+	const isRegression = routeGetters.getRouteTask(store) === TaskTypes.REGRESSION;
+	const isClassification = routeGetters.getRouteTask(store) === TaskTypes.CLASSIFICATION;
+	const isForecasting = routeGetters.getRouteTask(store) === TaskTypes.TIME_SERIES_FORECASTING;
 
 	// if current solutionId, pull result summaries
 	resultsActions.fetchPredictedSummary(store, {

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -25,6 +25,7 @@ export interface RouteArgs {
 	joinColumnSuggestions?: string; // suggested target join columns
 	groupingType?: string;
 	availableTargetVarsPage?: number;
+	task?: string;
 
 	// we currently don't have a way to add these to the interface
 	//
@@ -95,6 +96,7 @@ function validateQueryArgs(args: RouteArgs): RouteArgs {
 	if (!_.isUndefined(args.joinColumnSuggestions)) { query.joinColumnSuggestions = args.joinColumnSuggestions; }
 	if (!_.isUndefined(args.joinAccuracy)) { query.joinAccuracy = args.joinAccuracy; }
 	if (!_.isUndefined(args.groupingType)) { query.groupingType = args.groupingType; }
+	if (!_.isUndefined(args.task)) { query.task = args.task; }
 
 
 	if (args[JOINED_VARS_INSTANCE_PAGE]) { query[JOINED_VARS_INSTANCE_PAGE] = args[JOINED_VARS_INSTANCE_PAGE]; }


### PR DESCRIPTION
Fixes #1291 

1. Adds the modelling task to the route
1. Ensures that the task is fetched from server when necessary
1. Removes task from `dataset` store module

Note that we aren't tracking the sub-task, even though the server provides it.  Its not used anywhere in client, and a recent change to the D3M problem schema (which we have to incorporate soon) removes it in favour of list of task keywords.