### PR TITLE
#1276 Descriptions in Tooltips

### DIFF
--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -865,7 +865,9 @@ export default Vue.extend({
 		wrapGroupHeaderText(group: Group, $elem: JQuery) {
 			const $headerElement = $elem.find('.group-header');
 			const headerText = $headerElement.text();
-			const tooltipText =  headerText.concat(': ', this.currentVariable.colDescription).replace(/(\r\n|\n|\r|\t)/gm, '');
+			const tooltipText = (this.currentVariable.colDescription ?
+				headerText.concat(': ', this.currentVariable.colDescription) :
+				headerText).replace(/(\r\n|\n|\r|\t)/gm, '');
 			$headerElement.empty();
 			const $headerTextWrapped = $(`<div class="header-text" v-b-tooltip.hover title="${tooltipText}">${headerText}</div>`);
 			$headerElement.append($headerTextWrapped);

--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -15,7 +15,7 @@ import IconBookmark from './icons/IconBookmark';
 import { createIcon } from '../util/icon';
 import { CATEGORICAL_FILTER, NUMERICAL_FILTER, DATETIME_FILTER, BIVARIATE_FILTER, FEATURE_FILTER, TIMESERIES_FILTER, INCLUDE_FILTER } from '../util/filters';
 import { createGroup, Group, CategoricalFacet, isCategoricalFacet, getCategoricalChunkSize, isNumericalFacet, isSparklineFacet } from '../util/facets';
-import { VariableSummary, Highlight, RowSelection, Row } from '../store/dataset/index';
+import { VariableSummary, Highlight, RowSelection, Row, Variable } from '../store/dataset/index';
 import { Dictionary } from '../util/dict';
 import { getSelectedRows } from '../util/row';
 import Facets from '@uncharted.software/stories-facets';
@@ -232,6 +232,13 @@ export default Vue.extend({
 			}
 
 			return group;
+		},
+		currentVariable(): Variable {
+			const variables = datasetGetters.getVariables(this.$store);
+			const currentVariable = variables.filter(v => {
+				return v.colName === this.groupSpec.colName;
+			})[0];
+			return currentVariable;
 		}
 	},
 
@@ -858,8 +865,9 @@ export default Vue.extend({
 		wrapGroupHeaderText(group: Group, $elem: JQuery) {
 			const $headerElement = $elem.find('.group-header');
 			const headerText = $headerElement.text();
+			const tooltipText =  headerText.concat(': ', this.currentVariable.colDescription).replace(/(\r\n|\n|\r|\t)/gm, '');
 			$headerElement.empty();
-			const $headerTextWrapped = $(`<div class="header-text" v-b-tooltip.hover title=${headerText}>${headerText}</div>`);
+			const $headerTextWrapped = $(`<div class="header-text" v-b-tooltip.hover title="${tooltipText}">${headerText}</div>`);
 			$headerElement.append($headerTextWrapped);
 		},
 

--- a/public/components/FixedHeaderTable.vue
+++ b/public/components/FixedHeaderTable.vue
@@ -102,7 +102,7 @@ export default Vue.extend({
 			const target = event.target;
 			if (!target) { return; }
 
-			const isCell = target.tagName === 'TD' || target.tagName === 'TH';
+			const isCell = target.tagName === 'TD';
 			const isLeafNode = target.childElementCount === 0;
 			const text = target.innerText;
 			const title = target.getAttribute('title');

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -61,6 +61,7 @@ export interface Variable {
 	ranking?: number;
 	novelty: number;
 	colOriginalType: string;
+	colDescription: string;
 	suggestedTypes: SuggestedType[];
 	isColTypeChanged: boolean;
 	isGrouping: boolean;

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -365,13 +365,16 @@ function isPredictedCol(arg: string): boolean {
 export function getTableDataFields(data: TableData) {
 	if (validateData(data)) {
 		const result = {};
+		const variables = datasetGetters.getVariables(store);
 
 		for (const col of data.columns) {
 			if (col.key === D3M_INDEX_FIELD) {
 				continue;
 			}
+			const variable = variables.find(v => v.colName === col.key);
 
 			let label = col.label;
+			const description = variable.colDescription;
 
 			if (col.type === TIMESERIES_TYPE) {
 
@@ -380,17 +383,17 @@ export function getTableDataFields(data: TableData) {
 					continue;
 				}
 
-				const variables = datasetGetters.getVariables(store);
-				const variable = variables.find(v => v.colName === col.key);
 				if (variable && variable.grouping) {
 					label = variable.grouping.properties.yCol;
 				}
 			}
 
+
 			result[col.key] = {
 				label: label,
 				key: col.key,
 				type: col.type,
+				headerTitle: description ? label.concat(': ', description) : label,
 				sortable: true
 			};
 		}


### PR DESCRIPTION
- Added colDescription to the fields passed through Variable interface definition
- Modified facet entry component to query the colDescription from the variables store and place it in the tooltip directive text when available, extending prior tooltip work.
- Modified getTableDataFields call to include the colDescription as the title field of each table data field. 
- Removed previous hook up for tooltips on table headers in the fixed header table component.