### PR TITLE
Storage result and DB fixes

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -101,27 +101,13 @@ type SolutionScore struct {
 	SortMultiplier float64 `json:"sortMultiplier"`
 }
 
-// GetPredictedKey returns a solutions predicted col key.  This is not suitable to use as a
-// DB col name as it can be > 63 char limit.
-func GetPredictedKey(target string, solutionID string) string {
-	return target + ":" + solutionID + ":predicted"
-}
-
-// GetPredictedStorageKey returns a solution predicted col key that can be used as a DB col name,
-// but is less descriptive.
-func GetPredictedStorageKey(solutionID string) string {
+// GetPredictedKey returns a solutions predicted col key.
+func GetPredictedKey(solutionID string) string {
 	return solutionID + ":predicted"
 }
 
-// GetErrorKey returns a solutions error col key.  This is not suitable to use as a
-// DB col name as it can be > 63 char limit.
-func GetErrorKey(target string, solutionID string) string {
-	return target + ":" + solutionID + ":error"
-}
-
-// GetErrorStorageKey returns a solution predicted col key that can be used as a DB col name,
-// but is less descriptive.
-func GetErrorStorageKey(solutionID string) string {
+// GetErrorKey returns a solutions error col key.
+func GetErrorKey(solutionID string) string {
 	return solutionID + ":error"
 }
 

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -101,14 +101,28 @@ type SolutionScore struct {
 	SortMultiplier float64 `json:"sortMultiplier"`
 }
 
-// GetPredictedKey returns a solutions predicted col key.
+// GetPredictedKey returns a solutions predicted col key.  This is not suitable to use as a
+// DB col name as it can be > 63 char limit.
 func GetPredictedKey(target string, solutionID string) string {
 	return target + ":" + solutionID + ":predicted"
 }
 
-// GetErrorKey returns a solutions error col key.
+// GetPredictedStorageKey returns a solution predicted col key that can be used as a DB col name,
+// but is less descriptive.
+func GetPredictedStorageKey(solutionID string) string {
+	return solutionID + ":predicted"
+}
+
+// GetErrorKey returns a solutions error col key.  This is not suitable to use as a
+// DB col name as it can be > 63 char limit.
 func GetErrorKey(target string, solutionID string) string {
 	return target + ":" + solutionID + ":error"
+}
+
+// GetErrorStorageKey returns a solution predicted col key that can be used as a DB col name,
+// but is less descriptive.
+func GetErrorStorageKey(solutionID string) string {
+	return solutionID + ":error"
 }
 
 // IsPredictedKey returns true if the key matches a predicted key.

--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -289,7 +289,7 @@ func (f *CategoricalField) getTopCategories(filterParams *api.FilterParams, inve
 	// create the filter for the query
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -329,7 +329,7 @@ func (f *CategoricalField) fetchHistogram(filterParams *api.FilterParams, invert
 	// create the filter for the query
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -552,7 +552,7 @@ func (f *CategoricalField) fetchForecastingSummaryData(timeVar *model.Variable, 
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, false)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
 
 	categoryWhere := fmt.Sprintf("\"%s\" in (", resultVariable.Name)
 	for index, category := range categories {

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -117,7 +117,7 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -111,7 +111,7 @@ func (f *DateTimeField) fetchHistogram(filterParams *api.FilterParams, invert bo
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 
 	// need the extrema to calculate the histogram interval
 	extrema, err := f.fetchExtrema()

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -353,7 +353,7 @@ func (s *Storage) buildCorrectnessResultWhere(wheres []string, params []interfac
 func (s *Storage) buildErrorResultWhere(wheres []string, params []interface{}, residualFilter *model.Filter) ([]string, []interface{}, error) {
 	// Add a clause to filter residuals to the existing where
 	nameWithoutSuffix := api.StripKeySuffix(residualFilter.Key)
-	typedError := getErrorTyped(nameWithoutSuffix)
+	typedError := getErrorTyped("", nameWithoutSuffix)
 	where := fmt.Sprintf("(%s >= $%d AND %s <= $%d)", typedError, len(params)+1, typedError, len(params)+2)
 	params = append(params, *residualFilter.Min)
 	params = append(params, *residualFilter.Max)

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -91,16 +91,16 @@ func (s *Storage) parseFilteredData(dataset string, variables []*model.Variable,
 	return result, nil
 }
 
-func (s *Storage) formatFilterKey(key string) string {
+func (s *Storage) formatFilterKey(alias string, key string) string {
 	if api.IsResultKey(key) {
 		return "result.value"
 	}
-	return fmt.Sprintf("\"%s\"", key)
+	return getFullName(alias, key)
 }
 
-func (s *Storage) buildIncludeFilter(wheres []string, params []interface{}, filter *model.Filter) ([]string, []interface{}) {
+func (s *Storage) buildIncludeFilter(wheres []string, params []interface{}, alias string, filter *model.Filter) ([]string, []interface{}) {
 
-	name := s.formatFilterKey(filter.Key)
+	name := s.formatFilterKey(alias, filter.Key)
 
 	switch filter.Type {
 	case model.DatetimeFilter:
@@ -170,9 +170,9 @@ func (s *Storage) buildIncludeFilter(wheres []string, params []interface{}, filt
 	return wheres, params
 }
 
-func (s *Storage) buildExcludeFilter(wheres []string, params []interface{}, filter *model.Filter) ([]string, []interface{}) {
+func (s *Storage) buildExcludeFilter(wheres []string, params []interface{}, alias string, filter *model.Filter) ([]string, []interface{}) {
 
-	name := s.formatFilterKey(filter.Key)
+	name := s.formatFilterKey(alias, filter.Key)
 
 	switch filter.Type {
 	case model.DatetimeFilter:
@@ -242,7 +242,7 @@ func (s *Storage) buildExcludeFilter(wheres []string, params []interface{}, filt
 	return wheres, params
 }
 
-func (s *Storage) buildFilteredQueryWhere(wheres []string, params []interface{}, filterParams *api.FilterParams, invert bool) ([]string, []interface{}) {
+func (s *Storage) buildFilteredQueryWhere(wheres []string, params []interface{}, alias string, filterParams *api.FilterParams, invert bool) ([]string, []interface{}) {
 
 	if filterParams == nil {
 		return wheres, params
@@ -252,9 +252,9 @@ func (s *Storage) buildFilteredQueryWhere(wheres []string, params []interface{},
 	if highlight != nil {
 		switch highlight.Mode {
 		case model.IncludeFilter:
-			wheres, params = s.buildIncludeFilter(wheres, params, highlight)
+			wheres, params = s.buildIncludeFilter(wheres, params, alias, highlight)
 		case model.ExcludeFilter:
-			wheres, params = s.buildExcludeFilter(wheres, params, highlight)
+			wheres, params = s.buildExcludeFilter(wheres, params, alias, highlight)
 		}
 	}
 
@@ -262,9 +262,9 @@ func (s *Storage) buildFilteredQueryWhere(wheres []string, params []interface{},
 	for _, filter := range filterParams.Filters {
 		switch filter.Mode {
 		case model.IncludeFilter:
-			filterWheres, params = s.buildIncludeFilter(filterWheres, params, filter)
+			filterWheres, params = s.buildIncludeFilter(filterWheres, params, alias, filter)
 		case model.ExcludeFilter:
-			filterWheres, params = s.buildExcludeFilter(filterWheres, params, filter)
+			filterWheres, params = s.buildExcludeFilter(filterWheres, params, alias, filter)
 		}
 	}
 	if len(filterWheres) > 0 {
@@ -370,7 +370,7 @@ func (s *Storage) buildPredictedResultWhere(wheres []string, params []interface{
 		Filters: []*model.Filter{resultFilter},
 	}
 
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, filterParams, false)
+	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
 	return wheres, params, nil
 }
 
@@ -389,7 +389,7 @@ func (s *Storage) buildResultQueryFilters(storageName string, resultURI string, 
 	// create the filter for the query
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, genericFilterParams, false)
+	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", genericFilterParams, false)
 
 	// assemble split filters
 	var err error
@@ -565,7 +565,7 @@ func (s *Storage) FetchData(dataset string, storageName string, filterParams *ap
 
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 
 	if len(wheres) > 0 {
 		query = fmt.Sprintf("%s WHERE %s", query, strings.Join(wheres, " AND "))

--- a/api/model/storage/postgres/image.go
+++ b/api/model/storage/postgres/image.go
@@ -126,7 +126,7 @@ func (f *ImageField) fetchHistogram(filterParams *api.FilterParams, invert bool)
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 
 	prefixedVarName := f.featureVarName(f.Key)
 	fieldSelect := fmt.Sprintf("unnest(string_to_array(\"%s\", ','))", prefixedVarName)

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -306,7 +306,7 @@ func (f *NumericalField) fetchHistogram(filterParams *api.FilterParams, invert b
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 	wheres = append(wheres, f.getNaNFilter())
 
 	// need the extrema to calculate the histogram interval
@@ -719,7 +719,7 @@ func (f *NumericalField) FetchNumericalStats(filterParams *api.FilterParams, inv
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 	wheres = append(wheres, f.getNaNFilter())
 
 	where := ""

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -91,8 +91,12 @@ func (s *Storage) fetchResidualsSummary(dataset string, storageName string, vari
 	return nil, errors.Errorf("variable of type %s - should be numeric", variable.Type)
 }
 
-func getErrorTyped(variableName string) string {
-	return fmt.Sprintf("(cast(value as double precision) - cast(\"%s\" as double precision))", variableName)
+func getErrorTyped(alias string, variableName string) string {
+	fullName := fmt.Sprintf("\"%s\"", variableName)
+	if alias != "" {
+		fullName = fmt.Sprintf("%s.%s", alias, fullName)
+	}
+	return fmt.Sprintf("(cast(value as double precision) - cast(\"%s\" as double precision))", fullName)
 }
 
 func (s *Storage) getResidualsHistogramAggQuery(extrema *api.Extrema, variableName string, resultVariable *model.Variable, numBuckets int) (string, string, string) {
@@ -100,7 +104,7 @@ func (s *Storage) getResidualsHistogramAggQuery(extrema *api.Extrema, variableNa
 	interval := extrema.GetBucketInterval(numBuckets)
 
 	// Only numeric types should occur.
-	errorTyped := getErrorTyped(variableName)
+	errorTyped := getErrorTyped("", variableName)
 
 	// get histogram agg name & query string.
 	histogramAggName := fmt.Sprintf("\"%s%s\"", api.HistogramAggPrefix, extrema.Key)
@@ -123,7 +127,7 @@ func getResidualsMinMaxAggsQuery(variableName string, resultVariable *model.Vari
 	maxAggName := api.MaxAggPrefix + resultVariable.Name
 
 	// Only numeric types should occur.
-	errorTyped := getErrorTyped(variableName)
+	errorTyped := getErrorTyped("", variableName)
 
 	// create aggregations
 	queryPart := fmt.Sprintf("MIN(%s) AS \"%s\", MAX(%s) AS \"%s\"", errorTyped, minAggName, errorTyped, maxAggName)

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -196,7 +196,7 @@ func (s *Storage) fetchResidualsHistogram(resultURI string, storageName string, 
 	params = append(params, variable.Name)
 
 	wheres := make([]string, 0)
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, filterParams, false)
+	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
 
 	where := ""
 	if len(wheres) > 0 {

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -96,7 +96,7 @@ func getErrorTyped(alias string, variableName string) string {
 	if alias != "" {
 		fullName = fmt.Sprintf("%s.%s", alias, fullName)
 	}
-	return fmt.Sprintf("(cast(value as double precision) - cast(\"%s\" as double precision))", fullName)
+	return fmt.Sprintf("(cast(value as double precision) - cast(%s as double precision))", fullName)
 }
 
 func (s *Storage) getResidualsHistogramAggQuery(extrema *api.Extrema, variableName string, resultVariable *model.Variable, numBuckets int) (string, string, string) {

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -602,8 +602,8 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 	}
 
 	// If our results are numerical we need to compute residuals and store them in a column called 'error'
-	predictedCol := api.GetPredictedKey(targetName, solutionID)
-	errorCol := api.GetErrorKey(targetName, solutionID)
+	predictedCol := api.GetPredictedStorageKey(solutionID)
+	errorCol := api.GetErrorStorageKey(solutionID)
 	targetCol := targetName
 
 	errorExpr := ""

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -612,8 +612,8 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 	}
 
 	// If our results are numerical we need to compute residuals and store them in a column called 'error'
-	predictedCol := api.GetPredictedStorageKey(solutionID)
-	errorCol := api.GetErrorStorageKey(solutionID)
+	predictedCol := api.GetPredictedKey(solutionID)
+	errorCol := api.GetErrorKey(solutionID)
 	targetCol := targetName
 
 	errorExpr := ""

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -470,7 +470,7 @@ func addExcludePredictedFilterToWhere(wheres []string, params []interface{}, pre
 
 func addIncludeErrorFilterToWhere(wheres []string, params []interface{}, targetName string, residualFilter *model.Filter) ([]string, []interface{}, error) {
 	// Add a clause to filter residuals to the existing where
-	typedError := getErrorTyped(targetName)
+	typedError := getErrorTyped("", targetName)
 	where := fmt.Sprintf("(%s >= $%d AND %s <= $%d)", typedError, len(params)+1, typedError, len(params)+2)
 	params = append(params, *residualFilter.Min)
 	params = append(params, *residualFilter.Max)
@@ -482,7 +482,7 @@ func addIncludeErrorFilterToWhere(wheres []string, params []interface{}, targetN
 
 func addExcludeErrorFilterToWhere(wheres []string, params []interface{}, targetName string, residualFilter *model.Filter) ([]string, []interface{}, error) {
 	// Add a clause to filter residuals to the existing where
-	typedError := getErrorTyped(targetName)
+	typedError := getErrorTyped("", targetName)
 	where := fmt.Sprintf("(%s < $%d OR %s > $%d)", typedError, len(params)+1, typedError, len(params)+2)
 	params = append(params, *residualFilter.Min)
 	params = append(params, *residualFilter.Max)
@@ -608,7 +608,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 
 	errorExpr := ""
 	if model.IsNumerical(variable.Type) {
-		errorExpr = fmt.Sprintf("%s as \"%s\",", getErrorTyped(variable.Name), errorCol)
+		errorExpr = fmt.Sprintf("%s as \"%s\",", getErrorTyped("data", variable.Name), errorCol)
 	}
 
 	// errorExpr will have the necessary comma if relevant

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -352,6 +352,15 @@ func addExcludeCorrectnessFilterToWhere(wheres []string, params []interface{}, c
 	return wheres, params, nil
 }
 
+func getFullName(alias string, column string) string {
+	fullName := fmt.Sprintf("\"%s\"", column)
+	if alias != "" {
+		fullName = fmt.Sprintf("%s.%s", alias, fullName)
+	}
+
+	return fullName
+}
+
 func addIncludePredictedFilterToWhere(wheres []string, params []interface{}, predictedFilter *model.Filter, target *model.Variable) ([]string, []interface{}, error) {
 	// Handle the predicted column, which is accessed as `value` in the result query
 	where := ""
@@ -550,7 +559,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 	// Create the filter portion of the where clause.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, genericFilterParams, false)
+	wheres, params = s.buildFilteredQueryWhere(wheres, params, dataTableAlias, genericFilterParams, false)
 
 	// Add the predicted filter into the where clause if it was included in the filter set
 	if filters.predictedFilter != nil {

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -270,7 +270,7 @@ func (f *TextField) getTopCategories(filterParams *api.FilterParams, invert bool
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -312,7 +312,7 @@ func (f *TextField) fetchHistogram(filterParams *api.FilterParams, invert bool) 
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -147,7 +147,7 @@ func (s *Storage) FetchTimeseries(dataset string, storageName string, timeseries
 	wheres = append(wheres, fmt.Sprintf("\"%s\" = $1", timeseriesColName))
 	params = append(params, timeseriesURI)
 
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, filterParams, invert)
+	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
 	where := fmt.Sprintf("WHERE %s", strings.Join(wheres, " AND "))
 
 	// Get count by category.
@@ -175,7 +175,7 @@ func (s *Storage) FetchTimeseriesForecast(dataset string, storageName string, ti
 	wheres = append(wheres, fmt.Sprintf("\"%s\" = $1", timeseriesColName))
 	params = append(params, timeseriesURI)
 
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, filterParams, false)
+	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
 
 	params = append(params, resultURI)
 	wheres = append(wheres, fmt.Sprintf("result.result_id = $%d", len(params)))
@@ -261,7 +261,7 @@ func (f *TimeSeriesField) fetchHistogram(filterParams *api.FilterParams, invert 
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, filterParams, false)
+	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
 
 	clusteringColName := f.clusteringColName()
 

--- a/api/routes/correctness_summary.go
+++ b/api/routes/correctness_summary.go
@@ -83,7 +83,7 @@ func CorrectnessSummaryHandler(solutionCtor api.SolutionStorageCtor, dataCtor ap
 			handleError(w, err)
 			return
 		}
-		summary.Key = api.GetErrorKey(summary.Key, res.SolutionID)
+		summary.Key = api.GetErrorKey(res.SolutionID)
 		summary.Label = "Error"
 		summary.SolutionID = res.SolutionID
 

--- a/api/routes/predicted_summary.go
+++ b/api/routes/predicted_summary.go
@@ -143,7 +143,7 @@ func PredictedSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.
 			handleError(w, err)
 			return
 		}
-		summary.Key = api.GetPredictedKey(summary.Key, res.SolutionID)
+		summary.Key = api.GetPredictedKey(res.SolutionID)
 		summary.Label = "Predicted"
 		summary.SolutionID = res.SolutionID
 

--- a/api/routes/residuals_summary.go
+++ b/api/routes/residuals_summary.go
@@ -97,7 +97,7 @@ func ResidualsSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.
 			handleError(w, err)
 			return
 		}
-		summary.Key = api.GetErrorKey(summary.Key, res.SolutionID)
+		summary.Key = api.GetErrorKey(res.SolutionID)
 		summary.Label = "Error"
 		summary.SolutionID = res.SolutionID
 

--- a/api/routes/solutions.go
+++ b/api/routes/solutions.go
@@ -102,8 +102,8 @@ func SolutionHandler(solutionCtor model.SolutionStorageCtor) func(http.ResponseW
 					Timestamp:  sol.CreatedTime,
 					Progress:   sol.Progress,
 					// keys
-					PredictedKey: model.GetPredictedStorageKey(sol.SolutionID),
-					ErrorKey:     model.GetErrorStorageKey(sol.SolutionID),
+					PredictedKey: model.GetPredictedKey(sol.SolutionID),
+					ErrorKey:     model.GetErrorKey(sol.SolutionID),
 				}
 				if sol.Result != nil {
 					// result

--- a/api/routes/solutions.go
+++ b/api/routes/solutions.go
@@ -102,8 +102,8 @@ func SolutionHandler(solutionCtor model.SolutionStorageCtor) func(http.ResponseW
 					Timestamp:  sol.CreatedTime,
 					Progress:   sol.Progress,
 					// keys
-					PredictedKey: model.GetPredictedKey(req.TargetFeature(), sol.SolutionID),
-					ErrorKey:     model.GetErrorKey(req.TargetFeature(), sol.SolutionID),
+					PredictedKey: model.GetPredictedStorageKey(sol.SolutionID),
+					ErrorKey:     model.GetErrorStorageKey(sol.SolutionID),
 				}
 				if sol.Result != nil {
 					// result

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -7,6 +7,8 @@ import { Dictionary } from '../../util/dict';
 import { actions as datasetActions, mutations as datasetMutations } from '../dataset/module';
 import { actions as solutionActions, mutations as solutionMutations } from '../solutions/module';
 import { actions as resultActions, mutations as resultMutations } from '../results/module';
+import { getters as routeGetters } from '../route/module';
+import { TaskTypes } from '../dataset';
 
 enum ParamCacheKey {
 	VARIABLES = 'VARIABLES',
@@ -299,9 +301,6 @@ export const actions = {
 		// fetch new state
 		const dataset = context.getters.getRouteDataset;
 		const target = context.getters.getRouteTargetVariable;
-		const isRegression = context.getters.isRegression;
-		const isClassification = context.getters.isClassification;
-		const isForecasting = context.getters.isForecasting;
 		const requestIds = context.getters.getRelevantSolutionRequestIds;
 		const solutionId = context.getters.getRouteSolutionId;
 		const trainingVariables = context.getters.getActiveSolutionTrainingVariables;
@@ -331,7 +330,8 @@ export const actions = {
 			highlight: highlight
 		});
 
-		if (isRegression || isForecasting) {
+		const task = routeGetters.getRouteTask(store);
+		if (task === TaskTypes.REGRESSION || task === TaskTypes.TIME_SERIES_FORECASTING) {
 			resultActions.fetchResidualsExtrema(store, {
 				dataset: dataset,
 				target: target,
@@ -343,13 +343,15 @@ export const actions = {
 				requestIds: requestIds,
 				highlight: highlight
 			});
-		} else if (isClassification) {
+		} else if (task === TaskTypes.CLASSIFICATION) {
 			resultActions.fetchCorrectnessSummaries(store, {
 				dataset: dataset,
 				target: target,
 				requestIds: requestIds,
 				highlight: highlight
 			});
+		} else {
+			console.error(`unhandled task type ${task}`);
 		}
 	}
 };


### PR DESCRIPTION
Fixes #1286.  Using the variable name as part of the error/predicted keys was causing the PG 63 char col name limit to be exceeded, leading to the ID being truncated and a host of downstream problems cropped up as a result.  I turns out that the variable name doesn't need to be in that key at all, so it has been removed.

In testing, a number of issues related to DB queries that were introduced by SHAP changes were discovered, and those are fixed here as well.