### PR TITLE
Result tooltip fixes

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	suffixReg = regexp.MustCompile(`:\S+:error|:\S+:predicted$`)
+	suffixReg = regexp.MustCompile(`:error|:predicted$`)
 )
 
 // Request represents the request metadata.

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -116,9 +116,10 @@ func (s *Storage) getResidualsHistogramAggQuery(extrema *api.Extrema, variableNa
 	return histogramAggName, bucketQueryString, histogramQueryString
 }
 
-func getResultJoin(storageName string) string {
+func getResultJoin(alias string, storageName string) string {
 	// FROM clause to join result and base data on d3mIdex value
-	return fmt.Sprintf("%s_result as res inner join %s as data on data.\"%s\" = res.index", storageName, storageName, model.D3MIndexFieldName)
+	return fmt.Sprintf("%s_result as %s inner join %s as data on data.\"%s\" = %s.index",
+		storageName, alias, storageName, model.D3MIndexFieldName, alias)
 }
 
 func getResidualsMinMaxAggsQuery(variableName string, resultVariable *model.Variable) string {
@@ -147,7 +148,7 @@ func (s *Storage) fetchResidualsExtrema(resultURI string, storageName string, va
 	aggQuery := getResidualsMinMaxAggsQuery(targetName, resultVariable)
 
 	// from clause to join result and base data
-	fromClause := getResultJoin(storageName)
+	fromClause := getResultJoin("res", storageName)
 
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE result_id = $1 AND target = $2;", aggQuery, fromClause)
@@ -188,7 +189,7 @@ func (s *Storage) fetchResidualsHistogram(resultURI string, storageName string, 
 	// size is derived from the min/max and desired bucket count.
 	histogramName, bucketQuery, histogramQuery := s.getResidualsHistogramAggQuery(extrema, targetName, resultVariable, numBuckets)
 
-	fromClause := getResultJoin(storageName)
+	fromClause := getResultJoin("result", storageName)
 
 	// create the filter for the query
 	params := make([]interface{}, 0)

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -228,6 +228,9 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 	// add dataset
 	summary.Dataset = dataset
 
+	// add description
+	summary.Description = variable.Description
+
 	if variable.Grouping != nil {
 		if model.IsTimeSeries(variable.Grouping.Type) {
 			summary.Label = variable.Grouping.Properties.YCol

--- a/api/model/variable_summary.go
+++ b/api/model/variable_summary.go
@@ -49,15 +49,16 @@ type Histogram struct {
 
 // VariableSummary represents a summary of the variable values.
 type VariableSummary struct {
-	Label      string     `json:"label"`
-	Key        string     `json:"key"`
-	Type       string     `json:"type"`
-	VarType    string     `json:"varType"`
-	Dataset    string     `json:"dataset"`
-	SolutionID string     `json:"solutionId,omitempty"`
-	Baseline   *Histogram `json:"baseline"`
-	Filtered   *Histogram `json:"filtered"`
-	Timeline   *Histogram `json:"timeline"`
+	Label       string     `json:"label"`
+	Key         string     `json:"key"`
+	Description string     `json:"description"`
+	Type        string     `json:"type"`
+	VarType     string     `json:"varType"`
+	Dataset     string     `json:"dataset"`
+	SolutionID  string     `json:"solutionId,omitempty"`
+	Baseline    *Histogram `json:"baseline"`
+	Filtered    *Histogram `json:"filtered"`
+	Timeline    *Histogram `json:"timeline"`
 }
 
 // EmptyFilteredHistogram fills the filtered portion of the summary with empty

--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -233,13 +233,6 @@ export default Vue.extend({
 
 			return group;
 		},
-		currentVariable(): Variable {
-			const variables = datasetGetters.getVariables(this.$store);
-			const currentVariable = variables.filter(v => {
-				return v.colName === this.groupSpec.colName;
-			})[0];
-			return currentVariable;
-		}
 	},
 
 	watch: {
@@ -865,8 +858,8 @@ export default Vue.extend({
 		wrapGroupHeaderText(group: Group, $elem: JQuery) {
 			const $headerElement = $elem.find('.group-header');
 			const headerText = $headerElement.text();
-			const tooltipText = (this.currentVariable.colDescription ?
-				headerText.concat(': ', this.currentVariable.colDescription) :
+			const tooltipText = (this.summary.description ?
+				headerText.concat(': ', this.summary.description) :
 				headerText).replace(/(\r\n|\n|\r|\t)/gm, '');
 			$headerElement.empty();
 			const $headerTextWrapped = $(`<div class="header-text" v-b-tooltip.hover title="${tooltipText}">${headerText}</div>`);

--- a/public/components/FacetTimeseries.vue
+++ b/public/components/FacetTimeseries.vue
@@ -102,6 +102,7 @@ export default Vue.extend({
 				label: timeVarName,
 				key: timeVarName,
 				dataset: this.summary.dataset,
+				description: this.summary.description,
 				type: NUMERICAL_SUMMARY,
 				varType: timeVarType,
 				baseline: this.summary.timeline

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -601,7 +601,8 @@ export const actions = {
 				const key = variable.colName;
 				const label = variable.colDisplayName;
 				const dataset = args.dataset;
-				mutator(context, createPendingSummary(key, label, dataset));
+				const desciption = variable.colDescription;
+				mutator(context, createPendingSummary(key, label, desciption, dataset));
 			}
 
 			// fetch summary

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -163,6 +163,7 @@ export interface TableColumn {
 	label: string;
 	key: string;
 	type: string;
+	headerTitle: string;
 	sortable?: boolean;
 	variant?: string;
 }

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -125,6 +125,7 @@ export interface Histogram {
 
 export interface VariableSummary {
 	label: string;
+	description: string;
 	key: string;
 	dataset: string;
 	type?: string;

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -80,6 +80,7 @@ export interface Group {
 	dataset: string;
 	colName: string;
 	label: string;
+	description: string;
 	key: string;
 	type: string;
 	collapsible: boolean;
@@ -112,6 +113,7 @@ export function createErrorFacet(summary: VariableSummary): Group {
 	return {
 		dataset: summary.dataset,
 		colName: summary.key,
+		description: summary.description,
 		label: summary.label,
 		key: `${summary.dataset}:${summary.key}`,
 		type: summary.varType,
@@ -132,6 +134,7 @@ export function createPendingFacet(summary: VariableSummary): Group {
 		dataset: summary.dataset,
 		colName: summary.key,
 		label: summary.label,
+		description: summary.description,
 		key: `${summary.dataset}:${summary.key}`,
 		type: summary.varType,
 		collapsible: false,
@@ -249,6 +252,7 @@ function createCategoricalSummaryFacet(summary: VariableSummary): Group {
 		dataset: summary.dataset,
 		colName: summary.key,
 		label: summary.label,
+		description: summary.description,
 		key: `${summary.dataset}:${summary.key}`,
 		type: summary.varType,
 		collapsible: false,
@@ -309,6 +313,7 @@ function createCategoricalTimeseriesSummaryFacet(summary: VariableSummary): Grou
 		dataset: summary.dataset,
 		colName: summary.key,
 		label: summary.label,
+		description: summary.description,
 		key: `${summary.dataset}:${summary.key}`,
 		type: summary.varType,
 		collapsible: false,
@@ -387,6 +392,7 @@ function createNumericalSummaryFacet(summary: VariableSummary): Group {
 		dataset: summary.dataset,
 		colName: summary.key,
 		label: summary.label,
+		description: summary.description,
 		key: `${summary.dataset}:${summary.key}`,
 		type: summary.varType,
 		collapsible: false,
@@ -414,6 +420,7 @@ function createNumericalTimeseriesFacet(summary: VariableSummary): Group {
 		dataset: summary.dataset,
 		colName: summary.key,
 		label: summary.label,
+		description: summary.description,
 		key: `${summary.dataset}:${summary.key}`,
 		type: summary.varType,
 		collapsible: false,


### PR DESCRIPTION
Results were no longer displaying due to exceptions generated in tooltip code in the result table and facets.  Extra handling has been added to handle the error and predicted columns/facets.   As part of this support, the description was added to the facet model, and the code for populating it was moved up a level into the summary fetch code.