### PR TITLE
Log solution api

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,11 +91,11 @@
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-compute"
-  branch = "log-solution-api"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-ingest"
-  branch = "log-solution-api"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/unchartedsoftware/plog"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -91,11 +91,11 @@
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-compute"
-  branch = "master"
+  branch = "log-solution-api"
 
 [[constraint]]
   name = "github.com/uncharted-distil/distil-ingest"
-  branch = "master"
+  branch = "log-solution-api"
 
 [[constraint]]
   name = "github.com/unchartedsoftware/plog"

--- a/api/env/log.go
+++ b/api/env/log.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	log "github.com/unchartedsoftware/plog"
 
 	"github.com/uncharted-distil/distil/api/util"
 )
@@ -128,8 +129,16 @@ func (l *DiscoveryLogger) logAction(feature string, typ string, activity string,
 
 	mu.Lock()
 	defer mu.Unlock()
-	f, _ := os.OpenFile(l.csvFilename, os.O_WRONLY|os.O_APPEND, os.ModePerm)
+	f, err := os.OpenFile(l.csvFilename, os.O_WRONLY|os.O_APPEND, os.ModePerm)
+	if err != nil {
+		log.Errorf("unable to open discovery log: %v", err)
+	}
 	w := csv.NewWriter(f)
-	w.Write([]string{timestamp, feature, typ, activity, subActivity, string(paramsString)})
+
+	err = w.Write([]string{timestamp, feature, typ, activity, subActivity, string(paramsString)})
+	if err != nil {
+		log.Errorf("unable to log to discovery log: %v", err)
+	}
+
 	w.Flush()
 }

--- a/api/env/log.go
+++ b/api/env/log.go
@@ -68,17 +68,27 @@ var (
 // DiscoveryLogger logs problem discovery information.
 type DiscoveryLogger struct {
 	csvFilename string
+	config      *Config
+}
+
+// NewDiscoveryLogger creates and initializes a discovery logger.
+func NewDiscoveryLogger(filename string, config *Config) (*DiscoveryLogger, error) {
+	logger = &DiscoveryLogger{
+		config: config,
+	}
+
+	return logger.InitializeLog(filename)
 }
 
 // InitializeLog initializes the discovery log.
-func InitializeLog(filename string, config *Config) (*DiscoveryLogger, error) {
+func (l *DiscoveryLogger) InitializeLog(filename string) (*DiscoveryLogger, error) {
 
 	if logger != nil {
 		return nil, errors.Errorf("d3m system log already initialized")
 	}
 
 	// write the logs to the output log directory
-	csvFilename := path.Join(config.D3MOutputDir, "logs", filename)
+	csvFilename := path.Join(l.config.D3MOutputDir, "logs", filename)
 
 	// initialize the log with the header
 	err := util.WriteFileWithDirs(csvFilename, []byte("timestamp,feature_id,type,activity_l1,activity_l2,other\n"), os.ModePerm)
@@ -86,11 +96,9 @@ func InitializeLog(filename string, config *Config) (*DiscoveryLogger, error) {
 		return nil, errors.Wrap(err, "unable to initialize the activity log")
 	}
 
-	logger = &DiscoveryLogger{
-		csvFilename: csvFilename,
-	}
+	l.csvFilename = filename
 
-	return logger, nil
+	return l, nil
 }
 
 // LogDatamartActionGlobal logs a datamart fuction call to the discovery log.

--- a/api/env/log.go
+++ b/api/env/log.go
@@ -92,7 +92,7 @@ func (l *DiscoveryLogger) InitializeLog(filename string) (*DiscoveryLogger, erro
 		return nil, errors.Wrap(err, "unable to initialize the activity log")
 	}
 
-	l.csvFilename = filename
+	l.csvFilename = csvFilename
 
 	return l, nil
 }

--- a/api/env/log.go
+++ b/api/env/log.go
@@ -2,6 +2,7 @@ package env
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -99,31 +100,32 @@ func LogDatamartActionGlobal(feature string, activity string, subActivity string
 
 // LogSystemAction logs a system action to the discovery log.
 func (l *DiscoveryLogger) LogSystemAction(feature string, activity string, subActivity string) {
-	l.logAction(feature, "SYSTEM", activity, subActivity)
+	l.logAction(feature, "SYSTEM", activity, subActivity, nil)
 }
 
 // LogAPIAction logs a TA2TA3 API call to the discovery log.
-func (l *DiscoveryLogger) LogAPIAction(method string) {
+func (l *DiscoveryLogger) LogAPIAction(method string, params map[string]string) {
 	// look up the feature, the activity and sub activity based on the grpc method
 	feature := featureMap[method]
 	if feature == "" {
 		feature = method
 	}
-	l.logAction(feature, "TA2TA3", activityMap[method], subActivityMap[method])
+	l.logAction(feature, "TA2TA3", activityMap[method], subActivityMap[method], params)
 }
 
 // LogDatamartAction logs a datamart fuction call to the discovery log.
 func (l *DiscoveryLogger) LogDatamartAction(feature string, activity string, subActivity string) {
-	l.logAction(feature, "DATAMART", activity, subActivity)
+	l.logAction(feature, "DATAMART", activity, subActivity, nil)
 }
 
-func (l *DiscoveryLogger) logAction(feature string, typ string, activity string, subActivity string) {
+func (l *DiscoveryLogger) logAction(feature string, typ string, activity string, subActivity string, params map[string]string) {
 	timestamp := fmt.Sprintf(time.Now().Format(time.RFC3339))
+	paramsString, _ := json.Marshal(params)
 
 	mu.Lock()
 	defer mu.Unlock()
 	f, _ := os.OpenFile(l.csvFilename, os.O_WRONLY|os.O_APPEND, os.ModePerm)
 	w := csv.NewWriter(f)
-	w.Write([]string{timestamp, feature, typ, activity, subActivity, "{}"})
+	w.Write([]string{timestamp, feature, typ, activity, subActivity, string(paramsString)})
 	w.Flush()
 }

--- a/api/env/log.go
+++ b/api/env/log.go
@@ -83,10 +83,6 @@ func NewDiscoveryLogger(filename string, config *Config) (*DiscoveryLogger, erro
 // InitializeLog initializes the discovery log.
 func (l *DiscoveryLogger) InitializeLog(filename string) (*DiscoveryLogger, error) {
 
-	if logger != nil {
-		return nil, errors.Errorf("d3m system log already initialized")
-	}
-
 	// write the logs to the output log directory
 	csvFilename := path.Join(l.config.D3MOutputDir, "logs", filename)
 

--- a/api/routes/export.go
+++ b/api/routes/export.go
@@ -41,6 +41,9 @@ func ExportHandler(client *compute.Client, exportPath string, logger *env.Discov
 			log.Infof("Completed export request for %s", solutionID)
 		}
 
-		logger.InitializeLog("event-" + util.GenerateTimeFileNameStr() + ".csv")
+		err = logger.InitializeLog("event-" + util.GenerateTimeFileNameStr() + ".csv")
+		if err != nil {
+			log.Infof("error initializing log after export: %v", err)
+		}
 	}
 }

--- a/api/routes/export.go
+++ b/api/routes/export.go
@@ -22,12 +22,14 @@ import (
 	"goji.io/pat"
 
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
+	"github.com/uncharted-distil/distil/api/env"
+	"github.com/uncharted-distil/distil/api/util"
 	log "github.com/unchartedsoftware/plog"
 )
 
 // ExportHandler exports the caller supplied solution by calling through to the compute
 // server export functionality.
-func ExportHandler(client *compute.Client, exportPath string) func(http.ResponseWriter, *http.Request) {
+func ExportHandler(client *compute.Client, exportPath string, logger *env.DiscoveryLogger) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// extract route parameters
 		solutionID := pat.Param(r, "solution-id")
@@ -38,5 +40,7 @@ func ExportHandler(client *compute.Client, exportPath string) func(http.Response
 		} else {
 			log.Infof("Completed export request for %s", solutionID)
 		}
+
+		logger.InitializeLog("event-" + util.GenerateTimeFileNameStr() + ".csv")
 	}
 }

--- a/api/routes/export.go
+++ b/api/routes/export.go
@@ -41,7 +41,7 @@ func ExportHandler(client *compute.Client, exportPath string, logger *env.Discov
 			log.Infof("Completed export request for %s", solutionID)
 		}
 
-		err = logger.InitializeLog("event-" + util.GenerateTimeFileNameStr() + ".csv")
+		_, err = logger.InitializeLog("event-" + util.GenerateTimeFileNameStr() + ".csv")
 		if err != nil {
 			log.Infof("error initializing log after export: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 
 	// initialize the user event logger - records user interactions with the system in a CSV file for post-run
 	// analysis
-	discoveryLogger, err := env.InitializeLog("event-"+util.GenerateTimeFileNameStr()+".csv", &config)
+	discoveryLogger, err := env.NewDiscoveryLogger("event-"+util.GenerateTimeFileNameStr()+".csv", &config)
 	if err != nil {
 		log.Errorf("%+v", err)
 		os.Exit(1)
@@ -302,7 +302,7 @@ func main() {
 	registerRoute(mux, "/distil/variables/:dataset", routes.VariablesHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoute(mux, "/distil/variable-rankings/:dataset/:target", routes.VariableRankingHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoute(mux, "/distil/residuals-extrema/:dataset/:target", routes.ResidualsExtremaHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
-	registerRoute(mux, "/distil/export/:solution-id", routes.ExportHandler(solutionClient, config.D3MOutputDir))
+	registerRoute(mux, "/distil/export/:solution-id", routes.ExportHandler(solutionClient, config.D3MOutputDir, discoveryLogger))
 	registerRoute(mux, "/distil/config", routes.ConfigHandler(config, version, timestamp, problemPath, datasetDocPath))
 	registerRoute(mux, "/distil/task/:dataset/:target", routes.TaskHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor))


### PR DESCRIPTION
Fixes #1314 and fixes #1315 

Starts writing to a different file every time an export is done. Added solution id, fitted solution id and pipeline name to the TA2TA3 API logs.