### PR TITLE
Fixes for Row Selection & Feature Summary Update #1319

### DIFF
--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -40,6 +40,7 @@ export const actions = {
 		const solutionId = args.solutionId;
 
 		const promises = [];
+		mutations.clearTrainingSummaries(context);
 		args.training.forEach(variable => {
 			const key = variable.colName;
 			const label = variable.colDisplayName;

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -374,10 +374,14 @@ export function getTableDataItems(data: TableData): TableRow[] {
 			resultRow.forEach((colValue, colIndex) => {
 				const colName = data.columns[colIndex].key;
 				const colType = data.columns[colIndex].type;
-				row[colName] = {};
-				row[colName].value = formatValue(colValue.value, colType);
-				if (colValue.weight !== null && colValue.weight !== undefined) {
-					row[colName].weight = colValue.weight;
+				if (colName !== 'd3mIndex') {
+					row[colName] = {};
+					row[colName].value = formatValue(colValue.value, colType);
+					if (colValue.weight !== null && colValue.weight !== undefined) {
+						row[colName].weight = colValue.weight;
+					}
+				} else {
+					row[colName] = formatValue(colValue.value, colType);
 				}
 			});
 			row._key = rowIndex;


### PR DESCRIPTION
-Row Selection Now Works Again By Making d3mIndex a number again
-Feature Summaries Clear During Fetch instead of just patching in and retaining unused summaries.