### PR TITLE
Ingest image dataset

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -377,7 +377,7 @@ func persistOriginalData(params *persistedDataParams) (string, string, error) {
 	testSchemaFile := path.Join(testFolder, params.SchemaFile)
 
 	log.Infof("checking folders `%s` & `%s` to see if the dataset has been previously split", trainFolder, testFolder)
-	if fileExists(trainSchemaFile) && fileExists(testSchemaFile) {
+	if util.FileExists(trainSchemaFile) && util.FileExists(testSchemaFile) {
 		log.Infof("dataset '%s' already split", params.DatasetName)
 		return trainSchemaFile, testSchemaFile, nil
 	}

--- a/api/compute/problem_persist.go
+++ b/api/compute/problem_persist.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -28,6 +27,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/model"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/util"
 	log "github.com/unchartedsoftware/plog"
 )
 
@@ -107,17 +107,6 @@ type ProblemPersistExpectedOutput struct {
 	PredictionsFile string `json:"predictionsFile"`
 }
 
-func fileExists(filename string) bool {
-	_, err := os.Stat(filename)
-	if err == nil {
-		return true
-	}
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
-}
-
 // DefaultMetrics returns default metric for a given task.
 func DefaultMetrics(taskType string) []string {
 	return []string{compute.GetDefaultTaskMetricTA3(taskType)}
@@ -152,7 +141,7 @@ func CreateProblemSchema(datasetDir string, dataset string, targetVar *model.Var
 	// if so
 	pPath := path.Join(datasetDir, problemIDHash)
 	pFilePath := path.Join(pPath, D3MProblem)
-	if pathExists(pPath) && fileExists(pFilePath) {
+	if pathExists(pPath) && util.FileExists(pFilePath) {
 		log.Infof("Found stored problem for %s with hash %s", dataset, problemIDHash)
 		return nil, pPath, nil
 	}

--- a/api/routes/upload.go
+++ b/api/routes/upload.go
@@ -31,7 +31,10 @@ import (
 func UploadHandler(outputPath string, config *task.IngestTaskConfig) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		dataset := pat.Param(r, "dataset")
-		typ := pat.Param(r, "type")
+
+		// type cant be a post param since the upload is the actual data
+		queryValues := r.URL.Query()
+		typ := queryValues.Get("type")
 
 		var err error
 		formattedPath := ""

--- a/api/routes/upload.go
+++ b/api/routes/upload.go
@@ -31,20 +31,21 @@ import (
 func UploadHandler(outputPath string, config *task.IngestTaskConfig) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		dataset := pat.Param(r, "dataset")
+		typ := pat.Param(r, "type")
 
-		// read the file from the request
-		bytes, err := receiveFile(r)
+		var err error
+		formattedPath := ""
+		if typ == "table" {
+			formattedPath, err = uploadTableDataset(dataset, outputPath, config, r)
+		} else if typ == "image" {
+			formattedPath, err = uploadImageDataset(dataset, outputPath, config, r)
+		}
+
 		if err != nil {
-			handleError(w, errors.Wrap(err, "unable to receive file from request"))
+			handleError(w, errors.Wrap(err, "unable to upload dataset"))
 			return
 		}
 
-		// create the raw dataset schema doc
-		formattedPath, err := task.CreateDataset(dataset, bytes, outputPath, config)
-		if err != nil {
-			handleError(w, errors.Wrap(err, "unable to create dataset"))
-			return
-		}
 		log.Infof("uploaded new dataset %s at %s", dataset, formattedPath)
 		// marshal data and sent the response back
 		err = handleJSON(w, map[string]interface{}{"result": "uploaded"})
@@ -53,6 +54,52 @@ func UploadHandler(outputPath string, config *task.IngestTaskConfig) func(http.R
 			return
 		}
 	}
+}
+
+func uploadTableDataset(dataset string, outputPath string, config *task.IngestTaskConfig, r *http.Request) (string, error) {
+	// read the file from the request
+	bytes, err := receiveFile(r)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to receive file from request")
+	}
+
+	// create the raw dataset schema doc
+	formattedPath, err := task.CreateDataset(dataset, bytes, outputPath, config)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create dataset")
+	}
+
+	return formattedPath, nil
+}
+
+func uploadImageDataset(dataset string, outputPath string, config *task.IngestTaskConfig, r *http.Request) (string, error) {
+	// parse POST params
+	params, err := getPostParameters(r)
+	if err != nil {
+		return "", errors.Wrap(err, "Unable to parse post parameters")
+	}
+
+	foldersRaw, ok := params["folders"].([]interface{})
+	if !ok {
+		return "", errors.Errorf("unable to parse 'folders' parameter")
+	}
+
+	typ, ok := params["type"].(string)
+	if !ok {
+		return "", errors.Errorf("unable to parse 'type' parameter")
+	}
+	folders := make([]string, 0)
+	for _, f := range foldersRaw {
+		folders = append(folders, f.(string))
+	}
+
+	// create the raw dataset schema doc
+	formattedPath, err := task.CreateImageDataset(dataset, folders, typ, outputPath, config)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to create dataset")
+	}
+
+	return formattedPath, nil
 }
 
 func receiveFile(r *http.Request) ([]byte, error) {

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -108,8 +108,9 @@ func CreateImageDataset(dataset string, imageFolders []string, imageType string,
 			if path.Ext(imageFilename) != imageType {
 				imageFilename = fmt.Sprintf("%s.%s", imageFilename, imageType)
 			}
+			imageFilename = getUniqueName(path.Join(datasetFolder, mediaFolder, imageFilename))
 
-			err = util.Copy(path.Join(imageFolder, imageFile.Name()), getUniqueName(path.Join(datasetFolder, mediaFolder, imageFilename)))
+			err = util.Copy(path.Join(imageFolder, imageFile.Name()), imageFilename)
 			if err != nil {
 				return "", err
 			}
@@ -213,9 +214,11 @@ func getMediaFolder(refFolders []string) string {
 }
 
 func getUniqueName(filename string) string {
+	extension := path.Ext(filename)
+	baseFilename := strings.TrimSuffix(filename, extension)
 	currentFilename := filename
 	for i := 1; util.FileExists(currentFilename); {
-		currentFilename = fmt.Sprintf("%s_%d", filename, i)
+		currentFilename = fmt.Sprintf("%s_%d.%s", baseFilename, i, extension)
 	}
 
 	return currentFilename

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -16,8 +16,13 @@
 package task
 
 import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/uncharted-distil/distil-compute/model"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
@@ -25,6 +30,10 @@ import (
 	"github.com/uncharted-distil/distil-ingest/metadata"
 	api "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/util"
+)
+
+const (
+	baseMediaFolder = "media"
 )
 
 // CreateDataset structures a raw csv file into a valid D3M dataset.
@@ -71,6 +80,145 @@ func CreateDataset(dataset string, csvData []byte, outputPath string, config *In
 	}
 
 	return formattedPath, nil
+}
+
+// CreateImageDataset creates a D3M dataset from a collection of folders that
+// each contain images. The name of the folder represents the label to give
+// for the images within.
+func CreateImageDataset(dataset string, imageFolders []string, imageType string, outputPath string, config *IngestTaskConfig) (string, error) {
+	// generate all the image data for the csv table
+	csvData := make([][]string, 0)
+	csvData = append(csvData, []string{model.D3MIndexFieldName, "image_file", "label"})
+	mediaFolder := getMediaFolder(imageFolders)
+
+	// the folder name represents the label to apply for all containing images
+	for _, imageFolder := range imageFolders {
+		label := path.Base(imageFolder)
+		datasetFolder := path.Dir(imageFolder)
+
+		imageFiles, err := ioutil.ReadDir(imageFolder)
+		if err != nil {
+			return "", err
+		}
+
+		// copy images while building the csv data
+		d3mIndex := 0
+		for _, imageFile := range imageFiles {
+			imageFilename := imageFile.Name()
+			if path.Ext(imageFilename) != imageType {
+				imageFilename = fmt.Sprintf("%s.%s", imageFilename, imageType)
+			}
+
+			err = util.Copy(path.Join(imageFolder, imageFile.Name()), getUniqueName(path.Join(datasetFolder, mediaFolder, imageFilename)))
+			if err != nil {
+				return "", err
+			}
+
+			csvData = append(csvData, []string{fmt.Sprintf("%d", d3mIndex), imageFilename, label})
+		}
+	}
+
+	// create the data resource for the referenced images
+	refDR := model.NewDataResource("0", "image", []string{fmt.Sprintf("image/%s", imageType)})
+
+	// create the D3M dataset from the csv data
+	meta := createMetadata(dataset, config)
+
+	// add the image information
+	meta.DataResources = append(meta.DataResources, refDR)
+	meta.DataResources[0].Variables[1].RefersTo["resID"] = "0"
+	meta.DataResources[0].Variables[1].RefersTo["resObject"] = "item"
+
+	// write out the dataset
+	buf := bytes.NewBuffer(nil)
+	csvOutput := csv.NewWriter(buf)
+	err := csvOutput.WriteAll(csvData)
+	if err != nil {
+		return "", err
+	}
+
+	outputPathWritten, err := writeDataset(meta, buf.Bytes(), outputPath, config)
+	if err != nil {
+		return "", err
+	}
+
+	return outputPathWritten, nil
+}
+
+func writeDataset(meta *model.Metadata, csvData []byte, outputPath string, config *IngestTaskConfig) (string, error) {
+	// save the csv file in the file system datasets folder
+	outputDatasetPath := path.Join(outputPath, meta.Name)
+	dataFilePath := path.Join(compute.D3MDataFolder, compute.D3MLearningData)
+	dataPath := path.Join(outputDatasetPath, dataFilePath)
+	err := util.WriteFileWithDirs(dataPath, csvData, os.ModePerm)
+	if err != nil {
+		return "", err
+	}
+
+	schemaPath := path.Join(outputDatasetPath, compute.D3MDataSchema)
+	err = metadata.WriteSchema(meta, schemaPath)
+	if err != nil {
+		return "", err
+	}
+
+	// format the dataset into a D3M format
+	formattedPath, err := Format(metadata.Contrib, schemaPath, config)
+	if err != nil {
+		return "", err
+	}
+
+	// copy to the original output location for consistency
+	if formattedPath != outputDatasetPath {
+		err = os.RemoveAll(outputDatasetPath)
+		if err != nil {
+			return "", err
+		}
+
+		err = util.Copy(formattedPath, path.Dir(schemaPath))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return formattedPath, nil
+}
+
+func createMetadata(dataset string, config *IngestTaskConfig) *model.Metadata {
+	dataFilePath := path.Join(compute.D3MDataFolder, compute.D3MLearningData)
+
+	// create the raw dataset schema doc
+	datasetID := model.NormalizeDatasetID(dataset)
+	meta := model.NewMetadata(dataset, dataset, "", datasetID)
+	dr := model.NewDataResource("learningData", model.ResTypeRaw, []string{compute.D3MResourceFormat})
+	dr.ResPath = dataFilePath
+	meta.DataResources = []*model.DataResource{dr}
+
+	return meta
+}
+
+func getMediaFolder(refFolders []string) string {
+	duplicateCount := 0
+	for _, folder := range refFolders {
+		if strings.HasPrefix(folder, baseMediaFolder) {
+			duplicateCount = duplicateCount + 1
+		}
+	}
+
+	mediaFolder := baseMediaFolder
+	if duplicateCount > 0 {
+		mediaFolder = fmt.Sprintf("%s_%d", mediaFolder, duplicateCount)
+	}
+
+	return mediaFolder
+}
+
+func getUniqueName(filename string) string {
+	currentFilename := filename
+	for i := 1; util.FileExists(currentFilename); {
+		currentFilename = fmt.Sprintf("%s_%d", filename, i)
+	}
+
+	return currentFilename
 }
 
 // UpdateExtremas will update every field's extremas in the specified dataset.

--- a/api/util/file.go
+++ b/api/util/file.go
@@ -213,3 +213,15 @@ func GenerateTimeFileNameStr() string {
 	timeStr = strings.ReplaceAll(timeStr, "-", "")
 	return timeStr
 }
+
+// FileExists checks if a file already exists on disk.
+func FileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Added ability to format images into a d3m dataset. The input is assumed to be a series of folders containing images. The name of the folder denotes the label to use for images contained within. The output will be in d3m format, with all images copied to a single folder.