### PR TITLE
SHAP weight display #1278

### DIFF
--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -82,7 +82,7 @@ import { Solution } from '../store/solutions/index';
 import { Dictionary } from '../util/dict';
 import { getVarType, isTextType, IMAGE_TYPE, hasComputedVarPrefix } from '../util/types';
 import { addRowSelection, removeRowSelection, isRowSelected, updateTableRowSelection } from '../util/row';
-import { getTimeseriesGroupingsFromFields, formatSlot, formatFieldsAsArray, getCellColorByWeight } from '../util/data';
+import { getTimeseriesGroupingsFromFields, formatSlot, formatFieldsAsArray } from '../util/data';
 
 export default Vue.extend({
 	name: 'results-data-table',
@@ -220,6 +220,15 @@ export default Vue.extend({
 			}
 			return false;
 		},
+		columnWeightExtrema(): Object {
+			return this.tableFields.reduce((weightExtrema, tableCol) => {
+				weightExtrema[tableCol.key] = this.dataItems.reduce((maxWeight, item) => {
+					const currentWeight = Math.abs(item[tableCol.key].weight);
+					return maxWeight > currentWeight ? currentWeight : maxWeight;
+				}, 0);
+				return weightExtrema;
+			}, {});
+		}
 	},
 
 	updated() {
@@ -290,8 +299,15 @@ export default Vue.extend({
 			return hs;
 		},
 
-		cellColor(weight: number): string {
-			return getCellColorByWeight(weight, 0, 1);
+		cellColor(weight: number, data: any): string {
+			if (!weight) {
+				return '';
+			}
+			const absoluteWeight = Math.abs(weight / (this.columnWeightExtrema[data.field.key]));
+			const red = 255 - 128 * absoluteWeight;
+			const green = 255 - 64 * absoluteWeight;
+			const blue = 255;
+			return `background: rgba(${red}, ${green}, ${blue}, .75)`;
 		}
 	}
 

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -230,20 +230,6 @@ export function formatSlot(key: string, slotType: string): string {
 	return `${slotType}(${key})`;
 }
 
-export function getCellColorByWeight(weight: number, min: number, max: number): string {
-	if (!weight) {
-		return '';
-	}
-	const absMin = Math.abs(min);
-	const absMax = Math.abs(max);
-	const trueMax = Math.max(absMin, absMax);
-	const absoluteWeight = Math.abs(weight / trueMax);
-	const red = 255 - 128 * absoluteWeight;
-	const green = 255 - 64 * absoluteWeight;
-	const blue = 255;
-	return `background: rgb(${red}, ${green}, ${blue})`;
-}
-
 export function formatFieldsAsArray(fields: Dictionary<TableColumn>): TableColumn[] {
 	return _.map(fields, field => field);
 }


### PR DESCRIPTION
Moved the draft cell coloring back into Result Table View as it's probably the only place we'll use it for the forseeable future and since some of the math I thought we'd want it to do was instead handle by a new computed property which grabs the weight extrema from the data available to the table to use as a base for the cell color function.