### PR TITLE
#1306 Facet Highlight Fix

### DIFF
--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -178,6 +178,8 @@ export default Vue.extend({
 		this.facets.on('facet-histogram:mouseleave', (event: Event, key: string, value: string) => {
 			$(this.$el).find('.facet-tooltip').hide();
 		});
+
+		this.injectHighlights(this.highlight, this.rowSelection, this.deemphasis);
 	},
 
 	computed: {


### PR DESCRIPTION
Highlight injection function was seemingly omitted from being called when the facet is mounted - I suspect it's a hangover from prior facet refactors, and it was definitely another side effect from the vue/jquery mix in facets currently.