### PR TITLE
Update Schema Version

### DIFF
--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -52,7 +52,7 @@ func CreateDataset(dataset string, csvData []byte, outputPath string, config *In
 	// create the raw dataset schema doc
 	datasetID := model.NormalizeDatasetID(dataset)
 	meta := model.NewMetadata(dataset, dataset, "", datasetID)
-	dr := model.NewDataResource("learningData", model.ResTypeRaw, []string{compute.D3MResourceFormat})
+	dr := model.NewDataResource("learningData", model.ResTypeRaw, map[string][]string{compute.D3MResourceFormat: {"csv"}})
 	dr.ResPath = dataFilePath
 	meta.DataResources = []*model.DataResource{dr}
 
@@ -156,7 +156,7 @@ func CreateImageDataset(dataset string, data []byte, imageType string, outputPat
 	// create the dataset schema doc
 	datasetID := model.NormalizeDatasetID(dataset)
 	meta := model.NewMetadata(dataset, dataset, "", datasetID)
-	dr := model.NewDataResource("learningData", model.ResTypeTable, []string{compute.D3MResourceFormat})
+	dr := model.NewDataResource("learningData", model.ResTypeTable, map[string][]string{compute.D3MResourceFormat: {"csv"}})
 	dr.ResPath = dataFilePath
 	dr.Variables = append(dr.Variables,
 		model.NewVariable(0, model.D3MIndexFieldName, model.D3MIndexFieldName,
@@ -173,7 +173,7 @@ func CreateImageDataset(dataset string, data []byte, imageType string, outputPat
 			model.VarRoleData, nil, dr.Variables, false))
 
 	// create the data resource for the referenced images
-	refDR := model.NewDataResource("0", model.ResTypeImage, []string{fmt.Sprintf("image/%s", imageType)})
+	refDR := model.NewDataResource("0", model.ResTypeImage, map[string][]string{fmt.Sprintf("image/%s", imageType): {"jpeg", "jpg"}})
 	refDR.ResPath = path.Base(mediaFolder)
 
 	meta.DataResources = []*model.DataResource{refDR, dr}
@@ -244,7 +244,7 @@ func createMetadata(dataset string, config *IngestTaskConfig) *model.Metadata {
 	// create the raw dataset schema doc
 	datasetID := model.NormalizeDatasetID(dataset)
 	meta := model.NewMetadata(dataset, dataset, "", datasetID)
-	dr := model.NewDataResource("learningData", model.ResTypeRaw, []string{compute.D3MResourceFormat})
+	dr := model.NewDataResource("learningData", model.ResTypeRaw, map[string][]string{compute.D3MResourceFormat: {"csv"}})
 	dr.ResPath = dataFilePath
 	meta.DataResources = []*model.DataResource{dr}
 

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -172,7 +172,7 @@ func createDatasetFromCSV(config *env.Config, csvFile *os.File, datasetName stri
 	}
 
 	metadata := model.NewMetadata(datasetName, datasetName, datasetName, model.NormalizeDatasetID(datasetName))
-	dataResource := model.NewDataResource("learningData", compute.D3MResourceType, []string{compute.D3MResourceFormat})
+	dataResource := model.NewDataResource("learningData", compute.D3MResourceType, map[string][]string{compute.D3MResourceFormat: {"csv"}})
 
 	mergedVariables, err := createMergedVariables(fields, leftVarsMap, rightVarsMap)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,9 @@ require (
 	github.com/shopspring/decimal v0.0.0-20191009025716-f1972eb1d1f5 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/uncharted-distil/distil-compute v0.0.0-20191117195530-94b082255c3d
-	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191126210429-c33b22007657
+	github.com/uncharted-distil/distil-compute v0.0.0-20191129202341-b4581e1ee4f9
+	github.com/uncharted-distil/distil-ingest v0.1.0 // indirect
+	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191129203607-2718e91e6e9d
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
 	github.com/zenazn/goji v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,14 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/uncharted-distil/distil-compute v0.0.0-20191117195530-94b082255c3d h1:ukHugidoUEos0vKsQSmp9BA0XjopubJv6s5yz4jYTOs=
 github.com/uncharted-distil/distil-compute v0.0.0-20191117195530-94b082255c3d/go.mod h1:BUuePSuFH+bCaZnMQz8n86y8f8nYtXxT6LEli8Hq4Zw=
+github.com/uncharted-distil/distil-compute v0.0.0-20191129202341-b4581e1ee4f9 h1:Tb/PtiVIqSSssd91NzIuwqKNaV8bPBcccvSVb+jTKL4=
+github.com/uncharted-distil/distil-compute v0.0.0-20191129202341-b4581e1ee4f9/go.mod h1:BUuePSuFH+bCaZnMQz8n86y8f8nYtXxT6LEli8Hq4Zw=
+github.com/uncharted-distil/distil-ingest v0.1.0 h1:LTmn7ov4q8u7P91MrWKL4HtcAiyeoo8vYQXh/8/82dk=
+github.com/uncharted-distil/distil-ingest v0.1.0/go.mod h1:5QEyGfC8H6bpwOIGlU95DD1toI+Qg/hVjnnr4sIoBOE=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191126210429-c33b22007657 h1:CqnCFqyp58GM+T3dilxA6BWRUXA6swN3f5XdCKAACIU=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191126210429-c33b22007657/go.mod h1:JH/BMJRev35h1jQFR4pK3zQ9WYXYgUMgGBP3rF5I5aw=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191129203607-2718e91e6e9d h1:5drR+FabuPmzaX47TaK3+HdGSBXyfQ6iFeGm9s3NQxU=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191129203607-2718e91e6e9d/go.mod h1:XM+QHXV9c9jSTfgqElFdikunokU+lUn4tpbfuZFrX6E=
 github.com/uncharted-distil/distil-ingest/pkg v1.10.10 h1:kG4+xIGXqkTnnKOYKlfmAOkZP4f0DZRheIhLvFnk3Js=
 github.com/uncharted-distil/distil-ingest/pkg v1.10.10/go.mod h1:JH/BMJRev35h1jQFR4pK3zQ9WYXYgUMgGBP3rF5I5aw=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=


### PR DESCRIPTION
Switches distil to run on 4.0 of the schema. The only difference is in how data resource formats are structured. Also needed to bump ingest and compute references.