### PR TITLE
#1343 - table updating geocoordinate fix

### DIFF
--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -495,8 +495,10 @@ export function getTableDataFields(data: TableData): Dictionary<TableColumn> {
         description = `Difference between actual and predicted value for ${variable.colName}`;
       } else {
         variable = variables[col.key];
-        label = col.label;
-        description = variable.colDescription;
+        if (variable) {
+          label = col.label;
+          description = variable.colDescription;
+        }
       }
 
       if (col.type === TIMESERIES_TYPE) {


### PR DESCRIPTION
Issue was with the look up for variable descriptions used in table tooltips failing when, in the case of geocoordinate, we're looking for a description for a column we've since combined into the geocoordinate. The solution was to check the variable look up worked before trying to pull the description out of the variable. Only side effect is there's no description for that half of the geocoordinate variable in the table, but this behavior was okayed.