### PR TITLE
Create Dataset From CSV File

### DIFF
--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -36,38 +36,41 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 		datasetID := pat.Param(r, "datasetID")
 		source := metadata.DatasetSource(pat.Param(r, "source"))
 		provenance := pat.Param(r, "provenance")
-		// parse POST params
-		params, err := getPostParameters(r)
-		if err != nil {
-			handleError(w, errors.Wrap(err, "Unable to parse post parameters"))
-			return
-		}
 
-		if params == nil {
-			missingParamErr(w, "parameters")
-			return
-		}
-
-		if params["originalDataset"] == nil {
-			missingParamErr(w, "originalDataset")
-			return
-		}
-
-		if params["joinedDataset"] == nil {
-			missingParamErr(w, "joinedDataset")
-			return
-		}
-
-		// set the origin information
 		var origins []*model.DatasetOrigin
-		originalDataset, okOriginal := params["originalDataset"].(map[string]interface{})
-		joinedDataset, okJoined := params["joinedDataset"].(map[string]interface{})
-		if okOriginal && okJoined {
-			// combine the origin and joined dateset into an array of structs
-			origins, err = getOriginsFromMaps(originalDataset, joinedDataset)
+		if source == metadata.Augmented && provenance != "local" {
+			// parse POST params
+			params, err := getPostParameters(r)
 			if err != nil {
-				handleError(w, errors.Wrap(err, "unable marshal dataset origins from JSON to struct"))
+				handleError(w, errors.Wrap(err, "Unable to parse post parameters"))
 				return
+			}
+
+			if params == nil {
+				missingParamErr(w, "parameters")
+				return
+			}
+
+			if params["originalDataset"] == nil {
+				missingParamErr(w, "originalDataset")
+				return
+			}
+
+			if params["joinedDataset"] == nil {
+				missingParamErr(w, "joinedDataset")
+				return
+			}
+
+			// set the origin information
+			originalDataset, okOriginal := params["originalDataset"].(map[string]interface{})
+			joinedDataset, okJoined := params["joinedDataset"].(map[string]interface{})
+			if okOriginal && okJoined {
+				// combine the origin and joined dateset into an array of structs
+				origins, err = getOriginsFromMaps(originalDataset, joinedDataset)
+				if err != nil {
+					handleError(w, errors.Wrap(err, "unable marshal dataset origins from JSON to struct"))
+					return
+				}
 			}
 		}
 		// update ingest config to use ingest URI.

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -201,7 +201,7 @@ func Ingest(originalSchemaFile string, schemaFile string, storage api.MetadataSt
 
 	err = metadata.LoadImportance(meta, path.Join(datasetDir, config.RankingOutputPathRelative))
 	if err != nil {
-		return "", errors.Wrap(err, "unable to load importance from file")
+		log.Warnf("unable to load importance from file: %v", err)
 	}
 
 	// load stats


### PR DESCRIPTION
Fixes #1341 

Local provenance will skip the dataset origins building when importing a dataset. The process to import from a local file is to use the upload route, then the import route with the source as `augmented` and the provenance as `local`.