### PR TITLE
#1353 - fix regression type detection

### DIFF
--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -114,7 +114,8 @@ export default Vue.extend({
     },
 
     regressionEnabled(): boolean {
-      return routeGetters.getRouteTask(this.$store) === TaskTypes.REGRESSION;
+      const tasks = routeGetters.getRouteTask(this.$store).split(',');
+      return tasks.indexOf(TaskTypes.REGRESSION) > -1;
     },
 
     solutionId(): string {


### PR DESCRIPTION
The regression enabled function upon which error bounding depends expected task type to only ever be a single item, not multiple (like "?type=regression,univariate",) so it broke. Fix is just to split up the return from the route task getter and then see if there's regression in that set.