### PR TITLE
Ensures pipeilnes without explain support still run

### DIFF
--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -16,7 +16,6 @@
 package compute
 
 import (
-	"context"
 	"fmt"
 	"path"
 	"strconv"
@@ -36,17 +35,12 @@ var (
 	explainablePrimitives = map[string]bool{"e0ad06ce-b484-46b0-a478-c567e1ea7e02": true}
 )
 
-func (s *SolutionRequest) createExplainPipeline(client *compute.Client, solutionID string) (*pipeline.PipelineDescription, error) {
-	// get the pipeline description
-	desc, err := client.GetSolutionDescription(context.Background(), solutionID)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get solution description")
-	}
-
+func (s *SolutionRequest) createExplainPipeline(client *compute.Client, desc *pipeline.DescribeSolutionResponse) (*pipeline.PipelineDescription, error) {
 	// cycle through the description to determine if any primitive can be explained
-	_, pipExplain := s.explainablePipeline(desc)
-
-	return pipExplain, nil
+	if ok, pipExplain := s.explainablePipeline(desc); ok {
+		return pipExplain, nil
+	}
+	return nil, nil
 }
 
 func (s *SolutionRequest) explainOutput(resultURI string, datasetURITest string, outputURI string) (*api.SolutionFeatureWeights, error) {

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -464,16 +464,28 @@ func (s *SolutionRequest) dispatchSolution(statusChan chan SolutionStatus, clien
 	dataStorage api.DataStorage, initialSearchID string, initialSearchSolutionID string, dataset string, searchRequest *pipeline.SearchSolutionsRequest,
 	datasetURITrain string, datasetURITest string, variables []*model.Variable) {
 
-	// Need to create a new solution that has the explain output. This is the solution
-	// that will be used throughout distil except for the export (which will use the original solution).
-	// start a solution searchID
-	explainDesc, err := s.createExplainPipeline(client, initialSearchSolutionID)
+	desc, err := client.GetSolutionDescription(context.Background(), initialSearchSolutionID)
 	if err != nil {
 		s.persistSolutionError(statusChan, solutionStorage, initialSearchID, initialSearchSolutionID, err)
 		return
 	}
 
-	searchRequest.Template = explainDesc
+	// Need to create a new solution that has the explain output. This is the solution
+	// that will be used throughout distil except for the export (which will use the original solution).
+	// start a solution searchID
+	// get the pipeline description
+	explainDesc, err := s.createExplainPipeline(client, desc)
+	if err != nil {
+		s.persistSolutionError(statusChan, solutionStorage, initialSearchID, initialSearchSolutionID, err)
+		return
+	}
+
+	// Use the updated explain pipeline if it exists, otherwise use the baseline pipeline
+	if explainDesc != nil {
+		searchRequest.Template = explainDesc
+	} else {
+		searchRequest.Template = desc.GetPipeline()
+	}
 
 	searchID, err := client.StartSearch(context.Background(), searchRequest)
 	if err != nil {
@@ -542,8 +554,13 @@ func (s *SolutionRequest) dispatchSolution(statusChan chan SolutionStatus, clien
 		s.persistSolutionStatus(statusChan, solutionStorage, initialSearchID, initialSearchSolutionID, SolutionRunningStatus)
 		//s.persistSolutionStatus(statusChan, solutionStorage, searchID, solutionID, SolutionRunningStatus)
 
+		// generate output keys, adding one extra for explanation output if we expect it to exist
+		outputKeys := []string{defaultExposedOutputKey}
+		if explainDesc != nil {
+			outputKeys = append(outputKeys, explainOutputkey)
+		}
 		// generate predictions
-		produceSolutionRequest := s.createProduceSolutionRequest(datasetURITest, fittedSolutionID, []string{defaultExposedOutputKey, explainOutputkey})
+		produceSolutionRequest := s.createProduceSolutionRequest(datasetURITest, fittedSolutionID, outputKeys)
 
 		// generate predictions
 		predictionResponses, err := client.GeneratePredictions(context.Background(), produceSolutionRequest)


### PR DESCRIPTION
1. Ensures that when a pipeline doesn't have explain support it falsl back to the original pipeline. 
1. Adds a check when specifying exposed outputs to ensure that unexplained pipelines only request output 0.