### PR TITLE
Solution level weight

### DIFF
--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -26,6 +26,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/model"
 	"github.com/uncharted-distil/distil-compute/pipeline"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
+	"github.com/uncharted-distil/distil-compute/primitive/compute/result"
 	"github.com/uncharted-distil/distil-ingest/pkg/metadata"
 
 	api "github.com/uncharted-distil/distil/api/model"
@@ -33,7 +34,8 @@ import (
 )
 
 var (
-	explainablePrimitives = map[string]bool{"e0ad06ce-b484-46b0-a478-c567e1ea7e02": true}
+	explainablePrimitivesSolution = map[string]bool{"e0ad06ce-b484-46b0-a478-c567e1ea7e02": true}
+	explainablePrimitivesStep     = map[string]bool{"e0ad06ce-b484-46b0-a478-c567e1ea7e02": true}
 )
 
 func (s *SolutionRequest) createExplainPipeline(client *compute.Client, solutionID string) (*pipeline.PipelineDescription, error) {
@@ -49,7 +51,7 @@ func (s *SolutionRequest) createExplainPipeline(client *compute.Client, solution
 	return pipExplain, nil
 }
 
-func (s *SolutionRequest) explainOutput(resultURI string, datasetURITest string, outputURI string) (*api.SolutionFeatureWeights, error) {
+func (s *SolutionRequest) explainFeatureOutput(resultURI string, datasetURITest string, outputURI string) (*api.SolutionFeatureWeights, error) {
 	// get the d3m index lookup
 	rawData, err := readDatasetData(datasetURITest)
 	if err != nil {
@@ -59,7 +61,7 @@ func (s *SolutionRequest) explainOutput(resultURI string, datasetURITest string,
 	d3mIndexLookup := mapRowIndex(d3mIndexField, rawData[1:])
 
 	// parse the output for the explanations
-	parsed, err := s.parseSolutionFeatureWeight(resultURI, outputURI, d3mIndexLookup)
+	parsed, err := s.parseFeatureWeight(resultURI, outputURI, d3mIndexLookup)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to parse feature weight output")
 	}
@@ -67,7 +69,33 @@ func (s *SolutionRequest) explainOutput(resultURI string, datasetURITest string,
 	return parsed, nil
 }
 
-func (s *SolutionRequest) parseSolutionFeatureWeight(resultURI string, outputURI string, d3mIndexLookup map[int]string) (*api.SolutionFeatureWeights, error) {
+func (s *SolutionRequest) explainSolutionOutput(resultURI string, outputURI string,
+	solutionID string, variables []*model.Variable) ([]*api.SolutionWeight, error) {
+
+	// parse the output for the explanations
+	parsed, err := s.parseSolutionWeight(solutionID, outputURI)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse feature weight output")
+	}
+
+	// map column name to get the feature index
+	varsMapped := make(map[string]*model.Variable)
+	for _, v := range variables {
+		varsMapped[v.Name] = v
+	}
+
+	output := make([]*api.SolutionWeight, 0)
+	for _, fw := range parsed {
+		if varsMapped[fw.FeatureName] != nil {
+			fw.FeatureIndex = int64(varsMapped[fw.FeatureName].Index)
+			output = append(output, fw)
+		}
+	}
+
+	return output, nil
+}
+
+func (s *SolutionRequest) parseFeatureWeight(resultURI string, outputURI string, d3mIndexLookup map[int]string) (*api.SolutionFeatureWeights, error) {
 	// all results on one row, with header row having feature names
 	res, err := util.ReadCSVFile(outputURI, false)
 	if err != nil {
@@ -86,37 +114,75 @@ func (s *SolutionRequest) parseSolutionFeatureWeight(resultURI string, outputURI
 	}, nil
 }
 
+func (s *SolutionRequest) parseSolutionWeight(solutionID string, outputURI string) ([]*api.SolutionWeight, error) {
+	// all results on one row, with header row having feature names
+	res, err := result.ParseResultCSV(outputURI)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read solution weight output")
+	}
+
+	weights := make([]*api.SolutionWeight, len(res[0]))
+	for i := 0; i < len(res[0]); i++ {
+		weight, err := strconv.ParseFloat(res[1][i].(string), 64)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to parse feature weight")
+		}
+		featureName := res[0][i].(string)
+		weights[i] = &api.SolutionWeight{
+			SolutionID:  solutionID,
+			FeatureName: featureName,
+			Weight:      weight,
+		}
+	}
+
+	return weights, nil
+}
+
 func (s *SolutionRequest) explainablePipeline(solutionDesc *pipeline.DescribeSolutionResponse) (bool, *pipeline.PipelineDescription) {
 	pipelineDesc := solutionDesc.Pipeline
 	explainStep := -1
+	explainSolution := -1
 	for si, ps := range pipelineDesc.Steps {
 		// get the step outputs
 		primitive := ps.GetPrimitive()
 		if primitive != nil {
-			if s.isExplainablePrimitive(primitive.Primitive.Id) {
+			if s.isExplainablePrimitiveStep(primitive.Primitive.Id) {
 				primitive.Outputs = append(primitive.Outputs, &pipeline.StepOutput{
 					Id: "produce_shap_values",
 				})
 				explainStep = si
-				break
+			}
+			if s.isExplainablePrimitiveSolution(primitive.Primitive.Id) {
+				primitive.Outputs = append(primitive.Outputs, &pipeline.StepOutput{
+					Id: "produce_feature_importances",
+				})
+				explainSolution = si
 			}
 		}
 	}
 
-	if explainStep < 0 {
-		return false, nil
+	if explainStep >= 0 {
+		pipelineDesc.Outputs = append(pipelineDesc.Outputs, &pipeline.PipelineDescriptionOutput{
+			Name: "explain_step",
+			Data: fmt.Sprintf("steps.%d.produce_shap_values", explainStep),
+		})
 	}
-	//pipelineDesc.Steps = pipelineDesc.Steps[0 : explainStep+1]
-	pipelineDesc.Outputs = append(pipelineDesc.Outputs, &pipeline.PipelineDescriptionOutput{
-		Name: "explain",
-		Data: fmt.Sprintf("steps.%d.produce_shap_values", explainStep),
-	})
+	if explainSolution >= 0 {
+		pipelineDesc.Outputs = append(pipelineDesc.Outputs, &pipeline.PipelineDescriptionOutput{
+			Name: "explain_solution",
+			Data: fmt.Sprintf("steps.%d.produce_feature_importances", explainStep),
+		})
+	}
 
-	return true, pipelineDesc
+	return explainSolution >= 0 || explainStep >= 0, pipelineDesc
 }
 
-func (s *SolutionRequest) isExplainablePrimitive(primitive string) bool {
-	return explainablePrimitives[primitive]
+func (s *SolutionRequest) isExplainablePrimitiveStep(primitive string) bool {
+	return explainablePrimitivesStep[primitive]
+}
+
+func (s *SolutionRequest) isExplainablePrimitiveSolution(primitive string) bool {
+	return explainablePrimitivesSolution[primitive]
 }
 
 func mapRowIndex(d3mIndexCol int, data [][]string) map[int]string {

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -88,6 +88,14 @@ type SolutionFeatureWeight struct {
 	Weights   map[string]float64
 }
 
+// SolutionWeight captures the weights for a given d3m index and result.
+type SolutionWeight struct {
+	SolutionID   string
+	FeatureIndex int64
+	FeatureName  string
+	Weight       float64
+}
+
 // SolutionResult represents the solution result metadata.
 type SolutionResult struct {
 	FittedSolutionID string    `json:"fittedSolutionId"`

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -66,6 +66,7 @@ type SolutionStorage interface {
 	PersistRequestFeature(requestID string, featureName string, featureType string) error
 	PersistRequestFilters(requestID string, filters *FilterParams) error
 	PersistSolution(requestID string, solutionID string, initialSearchSolutionID string, createdTime time.Time) error
+	PersistSolutionWeight(solutionID string, featureName string, featureIndex int64, weight float64) error
 	PersistSolutionState(solutionID string, progress string, createdTime time.Time) error
 	PersistSolutionResult(solutionID string, fittedSolutionID, resultUUID string, resultURI string, progress string, createdTime time.Time) error
 	PersistSolutionScore(solutionID string, metric string, score float64) error
@@ -76,6 +77,7 @@ type SolutionStorage interface {
 	FetchRequestFeatures(requestID string) ([]*Feature, error)
 	FetchRequestFilters(requestID string, features []*Feature) (*FilterParams, error)
 	FetchSolution(solutionID string) (*Solution, error)
+	FetchSolutionWeights(solutionID string) ([]*SolutionWeight, error)
 	FetchSolutionResultByUUID(resultUUID string) (*SolutionResult, error)
 	FetchSolutionResult(solutionID string) (*SolutionResult, error)
 	FetchSolutionScores(solutionID string) ([]*SolutionScore, error)

--- a/api/model/storage/postgres/storage.go
+++ b/api/model/storage/postgres/storage.go
@@ -24,7 +24,7 @@ const (
 	requestTableName               = "request"
 	solutionTableName              = "solution"
 	solutionStateTableName         = "solution_state"
-	solutionFeatureWeightTableName = "solution_feature"
+	solutionFeatureWeightTableName = "solution_weight"
 	solutionResultTableName        = "solution_result"
 	solutionScoreTableName         = "solution_score"
 	featureTableName               = "request_feature"

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/uncharted-distil/distil-compute v0.0.0-20191205055858-6ec2122c50c3
-	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191205150232-3bc3ed209a09
+	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191205173026-dac646b805ff
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
 	github.com/zenazn/goji v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191204205000-0faf4023137c
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191204205000-0faf4023137c/go.mod h1:CJwk9IBthJgtSkcukJt88zT8OClGCTklIkke/wSxrqQ=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191205150232-3bc3ed209a09 h1:cDAthV/TWMiXTW6SWanpSw8VjHb4WsBTsWD/AG59aAc=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191205150232-3bc3ed209a09/go.mod h1:7b5+nzqxUcp9U9nXAsrcY0B76wq32jbkZANdOCCuV3g=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191205173026-dac646b805ff h1:tcp9ITQHm3Faod+3DtgoFMdVXIR/f4MheA4UYXXvpEQ=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191205173026-dac646b805ff/go.mod h1:7b5+nzqxUcp9U9nXAsrcY0B76wq32jbkZANdOCCuV3g=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9/go.mod h1:PrytgQ5GjTc6Z5/pbL5vj1UhD716wDobDeimrd7lRKY=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48 h1:XYef2jcFEKziHl4rv/21jrNeQg6Z3gL345u16fHWVDo=

--- a/main.go
+++ b/main.go
@@ -299,7 +299,7 @@ func main() {
 	registerRoute(mux, "/distil/join-suggestions/:dataset", routes.JoinSuggestionHandler(esMetadataStorageCtor, datamartCtors))
 	registerRoute(mux, "/distil/solutions/:dataset/:target/:solution-id", routes.SolutionHandler(pgSolutionStorageCtor))
 	registerRoute(mux, "/distil/variables/:dataset", routes.VariablesHandler(esMetadataStorageCtor, pgDataStorageCtor))
-	registerRoute(mux, "/distil/variable-rankings/:dataset/:target", routes.VariableRankingHandler(esMetadataStorageCtor, pgDataStorageCtor))
+	registerRoute(mux, "/distil/variable-rankings/:dataset/:target", routes.VariableRankingHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoute(mux, "/distil/residuals-extrema/:dataset/:target", routes.ResidualsExtremaHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoute(mux, "/distil/export/:solution-id", routes.ExportHandler(solutionClient, config.D3MOutputDir, discoveryLogger))
 	registerRoute(mux, "/distil/config", routes.ConfigHandler(config, version, timestamp, problemPath, datasetDocPath))


### PR DESCRIPTION
Fixes #1327 

Adds a third output to a pipeline to produce the overall feature weights and stores them to postgres. The variable rankings route accepts a solution id param, and when provided the solution weights will be used instead of MI.