### PR TITLE
#1351 - Call Refresh On WebSocket Close

### DIFF
--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -226,7 +226,8 @@ export default Vue.extend({
           metrics: this.metrics,
           maxSolutions: NUM_SOLUTIONS,
           // intentionally nulled for now - should be made user settable in the future
-          maxTime: null
+          maxTime: null,
+          onClose: ()=> { this.$router.go(0) }
         })
         .then((res: Solution) => {
           this.pending = false;

--- a/public/store/solutions/actions.ts
+++ b/public/store/solutions/actions.ts
@@ -29,6 +29,7 @@ interface CreateSolutionRequest {
   maxSolutions: number;
   maxTime: number;
   filters: FilterParams;
+  onClose: Function;
 }
 
 interface SolutionStatus {
@@ -313,6 +314,7 @@ export const actions = {
           }
           // close stream
           stream.close();
+          request.onClose();
         }
       });
 


### PR DESCRIPTION
added a callback to be called on web socket close, which I then I populated in the call from the create solutions from view with a simple vue router refresh via the $router.go function. It's not the the most elegant solution, but I should be fairly robust to changes in the pipeline messaging, since so long as the pipeline closes after we navigate to the results view, we're safe to refresh.