### PR TITLE
#1345 Filtering Reload Fix

### DIFF
--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -60,7 +60,20 @@ export const actions = {
     const solutionId = args.solutionId;
 
     const promises = [];
-    mutations.clearTrainingSummaries(context);
+
+    // remove summaries not used to predict the newly selected model
+    context.state.trainingSummaries.forEach(v => {
+      const isTrainingArg = args.training.reduce((isTrain, variable) => {
+        if (!isTrain) {
+          isTrain = variable.colName === v.key;
+        }
+        return isTrain;
+      }, false);
+      if(v.dataset !== args.dataset || !isTrainingArg) {
+        mutations.removeTrainingSummary(context, v);
+      };
+    });
+
     args.training.forEach(variable => {
       const key = variable.colName;
       const label = variable.colDisplayName;

--- a/public/store/results/module.ts
+++ b/public/store/results/module.ts
@@ -87,6 +87,7 @@ export const mutations = {
   clearTargetSummary: commit(moduleMutations.clearTargetSummary),
   updateTrainingSummary: commit(moduleMutations.updateTrainingSummary),
   updateTargetSummary: commit(moduleMutations.updateTargetSummary),
+  removeTrainingSummary: commit(moduleMutations.removeTrainingSummary),
   // result
   setIncludedResultTableData: commit(
     moduleMutations.setIncludedResultTableData

--- a/public/store/results/mutations.ts
+++ b/public/store/results/mutations.ts
@@ -2,7 +2,7 @@ import Vue from "vue";
 import _ from "lodash";
 import { ResultsState } from "./index";
 import { VariableSummary, Extrema, TableData } from "../dataset/index";
-import { updateSummaries } from "../../util/data";
+import { updateSummaries, removeSummary } from "../../util/data";
 
 export const mutations = {
   // training / target
@@ -17,6 +17,10 @@ export const mutations = {
 
   updateTrainingSummary(state: ResultsState, summary: VariableSummary) {
     updateSummaries(summary, state.trainingSummaries);
+  },
+
+  removeTrainingSummary(state: ResultsState, summary: VariableSummary) {
+    removeSummary(summary, state.trainingSummaries);
   },
 
   updateTargetSummary(state: ResultsState, summary: VariableSummary) {

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -257,6 +257,18 @@ export function updateSummaries(
   }
 }
 
+export function removeSummary(
+  summary: VariableSummary,
+  summaries: VariableSummary[]
+) {
+  const index = _.findIndex(summaries, s => {
+    return s.dataset === summary.dataset && s.key === summary.key;
+  });
+  if (index >= 0) {
+    Vue.delete(summaries, index);
+  }
+}
+
 export function filterSummariesByDataset(
   summaries: VariableSummary[],
   dataset: string


### PR DESCRIPTION
Added a means of removing unused feature variables based on the incoming set of variables to be used such that we don't hard clear and reload everything, which in turn keeps filtering triggering that hard clear and reload. Meanwhile, I manually verified that switching between models still clears the unused variables should the newly selected model use different models for it's predictions.