### PR TITLE
Timeseries pattern cleanup

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -106,7 +106,7 @@ type MetadataStorage interface {
 	// Dataset manipulation
 	SetDataType(dataset string, varName string, varType string) error
 	SetExtrema(dataset string, varName string, extrema *Extrema) error
-	AddVariable(dataset string, varName string, varType string, varDistilRole string) error
+	AddVariable(dataset string, varName string, varDisplayName string, varType string, varDistilRole string) error
 	DeleteVariable(dataset string, varName string) error
 	AddGrouping(datasetName string, grouping model.Grouping) error
 	RemoveGrouping(datasetName string, grouping model.Grouping) error

--- a/api/model/storage/datamart/dataset.go
+++ b/api/model/storage/datamart/dataset.go
@@ -84,7 +84,7 @@ func (s *Storage) SetExtrema(dataset string, varName string, extrema *api.Extrem
 }
 
 // AddVariable is not supported by the datamart.
-func (s *Storage) AddVariable(dataset string, varName string, varType string, varRole string) error {
+func (s *Storage) AddVariable(dataset string, varName string, varDisplayName string, varType string, varRole string) error {
 	return errors.Errorf("Not supported")
 }
 

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -291,8 +291,12 @@ func (s *Storage) SetExtrema(dataset string, varName string, extrema *api.Extrem
 	return s.updateVariables(dataset, vars)
 }
 
-// AddVariable adds a new variable to the dataset.
-func (s *Storage) AddVariable(dataset string, varName string, varType string, varRole string) error {
+// AddVariable adds a new variable to the dataset.  If the varDisplayName is left blank it will be set to the varName value.
+func (s *Storage) AddVariable(dataset string, varName string, varDisplayName string, varType string, varRole string) error {
+
+	if varDisplayName == "" {
+		varDisplayName = varName
+	}
 
 	// new variable definition
 	variable := &model.Variable{
@@ -300,7 +304,7 @@ func (s *Storage) AddVariable(dataset string, varName string, varType string, va
 		Type:             varType,
 		OriginalType:     varType,
 		OriginalVariable: varName,
-		DisplayName:      varName,
+		DisplayName:      varDisplayName,
 		DistilRole:       varRole,
 		Deleted:          false,
 		SuggestedTypes:   make([]*model.SuggestedType, 0),

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -307,7 +307,7 @@ func (s *Storage) AddVariable(dataset string, varName string, varType string, va
 	}
 
 	// query for existing variables
-	vars, err := s.FetchVariables(dataset, true, true, false)
+	vars, err := s.FetchVariables(dataset, true, true, true)
 	if err != nil {
 		return errors.Wrapf(err, "failed to fetch existing variable")
 	}

--- a/api/model/storage/file/dataset.go
+++ b/api/model/storage/file/dataset.go
@@ -72,7 +72,7 @@ func (s *Storage) SetExtrema(dataset string, varName string, extrema *api.Extrem
 }
 
 // AddVariable is not supported by the datamart.
-func (s *Storage) AddVariable(dataset string, varName string, varType string, varRole string) error {
+func (s *Storage) AddVariable(dataset string, varName string, varDisplayName string, varType string, varRole string) error {
 	return errors.Errorf("Not supported")
 }
 

--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -70,6 +70,11 @@ func (f *CategoricalField) FetchSummaryData(resultURI string, filterParams *api.
 	var filtered *api.Histogram
 	var err error
 
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -262,6 +267,11 @@ func (f *CategoricalField) FetchPredictedSummaryData(resultURI string, datasetRe
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -18,7 +18,6 @@ package postgres
 import (
 	"fmt"
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx"
@@ -29,22 +28,20 @@ import (
 
 // CategoricalField defines behaviour for the categorical field type.
 type CategoricalField struct {
-	Storage     *Storage
-	StorageName string
-	Key         string
-	Label       string
-	Type        string
-	subSelect   func() string
+	BasicField
+	subSelect func() string
 }
 
 // NewCategoricalField creates a new field for categorical types.
 func NewCategoricalField(storage *Storage, storageName string, key string, label string, typ string) *CategoricalField {
 	field := &CategoricalField{
-		Storage:     storage,
-		StorageName: storageName,
-		Key:         key,
-		Label:       label,
-		Type:        typ,
+		BasicField: BasicField{
+			Storage:     storage,
+			StorageName: storageName,
+			Key:         key,
+			Label:       label,
+			Type:        typ,
+		},
 	}
 
 	return field
@@ -54,12 +51,14 @@ func NewCategoricalField(storage *Storage, storageName string, key string, label
 // and specifies a sub select query to pull the raw data.
 func NewCategoricalFieldSubSelect(storage *Storage, storageName string, key string, label string, typ string, fieldSubSelect func() string) *CategoricalField {
 	field := &CategoricalField{
-		Storage:     storage,
-		StorageName: storageName,
-		Key:         key,
-		Label:       label,
-		Type:        typ,
-		subSelect:   fieldSubSelect,
+		BasicField: BasicField{
+			Storage:     storage,
+			StorageName: storageName,
+			Key:         key,
+			Label:       label,
+			Type:        typ,
+		},
+		subSelect: fieldSubSelect,
 	}
 
 	return field
@@ -67,10 +66,15 @@ func NewCategoricalFieldSubSelect(storage *Storage, storageName string, key stri
 
 // FetchSummaryData pulls summary data from the database and builds a histogram.
 func (f *CategoricalField) FetchSummaryData(resultURI string, filterParams *api.FilterParams, extrema *api.Extrema, invert bool) (*api.VariableSummary, error) {
-
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -102,183 +106,6 @@ func (f *CategoricalField) FetchSummaryData(resultURI string, filterParams *api.
 		VarType:  f.Type,
 		Baseline: baseline,
 		Filtered: filtered,
-	}, nil
-}
-
-func (f *CategoricalField) getTimeMinMaxAggsQuery(timeVar *model.Variable) string {
-	// get min / max agg names
-	minAggName := api.MinAggPrefix + timeVar.Name
-	maxAggName := api.MaxAggPrefix + timeVar.Name
-
-	timeSelect := fmt.Sprintf("CAST(\"%s\" AS INTEGER)", timeVar.Name)
-	if timeVar.Type == model.DateTimeType {
-		timeSelect = fmt.Sprintf("CAST(extract(epoch from \"%s\") AS INTEGER)", timeVar.Name)
-	}
-
-	// create aggregations
-	queryPart := fmt.Sprintf("MIN(%s) AS \"%s\", MAX(%s) AS \"%s\"",
-		timeSelect, minAggName, timeSelect, maxAggName)
-	// add aggregations
-	return queryPart
-}
-
-func (f *CategoricalField) fetchTimeExtrema(timeVar *model.Variable) (*api.Extrema, error) {
-	fromClause := f.getFromClause(true)
-
-	// add min / max aggregation
-	aggQuery := f.getTimeMinMaxAggsQuery(timeVar)
-
-	// create a query that does min and max aggregations for each variable
-	queryString := fmt.Sprintf("SELECT %s FROM %s;", aggQuery, fromClause)
-
-	// execute the postgres query
-	res, err := f.Storage.client.Query(queryString)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch extrema for variable summaries from postgres")
-	}
-	if res != nil {
-		defer res.Close()
-	}
-
-	return f.parseTimeExtrema(timeVar, res)
-}
-
-func (f *CategoricalField) fetchTimeExtremaByResultURI(timeVar *model.Variable, resultURI string) (*api.Extrema, error) {
-	fromClause := f.getFromClause(false)
-
-	// add min / max aggregation
-	aggQuery := f.getTimeMinMaxAggsQuery(timeVar)
-
-	// create a query that does min and max aggregations for each variable
-	queryString := fmt.Sprintf("SELECT %s FROM %s data INNER JOIN %s result ON data.\"%s\" = result.index WHERE result.result_id = $1;",
-		aggQuery, fromClause, f.Storage.getResultTable(f.StorageName), model.D3MIndexFieldName)
-
-	// execute the postgres query
-	res, err := f.Storage.client.Query(queryString, resultURI)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch time extrema for variable summaries by result from postgres")
-	}
-	if res != nil {
-		defer res.Close()
-	}
-
-	return f.parseTimeExtrema(timeVar, res)
-}
-
-func (f *CategoricalField) parseTimeExtrema(timeVar *model.Variable, rows *pgx.Rows) (*api.Extrema, error) {
-	var minValue *int64
-	var maxValue *int64
-	if rows != nil {
-		// Expect one row of data.
-		exists := rows.Next()
-		if !exists {
-			return nil, fmt.Errorf("no rows in extrema query result")
-		}
-		err := rows.Scan(&minValue, &maxValue)
-		if err != nil {
-			return nil, errors.Wrap(err, "no min / max aggregation found")
-		}
-	}
-	// check values exist
-	if minValue == nil || maxValue == nil {
-		return nil, errors.Errorf("no min / max aggregation values found")
-	}
-	// assign attributes
-	return &api.Extrema{
-		Key:  timeVar.Name,
-		Type: timeVar.Type,
-		Min:  float64(*minValue),
-		Max:  float64(*maxValue),
-	}, nil
-}
-
-func (f *CategoricalField) getTimeseriesHistogramAggQuery(extrema *api.Extrema, interval int) (string, string, string) {
-
-	// get histogram agg name & query string.
-	histogramAggName := fmt.Sprintf("\"%s%s\"", api.HistogramAggPrefix, extrema.Key)
-
-	binning := extrema.GetTimeseriesBinningArgs(interval)
-	timeSelect := fmt.Sprintf("CAST(\"%s\" AS INTEGER)", extrema.Key)
-	if extrema.Type == model.DateTimeType {
-		timeSelect = fmt.Sprintf("CAST(extract(epoch from \"%s\") AS INTEGER)", extrema.Key)
-	}
-
-	bucketQueryString := ""
-	// if only a single value, then return a simple count.
-	if binning.Rounded.Max == binning.Rounded.Min {
-		// want to return the count under bucket 0.
-		bucketQueryString = fmt.Sprintf("(%s - %s)", timeSelect, timeSelect)
-	} else {
-		bucketQueryString = fmt.Sprintf("width_bucket(%s, %d, %d, %d) - 1",
-			timeSelect, int(binning.Rounded.Min), int(binning.Rounded.Max), binning.Count)
-	}
-
-	histogramQueryString := fmt.Sprintf("(%s) * %d + %d", bucketQueryString, int(binning.Interval), int(binning.Rounded.Min))
-
-	return histogramAggName, bucketQueryString, histogramQueryString
-}
-
-func (f *CategoricalField) parseTimeHistogram(rows *pgx.Rows, extrema *api.Extrema, interval int) (*api.Histogram, error) {
-	// get histogram agg name
-	histogramAggName := api.HistogramAggPrefix + extrema.Key
-
-	binning := extrema.GetTimeseriesBinningArgs(interval)
-
-	keys := make([]string, binning.Count)
-	key := binning.Rounded.Min
-	for i := 0; i < len(keys); i++ {
-		keyString := ""
-		if model.IsFloatingPoint(extrema.Type) {
-			keyString = fmt.Sprintf("%f", key)
-		} else {
-			keyString = strconv.Itoa(int(key))
-		}
-
-		keys[i] = keyString
-
-		key = key + binning.Interval
-	}
-
-	categoryBuckets := make(map[string][]*api.Bucket)
-
-	for rows.Next() {
-		var bucketValue float64
-		var bucketCount int64
-		var bucket int64
-		var category string
-		err := rows.Scan(&bucket, &bucketValue, &category, &bucketCount)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("no %s histogram aggregation found", histogramAggName))
-		}
-
-		buckets, ok := categoryBuckets[category]
-		if !ok {
-			buckets = make([]*api.Bucket, binning.Count)
-			for i := range buckets {
-				buckets[i] = &api.Bucket{
-					Count: 0,
-					Key:   keys[i],
-				}
-			}
-			categoryBuckets[category] = buckets
-		}
-
-		if bucket < 0 {
-			// Due to float representation, sometimes the lowest value <
-			// first bucket interval and so ends up in bucket -1.
-			buckets[0].Count = bucketCount
-		} else if bucket < int64(len(buckets)) {
-			buckets[bucket].Count = bucketCount
-		} else {
-			// Since the max can match the limit, an extra bucket may exist.
-			// Add the value to the second to last bucket.
-			buckets[len(buckets)-1].Count += bucketCount
-		}
-	}
-	// assign histogram attributes
-	return &api.Histogram{
-		Extrema:         binning.Rounded,
-		CategoryBuckets: categoryBuckets,
 	}, nil
 }
 
@@ -441,6 +268,11 @@ func (f *CategoricalField) FetchPredictedSummaryData(resultURI string, datasetRe
 	var filtered *api.Histogram
 	var err error
 
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {
 		return nil, err
@@ -501,95 +333,4 @@ func (f *CategoricalField) getFromClause(alias bool) string {
 	}
 
 	return fromClause
-}
-
-// FetchForecastingSummaryData pulls data from the result table and builds the
-// forecasting histogram for the field.
-func (f *CategoricalField) FetchForecastingSummaryData(timeVar *model.Variable, interval int, resultURI string, filterParams *api.FilterParams) (*api.VariableSummary, error) {
-
-	var baseline *api.Histogram
-	var filtered *api.Histogram
-	var err error
-
-	baseline, err = f.fetchForecastingSummaryData(timeVar, interval, resultURI, nil)
-	if err != nil {
-		return nil, err
-	}
-	if !filterParams.Empty() {
-		filtered, err = f.fetchForecastingSummaryData(timeVar, interval, resultURI, filterParams)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return &api.VariableSummary{
-		Label:    f.Label,
-		Key:      f.Key,
-		Type:     model.CategoricalType,
-		VarType:  f.Type,
-		Baseline: baseline,
-		Filtered: filtered,
-	}, nil
-}
-
-func (f *CategoricalField) fetchForecastingSummaryData(timeVar *model.Variable, interval int, resultURI string, filterParams *api.FilterParams) (*api.Histogram, error) {
-	resultVariable := &model.Variable{
-		Name: "value",
-		Type: model.StringType,
-	}
-
-	categories, err := f.getTopCategories(filterParams, false)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch top categories")
-	}
-
-	extrema, err := f.fetchTimeExtremaByResultURI(timeVar, resultURI)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch extrema from postgres")
-	}
-
-	histogramName, bucketQuery, histogramQuery := f.getTimeseriesHistogramAggQuery(extrema, interval)
-
-	// create the filter for the query.
-	wheres := make([]string, 0)
-	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
-
-	categoryWhere := fmt.Sprintf("\"%s\" in (", resultVariable.Name)
-	for index, category := range categories {
-		categoryWhere += fmt.Sprintf("$%d", len(params)+1)
-		if index < len(categories)-1 {
-			categoryWhere += ","
-		}
-		params = append(params, category)
-	}
-	categoryWhere += ")"
-
-	wheres = append(wheres, categoryWhere)
-	where := fmt.Sprintf("WHERE %s", strings.Join(wheres, " AND "))
-
-	fromClause := f.getFromClause(false)
-	params = append(params, resultURI)
-
-	// Create the complete query string.
-	query := fmt.Sprintf(`
-			SELECT %s as bucket, CAST(%s as double precision) AS %s, "%s" as field, Count(*) AS count
-			FROM %s data INNER JOIN %s result ON data."%s" = result.index
-			%s AND result.result_id = $%d
-			GROUP BY %s, "%s"
-			ORDER BY %s;`,
-		bucketQuery, histogramQuery, histogramName, resultVariable.Name, fromClause,
-		f.Storage.getResultTable(f.StorageName), model.D3MIndexFieldName,
-		where, len(params),
-		bucketQuery, resultVariable.Name, histogramName)
-
-	// execute the postgres query
-	res, err := f.Storage.client.Query(query, params...)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch histograms for variable summaries from postgres")
-	}
-	if res != nil {
-		defer res.Close()
-	}
-
-	return f.parseTimeHistogram(res, extrema, interval)
 }

--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -70,11 +70,6 @@ func (f *CategoricalField) FetchSummaryData(resultURI string, filterParams *api.
 	var filtered *api.Histogram
 	var err error
 
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
-
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -267,11 +262,6 @@ func (f *CategoricalField) FetchPredictedSummaryData(resultURI string, datasetRe
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
-
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -58,11 +58,6 @@ func (f *CoordinateField) FetchSummaryData(resultURI string, filterParams *api.F
 	var filtered *api.Histogram
 	var err error
 
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
-
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert, coordinateBuckets)
 		if err != nil {

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -30,25 +30,23 @@ const coordinateBuckets = 20
 
 // CoordinateField defines behaviour for the coordinate field type.
 type CoordinateField struct {
-	Key         string
-	Storage     *Storage
-	StorageName string
-	XCol        string
-	YCol        string
-	Label       string
-	Type        string
+	BasicField
+	XCol string
+	YCol string
 }
 
 // NewCoordinateField creates a new field for coordinate types.
 func NewCoordinateField(key string, storage *Storage, storageName string, xCol string, yCol string, label string, typ string) *CoordinateField {
 	field := &CoordinateField{
-		Key:         key,
-		Storage:     storage,
-		StorageName: storageName,
-		XCol:        xCol,
-		YCol:        yCol,
-		Label:       label,
-		Type:        typ,
+		BasicField: BasicField{
+			Key:         key,
+			Storage:     storage,
+			StorageName: storageName,
+			Label:       label,
+			Type:        typ,
+		},
+		XCol: xCol,
+		YCol: yCol,
 	}
 
 	return field
@@ -59,6 +57,11 @@ func (f *CoordinateField) FetchSummaryData(resultURI string, filterParams *api.F
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert, coordinateBuckets)

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -36,14 +36,15 @@ type CoordinateField struct {
 }
 
 // NewCoordinateField creates a new field for coordinate types.
-func NewCoordinateField(key string, storage *Storage, storageName string, xCol string, yCol string, label string, typ string) *CoordinateField {
+func NewCoordinateField(key string, storage *Storage, datasetName string, datasetStorageName string, xCol string, yCol string, label string, typ string) *CoordinateField {
 	field := &CoordinateField{
 		BasicField: BasicField{
-			Key:         key,
-			Storage:     storage,
-			StorageName: storageName,
-			Label:       label,
-			Type:        typ,
+			Key:                key,
+			Storage:            storage,
+			DatasetName:        datasetName,
+			DatasetStorageName: datasetStorageName,
+			Label:              label,
+			Type:               typ,
 		},
 		XCol: xCol,
 		YCol: yCol,
@@ -128,8 +129,8 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
 	}
 
 	// treat each axis as a separte field for the purposes of query generation
-	xField := NewNumericalField(f.Storage, f.StorageName, f.XCol, f.XCol, model.RealType)
-	yField := NewNumericalField(f.Storage, f.StorageName, f.YCol, f.YCol, model.RealType)
+	xField := NewNumericalField(f.Storage, f.DatasetName, f.DatasetStorageName, f.XCol, f.XCol, model.RealType)
+	yField := NewNumericalField(f.Storage, f.DatasetName, f.DatasetStorageName, f.YCol, f.YCol, model.RealType)
 
 	// get the extrema for each axis
 	xExtrema, err := xField.fetchExtrema()
@@ -153,7 +154,7 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
         GROUP BY %s, %s
         ORDER BY %s, %s;`,
 		xBucketQuery, xHistogramQuery, xHistogramName, yBucketQuery, yHistogramQuery, yHistogramName,
-		f.StorageName, where, xBucketQuery, yBucketQuery, xHistogramName, yHistogramName)
+		f.DatasetStorageName, where, xBucketQuery, yBucketQuery, xHistogramName, yHistogramName)
 
 	// execute the postgres query
 	res, err := f.Storage.client.Query(query, params...)
@@ -175,7 +176,7 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
 func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams, numBuckets int) (*api.Histogram, error) {
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.StorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -188,8 +189,8 @@ func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams 
 	}
 
 	// create a numerical field for each of X and Y
-	xField := NewNumericalField(f.Storage, f.StorageName, f.XCol, f.XCol, model.RealType)
-	yField := NewNumericalField(f.Storage, f.StorageName, f.YCol, f.YCol, model.RealType)
+	xField := NewNumericalField(f.Storage, f.DatasetName, f.DatasetStorageName, f.XCol, f.XCol, model.RealType)
+	yField := NewNumericalField(f.Storage, f.DatasetName, f.DatasetStorageName, f.YCol, f.YCol, model.RealType)
 
 	// get the extrema for each
 	xExtrema, err := xField.fetchExtrema()
@@ -215,7 +216,7 @@ func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams 
 		GROUP BY %s, %s
 		ORDER BY %s, %s;`,
 		xBucketQuery, xHistogramQuery, xHistogramName, yBucketQuery, yHistogramQuery, yHistogramName,
-		f.StorageName, f.Storage.getResultTable(f.StorageName), model.D3MIndexFieldName,
+		f.DatasetStorageName, f.Storage.getResultTable(f.DatasetStorageName), model.D3MIndexFieldName,
 		len(params), where, xBucketQuery, yBucketQuery, xHistogramName, yHistogramName)
 
 	// execute the postgres query

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -58,6 +58,11 @@ func (f *CoordinateField) FetchSummaryData(resultURI string, filterParams *api.F
 	var filtered *api.Histogram
 	var err error
 
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert, coordinateBuckets)
 		if err != nil {

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -72,7 +72,7 @@ func (s *Storage) getDatabaseFields(tableName string) ([]string, error) {
 
 func (s *Storage) getExistingFields(dataset string) (map[string]*model.Variable, error) {
 	// Read the existing fields from the database.
-	vars, err := s.metadata.FetchVariablesDisplay(dataset)
+	vars, err := s.metadata.FetchVariables(dataset, false, false, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to get existing fields")
 	}

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -72,6 +72,11 @@ func (f *DateTimeField) FetchSummaryData(resultURI string, filterParams *api.Fil
 	var filtered *api.Histogram
 	var err error
 
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert, api.MaxNumBuckets)
 		if err != nil {
@@ -372,6 +377,11 @@ func (f *DateTimeField) FetchPredictedSummaryData(resultURI string, datasetResul
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema, api.MaxNumBuckets)
 	if err != nil {

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -72,11 +72,6 @@ func (f *DateTimeField) FetchSummaryData(resultURI string, filterParams *api.Fil
 	var filtered *api.Histogram
 	var err error
 
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
-
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert, api.MaxNumBuckets)
 		if err != nil {
@@ -377,11 +372,6 @@ func (f *DateTimeField) FetchPredictedSummaryData(resultURI string, datasetResul
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
-
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema, api.MaxNumBuckets)
 	if err != nil {

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -16,12 +16,7 @@
 package postgres
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
-	log "github.com/unchartedsoftware/plog"
 )
 
 // Field defines behaviour for a database field type.
@@ -85,25 +80,9 @@ func (b *BasicField) updateClusterHighlight(filterParams *api.FilterParams) erro
 		if !isClusteringColName(filterParams.Highlight.Key) {
 			clusterHighlightCol = clusteringColName(filterParams.Highlight.Key)
 		}
-		if b.hasClusterData(clusterHighlightCol) {
+		if b.Storage.hasClusterData(b.GetDatasetName(), clusterHighlightCol) {
 			filterParams.Highlight.Key = clusterHighlightCol
 		}
 	}
 	return nil
-}
-
-func (b *BasicField) hasClusterData(variableName string) bool {
-	result, err := b.GetStorage().metadata.DoesVariableExist(b.GetDatasetName(), variableName)
-	if err != nil {
-		log.Warn(err)
-	}
-	return result
-}
-
-func clusteringColName(variableName string) string {
-	return fmt.Sprintf("%s%s", model.ClusterVarPrefix, variableName)
-}
-
-func isClusteringColName(variableName string) bool {
-	return strings.HasPrefix(variableName, model.ClusterVarPrefix)
 }

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -68,6 +68,16 @@ func (b *BasicField) GetType() string {
 	return b.Type
 }
 
+// Checks to see if the highlighted variable has cluster data.  If so, the highlight key will be switched to the
+// cluster column ID to ensure that it is used in downstream queries.
+func (b *BasicField) updateClusterHighlight(filterParams *api.FilterParams) error {
+	if !filterParams.Empty() && filterParams.Highlight != nil {
+		if b.hasClusterData(filterParams.Highlight.Key) {
+			filterParams.Highlight.Key = clusteringColName(filterParams.Highlight.Key)
+		}
+	}
+	return nil
+}
 func (b *BasicField) hasClusterData(variableName string) bool {
 	query := fmt.Sprintf("SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = '%s' AND column_name = '%s');",
 		b.StorageName, variableName)

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -16,11 +16,83 @@
 package postgres
 
 import (
-	"github.com/uncharted-distil/distil/api/model"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/uncharted-distil/distil-compute/model"
+	api "github.com/uncharted-distil/distil/api/model"
 )
 
 // Field defines behaviour for a database field type.
 type Field interface {
-	FetchSummaryData(resultURI string, filterParams *model.FilterParams, extrema *model.Extrema, invert bool) (*model.VariableSummary, error)
-	FetchPredictedSummaryData(resultURI string, datasetResult string, filterParams *model.FilterParams, extrema *model.Extrema) (*model.VariableSummary, error)
+	FetchSummaryData(resultURI string, filterParams *api.FilterParams, extrema *api.Extrema, invert bool) (*api.VariableSummary, error)
+	FetchPredictedSummaryData(resultURI string, datasetResult string, filterParams *api.FilterParams, extrema *api.Extrema) (*api.VariableSummary, error)
+	GetStorage() *Storage
+	GetStorageName() string
+	GetKey() string
+	GetLabel() string
+	GetType() string
+}
+
+// BasicField provides access to baseline field data
+type BasicField struct {
+	Storage     *Storage
+	StorageName string
+	Key         string
+	Label       string
+	Type        string
+}
+
+// GetStorage returns the storage associated with the field
+func (b *BasicField) GetStorage() *Storage {
+	return b.Storage
+}
+
+// GetStorageName returns the storage name of the table
+func (b *BasicField) GetStorageName() string {
+	return b.StorageName
+}
+
+// GetKey returns the unique field key (name)
+func (b *BasicField) GetKey() string {
+	return b.Key
+}
+
+// GetLabel returns the field's label.  May not be unique, shouldn't be used to identify the field (use Key)
+func (b *BasicField) GetLabel() string {
+	return b.Label
+}
+
+// GetType returns the internal Distil type of the field.
+func (b *BasicField) GetType() string {
+	return b.Type
+}
+
+// Checks to see if the highlighted variable has cluster data.  If so, the highlight key will be switched to the
+// cluster column ID to ensure that it is used in downstream queries.
+func (b *BasicField) updateClusterHighlight(filterParams *api.FilterParams) error {
+	if !filterParams.Empty() && filterParams.Highlight != nil {
+		if b.hasClusterData(filterParams.Highlight.Key) {
+			filterParams.Highlight.Key = clusteringColName(filterParams.Highlight.Key)
+		}
+	}
+	return nil
+}
+
+func (b *BasicField) hasClusterData(variableName string) bool {
+	query := fmt.Sprintf("SELECT table_name FROM information_schema.columns WHERE table_name = %s AND column_name = %s;",
+		b.StorageName, clusteringColName(variableName))
+	res, err := b.Storage.client.Query(query)
+	if err != nil {
+		errors.Wrap(err, "failed to query cluster column status")
+		return false
+	}
+	if res != nil {
+		defer res.Close()
+	}
+	return res != nil
+}
+
+func clusteringColName(variableName string) string {
+	return fmt.Sprintf("%s%s", model.ClusterVarPrefix, variableName)
 }

--- a/api/model/storage/postgres/image.go
+++ b/api/model/storage/postgres/image.go
@@ -52,6 +52,11 @@ func (f *ImageField) FetchSummaryData(resultURI string, filterParams *api.Filter
 	var filtered *api.Histogram
 	var err error
 
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -258,6 +263,11 @@ func (f *ImageField) FetchPredictedSummaryData(resultURI string, datasetResult s
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/image.go
+++ b/api/model/storage/postgres/image.go
@@ -52,11 +52,6 @@ func (f *ImageField) FetchSummaryData(resultURI string, filterParams *api.Filter
 	var filtered *api.Histogram
 	var err error
 
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
-
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -263,11 +258,6 @@ func (f *ImageField) FetchPredictedSummaryData(resultURI string, datasetResult s
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
-
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/image.go
+++ b/api/model/storage/postgres/image.go
@@ -28,21 +28,19 @@ import (
 
 // ImageField defines behaviour for the image field type.
 type ImageField struct {
-	Storage     *Storage
-	StorageName string
-	Key         string
-	Label       string
-	Type        string
+	BasicField
 }
 
 // NewImageField creates a new field for image types.
 func NewImageField(storage *Storage, storageName string, key string, label string, typ string) *ImageField {
 	field := &ImageField{
-		Storage:     storage,
-		StorageName: storageName,
-		Key:         key,
-		Label:       label,
-		Type:        typ,
+		BasicField: BasicField{
+			Storage:     storage,
+			StorageName: storageName,
+			Key:         key,
+			Label:       label,
+			Type:        typ,
+		},
 	}
 
 	return field
@@ -53,6 +51,12 @@ func (f *ImageField) FetchSummaryData(resultURI string, filterParams *api.Filter
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -259,6 +263,11 @@ func (f *ImageField) FetchPredictedSummaryData(resultURI string, datasetResult s
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -41,14 +41,15 @@ type NumericalStats struct {
 }
 
 // NewNumericalField creates a new field for numerical types.
-func NewNumericalField(storage *Storage, storageName string, key string, label string, typ string) *NumericalField {
+func NewNumericalField(storage *Storage, datasetName string, datasetStorageName string, key string, label string, typ string) *NumericalField {
 	field := &NumericalField{
 		BasicField: BasicField{
-			Storage:     storage,
-			StorageName: storageName,
-			Key:         key,
-			Label:       label,
-			Type:        typ,
+			Storage:            storage,
+			DatasetName:        datasetName,
+			DatasetStorageName: datasetStorageName,
+			Key:                key,
+			Label:              label,
+			Type:               typ,
 		},
 	}
 
@@ -57,14 +58,15 @@ func NewNumericalField(storage *Storage, storageName string, key string, label s
 
 // NewNumericalFieldSubSelect creates a new field for numerical types
 // and specifies a sub select query to pull the raw data.
-func NewNumericalFieldSubSelect(storage *Storage, storageName string, key string, label string, typ string, fieldSubSelect func() string) *NumericalField {
+func NewNumericalFieldSubSelect(storage *Storage, datasetName string, datasetStorageName string, key string, label string, typ string, fieldSubSelect func() string) *NumericalField {
 	field := &NumericalField{
 		BasicField: BasicField{
-			Storage:     storage,
-			StorageName: storageName,
-			Key:         key,
-			Label:       label,
-			Type:        typ,
+			Storage:            storage,
+			DatasetName:        datasetName,
+			DatasetStorageName: datasetStorageName,
+			Key:                key,
+			Label:              label,
+			Type:               typ,
 		},
 		subSelect: fieldSubSelect,
 	}
@@ -184,7 +186,7 @@ func (f *NumericalField) fetchTimeExtremaByResultURI(timeVar *model.Variable, re
 
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s data INNER JOIN %s result ON data.\"%s\" = result.index WHERE result.result_id = $1;",
-		aggQuery, fromClause, f.Storage.getResultTable(f.StorageName), model.D3MIndexFieldName)
+		aggQuery, fromClause, f.Storage.getResultTable(f.DatasetStorageName), model.D3MIndexFieldName)
 
 	// execute the postgres query
 	res, err := f.Storage.client.Query(queryString, resultURI)
@@ -362,7 +364,7 @@ func (f *NumericalField) fetchHistogramByResult(resultURI string, filterParams *
 	fromClause := f.getFromClause(false)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.StorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +399,7 @@ func (f *NumericalField) fetchHistogramByResult(resultURI string, filterParams *
 		GROUP BY %s
 		ORDER BY %s;`,
 		bucketQuery, histogramQuery, histogramName, fromClause,
-		f.Storage.getResultTable(f.StorageName), model.D3MIndexFieldName, len(params), where, bucketQuery, histogramName)
+		f.Storage.getResultTable(f.DatasetStorageName), model.D3MIndexFieldName, len(params), where, bucketQuery, histogramName)
 
 	// execute the postgres query
 	res, err := f.Storage.client.Query(query, params...)
@@ -569,7 +571,7 @@ func (f *NumericalField) fetchExtremaByURI(resultURI string) (*api.Extrema, erro
 
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s data INNER JOIN %s result ON data.\"%s\" = result.index WHERE result.result_id = $1 AND %s;",
-		aggQuery, fromClause, f.Storage.getResultTable(f.StorageName), model.D3MIndexFieldName, f.getNaNFilter())
+		aggQuery, fromClause, f.Storage.getResultTable(f.DatasetStorageName), model.D3MIndexFieldName, f.getNaNFilter())
 
 	// execute the postgres query
 	// NOTE: We may want to use the regular Query operation since QueryRow
@@ -639,7 +641,7 @@ func (f *NumericalField) fetchPredictedSummaryData(resultURI string, datasetResu
 	histogramName, bucketQuery, histogramQuery := f.getResultHistogramAggQuery(extrema, resultVariable, numBuckets)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.StorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -654,7 +656,7 @@ func (f *NumericalField) fetchPredictedSummaryData(resultURI string, datasetResu
 		WHERE %s
 		GROUP BY %s
 		ORDER BY %s;`,
-		bucketQuery, histogramQuery, histogramName, f.StorageName, datasetResult,
+		bucketQuery, histogramQuery, histogramName, f.DatasetStorageName, datasetResult,
 		model.D3MIndexFieldName, strings.Join(wheres, " AND "), bucketQuery, histogramName)
 
 	// execute the postgres query
@@ -758,7 +760,7 @@ func (f *NumericalField) FetchNumericalStatsByResult(resultURI string, filterPar
 	fromClause := f.getFromClause(false)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.StorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -773,7 +775,7 @@ func (f *NumericalField) FetchNumericalStatsByResult(resultURI string, filterPar
 
 	// Create the complete query string.
 	query := fmt.Sprintf("SELECT coalesce(stddev(\"%s\"), 0) as stddev, avg(\"%s\") as avg FROM %s data INNER JOIN %s result ON data.\"%s\" = result.index WHERE result.result_id = $%d %s;",
-		f.Key, f.Key, fromClause, f.Storage.getResultTable(f.StorageName), model.D3MIndexFieldName, len(params), where)
+		f.Key, f.Key, fromClause, f.Storage.getResultTable(f.DatasetStorageName), model.D3MIndexFieldName, len(params), where)
 
 	// execute the postgres query
 	res, err := f.Storage.client.Query(query, params...)
@@ -824,11 +826,11 @@ func (f *NumericalField) parseStats(row *pgx.Rows) (*NumericalStats, error) {
 }
 
 func (f *NumericalField) getFromClause(alias bool) string {
-	fromClause := f.StorageName
+	fromClause := f.DatasetStorageName
 	if f.subSelect != nil {
 		fromClause = f.subSelect()
 		if alias {
-			fromClause = fmt.Sprintf("%s as nested INNER JOIN %s as data on nested.\"%s\" = data.\"%s\"", fromClause, f.StorageName, model.D3MIndexFieldName, model.D3MIndexFieldName)
+			fromClause = fmt.Sprintf("%s as nested INNER JOIN %s as data on nested.\"%s\" = data.\"%s\"", fromClause, f.DatasetStorageName, model.D3MIndexFieldName, model.D3MIndexFieldName)
 		}
 	}
 

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -79,11 +79,6 @@ func (f *NumericalField) FetchSummaryData(resultURI string, filterParams *api.Fi
 	var filtered *api.Histogram
 	var err error
 
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
-
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert, api.MaxNumBuckets)
 		if err != nil {
@@ -591,11 +586,6 @@ func (f *NumericalField) FetchPredictedSummaryData(resultURI string, datasetResu
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
-
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema, api.MaxNumBuckets)
 	if err != nil {

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -79,6 +79,11 @@ func (f *NumericalField) FetchSummaryData(resultURI string, filterParams *api.Fi
 	var filtered *api.Histogram
 	var err error
 
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert, api.MaxNumBuckets)
 		if err != nil {
@@ -586,6 +591,11 @@ func (f *NumericalField) FetchPredictedSummaryData(resultURI string, datasetResu
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema, api.MaxNumBuckets)
 	if err != nil {

--- a/api/model/storage/postgres/pipeline.go
+++ b/api/model/storage/postgres/pipeline.go
@@ -98,7 +98,7 @@ func (s *Storage) isBadSolution(solution *api.Solution) (bool, error) {
 	if !model.IsNumerical(variable.Type) {
 		return false, nil
 	}
-	f := NewNumericalField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+	f := NewNumericalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 
 	// predicted extrema
 	predictedExtrema, err := s.FetchResultsExtremaByURI(dataset, storageName, solution.Results[0].ResultURI)

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -82,7 +82,7 @@ func (s *Storage) fetchResidualsSummary(dataset string, storageName string, vari
 	// Just return a nil in the case where we were asked to return residuals for a non-numeric variable.
 	if model.IsNumerical(variable.Type) || variable.Type == model.TimeSeriesType {
 		// fetch numeric histograms
-		residuals, err := s.fetchResidualsHistogram(resultURI, storageName, variable, filterParams, extrema, numBuckets)
+		residuals, err := s.fetchResidualsHistogram(resultURI, dataset, storageName, variable, filterParams, extrema, numBuckets)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +163,8 @@ func (s *Storage) fetchResidualsExtrema(resultURI string, storageName string, va
 	return s.parseExtrema(res, variable)
 }
 
-func (s *Storage) fetchResidualsHistogram(resultURI string, storageName string, variable *model.Variable, filterParams *api.FilterParams, extrema *api.Extrema, numBuckets int) (*api.Histogram, error) {
+func (s *Storage) fetchResidualsHistogram(resultURI string, datasetName, storageName string, variable *model.Variable, filterParams *api.FilterParams,
+	extrema *api.Extrema, numBuckets int) (*api.Histogram, error) {
 	resultVariable := &model.Variable{
 		Name: "value",
 		Type: model.StringType,
@@ -218,7 +219,7 @@ func (s *Storage) fetchResidualsHistogram(resultURI string, storageName string, 
 	}
 	defer res.Close()
 
-	field := NewNumericalField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+	field := NewNumericalField(s, datasetName, storageName, variable.Name, variable.DisplayName, variable.Type)
 
 	return field.parseHistogram(res, extrema, numBuckets)
 }

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -716,7 +716,7 @@ func (s *Storage) FetchResultsExtremaByURI(dataset string, storageName string, r
 		Type: model.StringType,
 	}
 
-	field := NewNumericalField(s, storageName, targetVariable.Name, targetVariable.DisplayName, targetVariable.Type)
+	field := NewNumericalField(s, dataset, storageName, targetVariable.Name, targetVariable.DisplayName, targetVariable.Type)
 	return field.fetchResultsExtrema(resultURI, storageNameResult, resultVariable)
 }
 
@@ -749,7 +749,7 @@ func (s *Storage) FetchPredictedSummary(dataset string, storageName string, resu
 				return nil, errors.Wrap(err, "failed to fetch variable description for summary")
 			}
 
-			field = NewTimeSeriesField(s, storageName, variable.Grouping.Properties.ClusterCol, variable.Grouping.IDCol, variable.Grouping.IDCol, variable.Grouping.Type,
+			field = NewTimeSeriesField(s, dataset, storageName, variable.Grouping.Properties.ClusterCol, variable.Grouping.IDCol, variable.Grouping.IDCol, variable.Grouping.Type,
 				timeColVar.Name, timeColVar.Type, valueColVar.Name, valueColVar.Type)
 
 		} else {
@@ -761,11 +761,11 @@ func (s *Storage) FetchPredictedSummary(dataset string, storageName string, resu
 		// use the variable type to guide the summary creation
 
 		if model.IsNumerical(variable.Type) {
-			field = NewNumericalField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewNumericalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else if model.IsCategorical(variable.Type) {
-			field = NewCategoricalField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewCategoricalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else if model.IsVector(variable.Type) {
-			field = NewVectorField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewVectorField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else {
 			return nil, errors.Errorf("variable %s of type %s does not support summary", variable.Name, variable.Type)
 		}

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -29,21 +29,19 @@ import (
 
 // TextField defines behaviour for the text field type.
 type TextField struct {
-	Storage     *Storage
-	StorageName string
-	Key         string
-	Label       string
-	Type        string
+	BasicField
 }
 
 // NewTextField creates a new field for text types.
 func NewTextField(storage *Storage, storageName string, key string, label string, typ string) *TextField {
 	field := &TextField{
-		Storage:     storage,
-		StorageName: storageName,
-		Key:         key,
-		Label:       label,
-		Type:        typ,
+		BasicField: BasicField{
+			Storage:     storage,
+			StorageName: storageName,
+			Key:         key,
+			Label:       label,
+			Type:        typ,
+		},
 	}
 
 	return field
@@ -54,6 +52,12 @@ func (f *TextField) FetchSummaryData(resultURI string, filterParams *api.FilterP
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -419,6 +423,11 @@ func (f *TextField) FetchPredictedSummaryData(resultURI string, datasetResult st
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -53,11 +53,6 @@ func (f *TextField) FetchSummaryData(resultURI string, filterParams *api.FilterP
 	var filtered *api.Histogram
 	var err error
 
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
-
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -423,11 +418,6 @@ func (f *TextField) FetchPredictedSummaryData(resultURI string, datasetResult st
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
-
-	// update the highlight key to use the cluster if necessary
-	if err = f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -53,6 +53,11 @@ func (f *TextField) FetchSummaryData(resultURI string, filterParams *api.FilterP
 	var filtered *api.Histogram
 	var err error
 
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -418,6 +423,11 @@ func (f *TextField) FetchPredictedSummaryData(resultURI string, datasetResult st
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -255,7 +255,7 @@ func (f *TimeSeriesField) FetchSummaryData(resultURI string, filterParams *api.F
 }
 
 func (f *TimeSeriesField) keyColName() string {
-	if f.hasClusterData(f.ClusterCol) {
+	if f.GetStorage().hasClusterData(f.GetDatasetName(), f.ClusterCol) {
 		return f.ClusterCol
 	}
 	return f.Key

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -206,6 +206,11 @@ func (f *TimeSeriesField) FetchSummaryData(resultURI string, filterParams *api.F
 	var timeline *api.Histogram
 	var err error
 
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	if resultURI == "" {
 		baseline, err = f.fetchHistogram(nil, invert)
 		if err != nil {
@@ -397,6 +402,11 @@ func (f *TimeSeriesField) FetchPredictedSummaryData(resultURI string, datasetRes
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	var err error
+
+	// update the highlight key to use the cluster if necessary
+	if err = f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
 
 	baseline, err = f.fetchPredictedSummaryData(resultURI, datasetResult, nil, extrema)
 	if err != nil {

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -191,11 +191,11 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 				return nil, errors.Wrap(err, "failed to fetch variable description for summary")
 			}
 
-			field = NewTimeSeriesField(s, storageName, variable.Grouping.Properties.ClusterCol, variable.Grouping.IDCol, variable.Grouping.IDCol, variable.Grouping.Type,
+			field = NewTimeSeriesField(s, dataset, storageName, variable.Grouping.Properties.ClusterCol, variable.Grouping.IDCol, variable.Grouping.IDCol, variable.Grouping.Type,
 				timeColVar.Name, timeColVar.Type, valueColVar.Name, valueColVar.Type)
 
 		} else if model.IsGeoCoordinate(variable.Grouping.Type) {
-			field = NewCoordinateField(variable.Grouping.IDCol, s, storageName, variable.Grouping.Properties.XCol, variable.Grouping.Properties.YCol, variable.Grouping.IDCol, variable.Grouping.Type)
+			field = NewCoordinateField(variable.Grouping.IDCol, s, dataset, storageName, variable.Grouping.Properties.XCol, variable.Grouping.Properties.YCol, variable.Grouping.IDCol, variable.Grouping.Type)
 		} else {
 			return nil, errors.Errorf("variable grouping `%s` of type `%s` does not support summary", variable.Grouping.IDCol, variable.Grouping.Type)
 		}
@@ -203,17 +203,17 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 	} else {
 
 		if model.IsNumerical(variable.Type) || model.IsTimestamp(variable.Type) {
-			field = NewNumericalField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewNumericalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else if model.IsCategorical(variable.Type) {
-			field = NewCategoricalField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewCategoricalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else if model.IsVector(variable.Type) {
-			field = NewVectorField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewVectorField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else if model.IsText(variable.Type) {
-			field = NewTextField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewTextField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else if model.IsImage(variable.Type) {
-			field = NewImageField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewImageField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else if model.IsDateTime(variable.Type) {
-			field = NewDateTimeField(s, storageName, variable.Name, variable.DisplayName, variable.Type)
+			field = NewDateTimeField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 		} else {
 			return nil, errors.Errorf("variable `%s` of type `%s` does not support summary", variable.Name, variable.Type)
 		}

--- a/api/model/storage/postgres/vector.go
+++ b/api/model/storage/postgres/vector.go
@@ -30,12 +30,8 @@ const (
 
 // VectorField defines behaviour for any Vector type.
 type VectorField struct {
-	Storage     *Storage
-	StorageName string
-	Key         string
-	Label       string
-	Type        string
-	Unnested    string
+	BasicField
+	Unnested string
 }
 
 // NewVectorField creates a new field of the vector type. A vector field
@@ -43,18 +39,26 @@ type VectorField struct {
 // data type to get summaries.
 func NewVectorField(storage *Storage, storageName string, key string, label string, typ string) *VectorField {
 	field := &VectorField{
-		Storage:     storage,
-		StorageName: storageName,
-		Key:         key + unnestedSuffix,
-		Label:       label,
-		Type:        typ,
-		Unnested:    key,
+		BasicField: BasicField{
+			Storage:     storage,
+			StorageName: storageName,
+			Key:         key + unnestedSuffix,
+			Label:       label,
+			Type:        typ,
+		},
+		Unnested: key,
 	}
 	return field
 }
 
 // FetchSummaryData pulls summary data from the database and builds a histogram.
 func (f *VectorField) FetchSummaryData(resultURI string, filterParams *api.FilterParams, extrema *api.Extrema, invert bool) (*api.VariableSummary, error) {
+
+	// update the highlight key to use the cluster if necessary
+	if err := f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	var underlyingField Field
 	if f.isNumerical() {
 		underlyingField = NewNumericalFieldSubSelect(f.Storage, f.StorageName, f.Key, f.Label, f.Type, f.subSelect)

--- a/api/model/storage/postgres/vector.go
+++ b/api/model/storage/postgres/vector.go
@@ -54,6 +54,11 @@ func NewVectorField(storage *Storage, storageName string, key string, label stri
 // FetchSummaryData pulls summary data from the database and builds a histogram.
 func (f *VectorField) FetchSummaryData(resultURI string, filterParams *api.FilterParams, extrema *api.Extrema, invert bool) (*api.VariableSummary, error) {
 
+	// update the highlight key to use the cluster if necessary
+	if err := f.updateClusterHighlight(filterParams); err != nil {
+		return nil, err
+	}
+
 	var underlyingField Field
 	if f.isNumerical() {
 		underlyingField = NewNumericalFieldSubSelect(f.Storage, f.StorageName, f.Key, f.Label, f.Type, f.subSelect)

--- a/api/model/storage/postgres/vector.go
+++ b/api/model/storage/postgres/vector.go
@@ -54,11 +54,6 @@ func NewVectorField(storage *Storage, storageName string, key string, label stri
 // FetchSummaryData pulls summary data from the database and builds a histogram.
 func (f *VectorField) FetchSummaryData(resultURI string, filterParams *api.FilterParams, extrema *api.Extrema, invert bool) (*api.VariableSummary, error) {
 
-	// update the highlight key to use the cluster if necessary
-	if err := f.updateClusterHighlight(filterParams); err != nil {
-		return nil, err
-	}
-
 	var underlyingField Field
 	if f.isNumerical() {
 		underlyingField = NewNumericalFieldSubSelect(f.Storage, f.StorageName, f.Key, f.Label, f.Type, f.subSelect)

--- a/api/model/storage/postgres/vector.go
+++ b/api/model/storage/postgres/vector.go
@@ -37,14 +37,15 @@ type VectorField struct {
 // NewVectorField creates a new field of the vector type. A vector field
 // uses unnest to flatten the database array and then uses the underlying
 // data type to get summaries.
-func NewVectorField(storage *Storage, storageName string, key string, label string, typ string) *VectorField {
+func NewVectorField(storage *Storage, datasetName string, datasetStorageName string, key string, label string, typ string) *VectorField {
 	field := &VectorField{
 		BasicField: BasicField{
-			Storage:     storage,
-			StorageName: storageName,
-			Key:         key + unnestedSuffix,
-			Label:       label,
-			Type:        typ,
+			Storage:            storage,
+			DatasetName:        datasetName,
+			DatasetStorageName: datasetStorageName,
+			Key:                key + unnestedSuffix,
+			Label:              label,
+			Type:               typ,
 		},
 		Unnested: key,
 	}
@@ -61,9 +62,9 @@ func (f *VectorField) FetchSummaryData(resultURI string, filterParams *api.Filte
 
 	var underlyingField Field
 	if f.isNumerical() {
-		underlyingField = NewNumericalFieldSubSelect(f.Storage, f.StorageName, f.Key, f.Label, f.Type, f.subSelect)
+		underlyingField = NewNumericalFieldSubSelect(f.Storage, f.DatasetName, f.DatasetStorageName, f.Key, f.Label, f.Type, f.subSelect)
 	} else {
-		underlyingField = NewCategoricalFieldSubSelect(f.Storage, f.StorageName, f.Key, f.Label, f.Type, f.subSelect)
+		underlyingField = NewCategoricalFieldSubSelect(f.Storage, f.DatasetName, f.DatasetStorageName, f.Key, f.Label, f.Type, f.subSelect)
 	}
 
 	histo, err := underlyingField.FetchSummaryData(resultURI, filterParams, extrema, invert)
@@ -82,7 +83,7 @@ func (f *VectorField) FetchNumericalStats(filterParams *api.FilterParams, invert
 	}
 
 	// use the underlying numerical field implementation
-	field := NewNumericalFieldSubSelect(f.Storage, f.StorageName, f.Key, f.Label, f.Type, f.subSelect)
+	field := NewNumericalFieldSubSelect(f.Storage, f.DatasetName, f.DatasetStorageName, f.Key, f.Label, f.Type, f.subSelect)
 
 	return field.FetchNumericalStats(filterParams, invert)
 }
@@ -95,7 +96,7 @@ func (f *VectorField) FetchNumericalStatsByResult(resultURI string, filterParams
 	}
 
 	// use the underlying numerical field implementation
-	field := NewNumericalFieldSubSelect(f.Storage, f.StorageName, f.Key, f.Label, f.Type, f.subSelect)
+	field := NewNumericalFieldSubSelect(f.Storage, f.DatasetName, f.DatasetStorageName, f.Key, f.Label, f.Type, f.subSelect)
 
 	return field.FetchNumericalStatsByResult(resultURI, filterParams)
 }
@@ -112,5 +113,5 @@ func (f *VectorField) isNumerical() bool {
 
 func (f *VectorField) subSelect() string {
 	return fmt.Sprintf("(SELECT \"%s\", unnest(\"%s\") as %s FROM %s)",
-		model.D3MIndexFieldName, f.Unnested, f.Key, f.StorageName)
+		model.D3MIndexFieldName, f.Unnested, f.Key, f.DatasetStorageName)
 }

--- a/api/routes/clustering.go
+++ b/api/routes/clustering.go
@@ -71,15 +71,14 @@ func ClusteringHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorag
 		}
 		sourceFolder := env.ResolvePath(datasetMeta.Source, datasetMeta.Folder)
 
-		// cluster data
-		clustered, err := task.Cluster(sourceFolder, dataset, variable)
-		if err != nil {
-			handleError(w, err)
-			return
-		}
-
 		// create the new metadata and database variables
 		if !clusterVarExist {
+			// cluster data
+			clustered, err := task.Cluster(sourceFolder, dataset, variable)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
 			err = metaStorage.AddVariable(dataset, clusterVarName, "Pattern", model.CategoricalType, "metadata")
 			if err != nil {
 				handleError(w, err)
@@ -90,19 +89,19 @@ func ClusteringHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorag
 				handleError(w, err)
 				return
 			}
-		}
 
-		// build the data for batching
-		clusteredData := make(map[string]string)
-		for _, cluster := range clustered {
-			clusteredData[cluster.D3MIndex] = cluster.Label
-		}
+			// build the data for batching
+			clusteredData := make(map[string]string)
+			for _, cluster := range clustered {
+				clusteredData[cluster.D3MIndex] = cluster.Label
+			}
 
-		// update the batches
-		err = dataStorage.UpdateVariableBatch(storageName, clusterVarName, clusteredData)
-		if err != nil {
-			handleError(w, err)
-			return
+			// update the batches
+			err = dataStorage.UpdateVariableBatch(storageName, clusterVarName, clusteredData)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
 		}
 
 		// marshal output into JSON

--- a/api/routes/clustering.go
+++ b/api/routes/clustering.go
@@ -54,7 +54,7 @@ func ClusteringHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorag
 			handleError(w, err)
 			return
 		}
-		clusterVarName := fmt.Sprintf("_cluster_%s", variable)
+		clusterVarName := fmt.Sprintf("%s%s", model.ClusterVarPrefix, variable)
 
 		// check if the cluster variables exist
 		clusterVarExist, err := metaStorage.DoesVariableExist(dataset, clusterVarName)

--- a/api/routes/clustering.go
+++ b/api/routes/clustering.go
@@ -80,7 +80,7 @@ func ClusteringHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorag
 
 		// create the new metadata and database variables
 		if !clusterVarExist {
-			err = metaStorage.AddVariable(dataset, clusterVarName, model.CategoricalType, "metadata")
+			err = metaStorage.AddVariable(dataset, clusterVarName, "Pattern", model.CategoricalType, "metadata")
 			if err != nil {
 				handleError(w, err)
 				return

--- a/api/routes/clustering.go
+++ b/api/routes/clustering.go
@@ -63,20 +63,6 @@ func ClusteringHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorag
 			return
 		}
 
-		// create the new metadata and database variables
-		if !clusterVarExist {
-			err = metaStorage.AddVariable(dataset, clusterVarName, model.StringType, "metadata")
-			if err != nil {
-				handleError(w, err)
-				return
-			}
-			err = dataStorage.AddVariable(dataset, storageName, clusterVarName, model.StringType)
-			if err != nil {
-				handleError(w, err)
-				return
-			}
-		}
-
 		// get the source dataset folder
 		datasetMeta, err := metaStorage.FetchDataset(dataset, false, false)
 		if err != nil {
@@ -90,6 +76,20 @@ func ClusteringHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorag
 		if err != nil {
 			handleError(w, err)
 			return
+		}
+
+		// create the new metadata and database variables
+		if !clusterVarExist {
+			err = metaStorage.AddVariable(dataset, clusterVarName, model.CategoricalType, "metadata")
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+			err = dataStorage.AddVariable(dataset, storageName, clusterVarName, model.CategoricalType)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
 		}
 
 		// build the data for batching

--- a/api/routes/compose.go
+++ b/api/routes/compose.go
@@ -73,7 +73,7 @@ func ComposeHandler(dataCtor api.DataStorageCtor, esMetaCtor api.MetadataStorage
 
 		if !composeExists {
 			// create the new field
-			err = metaStorage.AddVariable(dataset, varName, model.StringType, "grouping")
+			err = metaStorage.AddVariable(dataset, varName, "key", model.StringType, "grouping")
 			if err != nil {
 				handleError(w, err)
 				return

--- a/api/routes/geocoding.go
+++ b/api/routes/geocoding.go
@@ -72,7 +72,7 @@ func GeocodingHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 
 		// create the new metadata and database variables
 		if !latVarExist {
-			err = metaStorage.AddVariable(dataset, latVarName, model.LatitudeType, "geocoding")
+			err = metaStorage.AddVariable(dataset, latVarName, latVarName, model.LatitudeType, "geocoding")
 			if err != nil {
 				handleError(w, err)
 				return
@@ -84,7 +84,7 @@ func GeocodingHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 			}
 		}
 		if !lonVarExist {
-			err = metaStorage.AddVariable(dataset, lonVarName, model.LongitudeType, "geocoding")
+			err = metaStorage.AddVariable(dataset, lonVarName, lonVarName, model.LongitudeType, "geocoding")
 			if err != nil {
 				handleError(w, err)
 				return

--- a/api/routes/grouping.go
+++ b/api/routes/grouping.go
@@ -76,13 +76,13 @@ func GroupingHandler(dataCtor api.DataStorageCtor, metaCtor api.MetadataStorageC
 				return
 			}
 
-			if grouping.Properties.ClusterCol != "" {
-				// ensure cluster is categorical
-				err = setDataType(meta, data, dataset, storageName, grouping.Properties.ClusterCol, model.CategoricalType)
-				if err != nil {
-					handleError(w, errors.Wrap(err, "unable to update the data type in storage"))
-					return
-				}
+			// Using the grouping ID column as the cluster column by default
+			// ensure cluster exists and is categorical
+			grouping.Properties.ClusterCol = grouping.IDCol
+			err = setDataType(meta, data, dataset, storageName, grouping.Properties.ClusterCol, model.CategoricalType)
+			if err != nil {
+				handleError(w, errors.Wrap(err, "unable to update the data type in storage"))
+				return
 			}
 
 		} else if model.IsGeoCoordinate(grouping.Type) {

--- a/api/routes/grouping.go
+++ b/api/routes/grouping.go
@@ -140,6 +140,24 @@ func RemoveGroupingHandler(dataCtor api.DataStorageCtor, metaCtor api.MetadataSt
 			return
 		}
 
+		// if there was a cluster var associated with this group and it has been created, remove it now
+		// TODO: Should this be done explicitly through the client through some type of a
+		// delete route?
+		if grouping.Properties.ClusterCol != "" {
+			clusterVarExist, err := meta.DoesVariableExist(dataset, grouping.Properties.ClusterCol)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+			if clusterVarExist {
+				err = meta.DeleteVariable(dataset, grouping.Properties.ClusterCol)
+				if err != nil {
+					handleError(w, err)
+					return
+				}
+			}
+		}
+
 		// marshal data
 		err = handleJSON(w, map[string]interface{}{
 			"success": true,

--- a/api/routes/grouping.go
+++ b/api/routes/grouping.go
@@ -16,6 +16,7 @@
 package routes
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -76,15 +77,8 @@ func GroupingHandler(dataCtor api.DataStorageCtor, metaCtor api.MetadataStorageC
 				return
 			}
 
-			// Using the grouping ID column as the cluster column by default
-			// ensure cluster exists and is categorical
-			grouping.Properties.ClusterCol = grouping.IDCol
-			err = setDataType(meta, data, dataset, storageName, grouping.Properties.ClusterCol, model.CategoricalType)
-			if err != nil {
-				handleError(w, errors.Wrap(err, "unable to update the data type in storage"))
-				return
-			}
-
+			// For set the name of the expected cluster column - it doesn't necessarily exist.
+			grouping.Properties.ClusterCol = fmt.Sprintf("_cluster_%s", grouping.IDCol)
 		} else if model.IsGeoCoordinate(grouping.Type) {
 			// make the lat column the id col for now since id col is what holds the info.
 			grouping.IDCol = grouping.Properties.XCol

--- a/api/routes/grouping.go
+++ b/api/routes/grouping.go
@@ -78,7 +78,7 @@ func GroupingHandler(dataCtor api.DataStorageCtor, metaCtor api.MetadataStorageC
 			}
 
 			// For set the name of the expected cluster column - it doesn't necessarily exist.
-			grouping.Properties.ClusterCol = fmt.Sprintf("_cluster_%s", grouping.IDCol)
+			grouping.Properties.ClusterCol = fmt.Sprintf("%s%s", model.ClusterVarPrefix, grouping.IDCol)
 		} else if model.IsGeoCoordinate(grouping.Type) {
 			// make the lat column the id col for now since id col is what holds the info.
 			grouping.IDCol = grouping.Properties.XCol

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -153,7 +153,7 @@ func Cluster(datasetInputDir string, dataset string, variable string) ([]*Cluste
 	// build the output (skipping the header)
 	clusteredData := make([]*ClusterPoint, len(res)-1)
 	for i, v := range res[1:] {
-		label := v[clusterIndex].(string)
+		label := createFriendlyLabel(v[clusterIndex].(string))
 		d3mIndex := v[d3mIndexIndex].(string)
 
 		clusteredData[i] = &ClusterPoint{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,27 @@
 elastic:
-  image:
-    docker.uncharted.software/distil_dev_es:latest
+  image: docker.uncharted.software/distil_dev_es:latest
   ports:
     - "9200:9200"
 
-pipeline_server:
-  image:
-    docker.uncharted.software/distil-pipeline-server:latest
-  ports:
-    - "45042:45042"
-  environment:
-    - SOLUTION_SERVER_RESULT_DIR=$D3MOUTPUTDIR
-    - SOLUTION_SEND_DELAY=2000
-    - SOLUTION_NUM_UPDATES=3
-    - SOLUTION_MAX_SOLUTIONS=3
-    - SOLUTION_ERR_PERCENT=0.1
-  volumes:
-    - $D3MINPUTDIR:$D3MINPUTDIR
-    - $D3MOUTPUTDIR:$D3MOUTPUTDIR
-
 postgres:
-  image:
-    docker.uncharted.software/distil_dev_postgres:latest
+  image: docker.uncharted.software/distil_dev_postgres:latest
   ports:
     - "5432:5432"
-  command:
-    -d postgres
+  command: -d postgres
+# pipeline_server:
+#   image:
+#     docker.uncharted.software/distil-pipeline-server:latest
+#   ports:
+#     - "45042:45042"
+#   environment:
+#     - SOLUTION_SERVER_RESULT_DIR=$D3MOUTPUTDIR
+#     - SOLUTION_SEND_DELAY=2000
+#     - SOLUTION_NUM_UPDATES=3
+#     - SOLUTION_MAX_SOLUTIONS=3
+#     - SOLUTION_ERR_PERCENT=0.1
+#   volumes:
+#     - $D3MINPUTDIR:$D3MINPUTDIR
+#     - $D3MOUTPUTDIR:$D3MOUTPUTDIR
 
 # distil-auto-ml:
 #   image:

--- a/public/components/FacetTimeseries.vue
+++ b/public/components/FacetTimeseries.vue
@@ -15,6 +15,7 @@
       @html-appended="onHtmlAppend"
       @numerical-click="onNumericalClick"
       @categorical-click="onCategoricalClick"
+      @facet-click="onFacetClick"
       @range-change="onRangeChange"
     >
     </facet-entry>
@@ -87,9 +88,11 @@ export default Vue.extend({
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);
     },
+
     variable(): Variable {
       return this.variables.find(v => v.colName === this.summary.key);
     },
+
     timelineSummary(): VariableSummary {
       if (this.summary.pending) {
         return null;
@@ -132,6 +135,9 @@ export default Vue.extend({
   methods: {
     onCategoricalClick(...args) {
       this.$emit("categorical-click", ...args);
+    },
+    onFacetClick(...args) {
+      this.$emit("facet-click", ...args);
     },
     onNumericalClick(...args) {
       this.$emit("numerical-click", ...args);

--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -39,6 +39,7 @@
                 :instanceName="instanceName"
                 @numerical-click="onNumericalClick"
                 @categorical-click="onCategoricalClick"
+                @facet-click="onFacetClick"
                 @range-change="onRangeChange"
                 @histogram-numerical-click="onNumericalClick"
                 @histogram-categorical-click="onCategoricalClick"
@@ -330,7 +331,6 @@ export default Vue.extend({
 
     availableVariables(): string[] {
       // NOTE: used externally, not internally by the component
-
       // filter by search
       const searchFiltered = this.summaries.filter(summary => {
         return (


### PR DESCRIPTION
1.  Calls cluster route when time series is created
1.  Adds logic to replace timeseries facet entries with pattern facet entries when clusters are available
1.  Ensures all facet highlight operations support the dual-mode timeseries facet display

There is still some additional work to be done client side to ensure that:
1. The time series cluster variable does not appear as a facet (should only appear in timeseries facet)
1. The display of the cluster data in the timeseries facet only occurs if the user applies the cluster info from the asynch panel
That work will be done in a follow on PR.