### PR TITLE
Geofacet map integration

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -51,7 +51,12 @@ import {
   removeRowSelection,
   isRowSelected
 } from "../util/row";
-import { LATITUDE_TYPE, LONGITUDE_TYPE, REAL_VECTOR_TYPE } from "../util/types";
+import {
+  LATITUDE_TYPE,
+  LONGITUDE_TYPE,
+  REAL_VECTOR_TYPE,
+  GEOCOORDINATE_TYPE
+} from "../util/types";
 
 import "leaflet/dist/leaflet.css";
 import "leaflet/dist/images/marker-icon.png";
@@ -150,17 +155,21 @@ export default Vue.extend({
       let lat = null;
       const fields = [];
       matches.forEach(match => {
-        if (match.colType === LONGITUDE_TYPE) {
-          lng = match.colName;
-        }
-        if (match.colType === LATITUDE_TYPE) {
-          lat = match.colName;
-        }
-        if (match.colType === REAL_VECTOR_TYPE) {
+        if (match.grouping && match.grouping.type === GEOCOORDINATE_TYPE) {
+          lng = match.grouping.properties.xCol;
+          lat = match.grouping.properties.yCol;
+        } else if (match.colType === REAL_VECTOR_TYPE) {
           fields.push({
             type: SINGLE_FIELD,
             field: match.colName
           });
+        } else {
+          if (match.colType === LONGITUDE_TYPE) {
+            lng = match.colName;
+          }
+          if (match.colType === LATITUDE_TYPE) {
+            lat = match.colName;
+          }
         }
         // TODO: currently we pair any two random lat / lngs, we should
         // eventually use the groupings functionality to let the user

--- a/public/components/GeocoordinateFacet.vue
+++ b/public/components/GeocoordinateFacet.vue
@@ -12,9 +12,9 @@
       >
       </type-change-menu>
     </div>
-    <div class="geo-plot-container">
+    <div class="geofacet-container">
       <div
-        class="geo-plot"
+        class="geofacet"
         v-bind:id="mapID"
         v-on:mousedown="onMouseDown"
         v-on:mouseup="onMouseUp"
@@ -712,17 +712,17 @@ export default Vue.extend({
   z-index: 1;
 }
 
-.facet-card .geo-plot-container .selection-toggle {
+.facet-card .geofacet-container .selection-toggle {
   top: 55px;
 }
 
-.facet-card .geo-plot-container .action-btn {
+.facet-card .geofacet-container .action-btn {
   position: relative;
   bottom: 37px;
   background: white;
 }
 
-.facet-card .geo-plot-container .action-btn:hover {
+.facet-card .geofacet-container .action-btn:hover {
   color: #fff;
   background-color: #9e9e9e;
   border-color: #9e9e9e;
@@ -734,13 +734,16 @@ export default Vue.extend({
   text-overflow: ellipsis;
 }
 
-.geo-plot-container {
+.geofacet-container {
   bottom: 16px;
 }
 
-.geo-plot-container,
-.geo-plot {
+.geofacet,
+.geofacet-container {
+  position: relative;
+  z-index: 0;
   height: 214px;
+  width: 100%;
 }
 
 .facet-card .group-header .type-change-dropdown-wrapper {
@@ -748,11 +751,7 @@ export default Vue.extend({
   bottom: 20px;
 }
 
-.geo-plot-container .type-change-dropdown-wrapper .dropdown-menu {
-  z-index: 3;
-}
-
-.geo-close-button {
+.geofacet-container .type-change-dropdown-wrapper .dropdown-menu {
   z-index: 3;
 }
 </style>

--- a/public/components/ViewTypeToggle.vue
+++ b/public/components/ViewTypeToggle.vue
@@ -55,7 +55,8 @@ import {
   TIMESERIES_TYPE,
   IMAGE_TYPE,
   LONGITUDE_TYPE,
-  LATITUDE_TYPE
+  LATITUDE_TYPE,
+  GEOCOORDINATE_TYPE
 } from "../util/types";
 
 const TABLE_VIEW = "table";
@@ -105,14 +106,16 @@ export default Vue.extend({
       return false;
     },
     hasGeoVariables(): boolean {
-      // TODO: impl groupings for lon / lat
-      // const hasLat = this.variables.filter(v => v.grouping && v.grouping.type === LONGITUDE_TYPE).length  > 0;
-      // const hasLon = this.variables.filter(v => v.grouping && v.grouping.type === LATITUDE_TYPE).length  > 0;
+      const hasGeocoord =
+        this.variables.filter(
+          v => v.grouping && v.grouping.type === GEOCOORDINATE_TYPE
+        ).length > 0;
       const hasLat =
         this.variables.filter(v => v.colType === LONGITUDE_TYPE).length > 0;
       const hasLon =
         this.variables.filter(v => v.colType === LATITUDE_TYPE).length > 0;
-      return hasLat && hasLon;
+
+      return (hasLat && hasLon) || hasGeocoord;
     },
     hasTimeseriesVariables(): boolean {
       return (


### PR DESCRIPTION
fixes #1364 

1. Fixes some CSS naming clashes between GeoPlot.vue and GeocoordinateFacet.vue that were breaking layout for one or another.
1. Ensures map toggle appears when geocoordinate facet is present
1. Ensures that lat/lon data are exracted for GeoPlot when using a geocoordinate