### PR TITLE
Update metadata file

### DIFF
--- a/api/task/cleaning.go
+++ b/api/task/cleaning.go
@@ -97,7 +97,7 @@ func Clean(datasetSource metadata.DatasetSource, schemaFile string, index string
 	mainDR.ResPath = relativePath
 
 	// write the new schema to file
-	err = metadata.WriteSchema(meta, outputPath.outputSchema)
+	err = metadata.WriteSchema(meta, outputPath.outputSchema, true)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to store cluster schema")
 	}

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -115,7 +115,7 @@ func ClusterDataset(datasetSource metadata.DatasetSource, schemaFile string, ind
 	mainDR.ResPath = relativePath
 
 	// write the new schema to file
-	err = metadata.WriteSchema(meta, outputPath.outputSchema)
+	err = metadata.WriteSchema(meta, outputPath.outputSchema, true)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to store cluster schema")
 	}

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -57,7 +57,7 @@ func CreateDataset(dataset string, csvData []byte, outputPath string, config *In
 	meta.DataResources = []*model.DataResource{dr}
 
 	schemaPath := path.Join(outputDatasetPath, compute.D3MDataSchema)
-	err = metadata.WriteSchema(meta, schemaPath)
+	err = metadata.WriteSchema(meta, schemaPath, true)
 	if err != nil {
 		return "", err
 	}
@@ -179,7 +179,7 @@ func CreateImageDataset(dataset string, data []byte, imageType string, outputPat
 	meta.DataResources = []*model.DataResource{refDR, dr}
 
 	log.Infof("writing schema to '%s'", schemaPath)
-	err = metadata.WriteSchema(meta, schemaPath)
+	err = metadata.WriteSchema(meta, schemaPath, true)
 	if err != nil {
 		return "", err
 	}
@@ -211,7 +211,7 @@ func writeDataset(meta *model.Metadata, csvData []byte, outputPath string, confi
 	}
 
 	schemaPath := path.Join(outputDatasetPath, compute.D3MDataSchema)
-	err = metadata.WriteSchema(meta, schemaPath)
+	err = metadata.WriteSchema(meta, schemaPath, true)
 	if err != nil {
 		return "", err
 	}

--- a/api/task/feature.go
+++ b/api/task/feature.go
@@ -117,7 +117,7 @@ func Featurize(datasetSource metadata.DatasetSource, schemaFile string, index st
 	mainDR.ResPath = relativePath
 
 	// write the new schema to file
-	err = metadata.WriteSchema(meta, outputPath.outputSchema)
+	err = metadata.WriteSchema(meta, outputPath.outputSchema, true)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to store feature schema")
 	}

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -108,7 +108,7 @@ func outputDataset(paths *datasetCopyPath, meta *model.Metadata, lines [][]strin
 	dr.ResType = model.ResTypeTable
 
 	// write the new schema to file
-	err = metadata.WriteSchema(meta, paths.outputSchema)
+	err = metadata.WriteSchema(meta, paths.outputSchema, true)
 	if err != nil {
 		return errors.Wrap(err, "unable to store schema")
 	}

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -146,7 +146,7 @@ func GeocodeForwardDataset(datasetSource metadata.DatasetSource, schemaFile stri
 	mainDR.ResPath = relativePath
 
 	// write the new schema to file
-	err = metadata.WriteSchema(meta, outputPath.outputSchema)
+	err = metadata.WriteSchema(meta, outputPath.outputSchema, true)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to store feature schema")
 	}

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -209,12 +209,12 @@ func Ingest(originalSchemaFile string, schemaFile string, storage api.MetadataSt
 
 	// store the updated metadata
 	if updated {
-		log.Infof("storing updated metadata")
-		err = metadata.WriteSchema(meta, schemaFile)
+		log.Infof("storing updated metadata to %s", originalSchemaFile)
+		err = metadata.WriteSchema(meta, originalSchemaFile, false)
 		if err != nil {
 			return "", errors.Wrap(err, "unable to store updated metadata")
 		}
-		log.Infof("updated metadata written")
+		log.Infof("updated metadata written to %s", originalSchemaFile)
 	}
 
 	err = metadata.LoadImportance(meta, path.Join(datasetDir, config.RankingOutputPathRelative))

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -207,7 +207,7 @@ func createDatasetFromCSV(config *env.Config, csvFile *os.File, datasetName stri
 	metadataDestPath := path.Join(outputPath, compute.D3MDataSchema)
 	relativePath := getRelativePath(path.Dir(metadataDestPath), csvDestPath)
 	dataResource.ResPath = relativePath
-	err = ingestMetadata.WriteSchema(metadata, metadataDestPath)
+	err = ingestMetadata.WriteSchema(metadata, metadataDestPath, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to write schema")
 	}

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -119,7 +119,7 @@ func Merge(datasetSource metadata.DatasetSource, schemaFile string, index string
 	outputMeta.DataResources[0].ResPath = relativePath
 
 	// write the new schema to file
-	err = metadata.WriteSchema(outputMeta, outputPath.outputSchema)
+	err = metadata.WriteSchema(outputMeta, outputPath.outputSchema, true)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to store merged schema")
 	}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -64,7 +64,7 @@ func Predict(meta *model.Metadata, dataset string, solutionID string, fittedSolu
 	meta.StorageName = model.NormalizeDatasetID(dataset)
 	meta.DatasetFolder = path.Base(datasetPath)
 	schemaPath := path.Join(datasetPath, compute.D3MDataSchema)
-	err = metadata.WriteSchema(meta, schemaPath)
+	err = metadata.WriteSchema(meta, schemaPath, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update dataset doc")
 	}
@@ -79,7 +79,7 @@ func Predict(meta *model.Metadata, dataset string, solutionID string, fittedSolu
 
 	// the dataset id needs to match the original dataset id for TA2 to be able to use the model
 	meta.ID = sourceDatasetID
-	err = metadata.WriteSchema(meta, schemaPath)
+	err = metadata.WriteSchema(meta, schemaPath, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update dataset doc")
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/uncharted-distil/distil-compute v0.0.0-20191219155854-7e71c22c816d
-	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220152500-df714b8f0188
+	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220192629-b9e430c40e3e
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
 	github.com/zenazn/goji v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/uncharted-distil/distil-compute v0.0.0-20191219155854-7e71c22c816d
-	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220192629-b9e430c40e3e
+	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191221145213-f91acf748127
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
 	github.com/zenazn/goji v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/uncharted-distil/distil-compute v0.0.0-20191219155854-7e71c22c816d
-	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191221145213-f91acf748127
+	github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191223172758-2d0b32f14622
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
 	github.com/zenazn/goji v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220192629-b9e430c40e3e
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220192629-b9e430c40e3e/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191221145213-f91acf748127 h1:h1qxwBBURCDVXPUx+GB3K+BwePrDVtLPDQhrNNZULR8=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191221145213-f91acf748127/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191223172758-2d0b32f14622 h1:5+vzI2Y5eQp/9J/VxvjXNDoDkPcA3ffHp7D55+wHBTU=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191223172758-2d0b32f14622/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9/go.mod h1:PrytgQ5GjTc6Z5/pbL5vj1UhD716wDobDeimrd7lRKY=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48 h1:XYef2jcFEKziHl4rv/21jrNeQg6Z3gL345u16fHWVDo=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220144044-33dabd805ff8
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220144044-33dabd805ff8/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220152500-df714b8f0188 h1:4NU32EvBGPJFsYdFadXZNRgaSJjpDfbdn7kWio5vkB4=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220152500-df714b8f0188/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220192629-b9e430c40e3e h1:f8/Tn3Dr7nxj0mQT4RAIbZXkrXjVNh2/iaASt0Epyl4=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220192629-b9e430c40e3e/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9/go.mod h1:PrytgQ5GjTc6Z5/pbL5vj1UhD716wDobDeimrd7lRKY=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48 h1:XYef2jcFEKziHl4rv/21jrNeQg6Z3gL345u16fHWVDo=

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220152500-df714b8f0188
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220152500-df714b8f0188/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220192629-b9e430c40e3e h1:f8/Tn3Dr7nxj0mQT4RAIbZXkrXjVNh2/iaASt0Epyl4=
 github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191220192629-b9e430c40e3e/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191221145213-f91acf748127 h1:h1qxwBBURCDVXPUx+GB3K+BwePrDVtLPDQhrNNZULR8=
+github.com/uncharted-distil/distil-ingest/pkg v0.0.0-20191221145213-f91acf748127/go.mod h1:1xWj/PKIQ48m0AogImK/M0ZvcvYM3e/+DNwXorJPawI=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9/go.mod h1:PrytgQ5GjTc6Z5/pbL5vj1UhD716wDobDeimrd7lRKY=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48 h1:XYef2jcFEKziHl4rv/21jrNeQg6Z3gL345u16fHWVDo=


### PR DESCRIPTION
Write out the updated metadata if during ingest inconsistencies are found. This means that an imported dataset from datamart which doesn't have the right role for d3m index can now be run properly.