### PR TITLE
Fix Join Redirect Task

### DIFF
--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -210,7 +210,8 @@ export default Vue.extend({
     onJoinCommitSuccess(datasetID: string) {
       const entry = createRouteEntry(SELECT_TRAINING_ROUTE, {
         dataset: datasetID,
-        target: this.target
+        target: this.target,
+        task: routeGetters.getRouteTask(this.$store)
       });
       this.$router.push(entry);
       this.addRecentDataset(datasetID);

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -522,7 +522,8 @@ export default Vue.extend({
     onJoinCommitSuccess(datasetID: string) {
       const entry = createRouteEntry(SELECT_TRAINING_ROUTE, {
         dataset: datasetID,
-        target: this.target
+        target: this.target,
+        task: routeGetters.getRouteTask(this.$store)
       });
       this.$router.push(entry);
       this.addRecentDataset(datasetID);


### PR DESCRIPTION
When a join is committed, the redirect did not include the task on the route info. If a model was built from that page then the results page also did not include the task type and was therefore not displaying properly.