### PR TITLE
Allows timeseries with no grouping key selected

### DIFF
--- a/api/routes/grouping.go
+++ b/api/routes/grouping.go
@@ -204,7 +204,7 @@ func createComposedVariable(metaStorage api.MetadataStorage, dataStorage api.Dat
 	}
 
 	composedData := map[string]string{}
-	var filter *api.FilterParams = nil
+	var filter *api.FilterParams
 	if len(sourceVarNames) > 0 {
 		// Fetch data using the source names as the filter
 		filter = &api.FilterParams{

--- a/public/views/VariableGrouping.vue
+++ b/public/views/VariableGrouping.vue
@@ -362,8 +362,8 @@ export default Vue.extend({
           grouping: grouping
         })
         .then(() => {
-          // If this is a timeseries, then we need to request clustering be run on it
-          if (this.isTimeseries) {
+          // If this dataset contains multiple timeseries, then we need to request clustering be run on it
+          if (this.isTimeseries && ids.length > 0) {
             datasetActions.clusterData(this.$store, {
               dataset: this.dataset,
               variable: getComposedVariableKey(ids)


### PR DESCRIPTION
Fixes #1174.  We now have the option of not specifying a grouping key column - in that case the column data is treated as a single time series.