### PR TITLE
#1362 - geocoord facet menu fix

### DIFF
--- a/public/components/GeocoordinateFacet.vue
+++ b/public/components/GeocoordinateFacet.vue
@@ -168,7 +168,7 @@ export default Vue.extend({
     },
 
     target(): string {
-      return routeGetters.getRouteTargetVariable(this.$store);
+      return this.summary.key;
     },
 
     instanceName(): string {

--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -113,7 +113,7 @@ export default Vue.extend({
     isPredictionOrResultsView(): boolean {
       const routePath = routeGetters.getRoutePath(this.$store);
       return routePath &&
-        (routePath === PREDICTION_ROUTE || routePath == RESULTS_ROUTE);
+        (routePath === PREDICTION_ROUTE || routePath === RESULTS_ROUTE);
     },
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);

--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -87,7 +87,7 @@ import {
 } from "../util/types";
 import { hasFilterInRoute } from "../util/filters";
 import { createRouteEntry } from "../util/routes";
-import { GROUPING_ROUTE } from "../store/route";
+import { GROUPING_ROUTE, PREDICTION_ROUTE, RESULTS_ROUTE } from "../store/route";
 import { getComposedVariableKey } from "../util/data";
 import { actions as appActions } from "../store/app/module";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
@@ -109,6 +109,11 @@ export default Vue.extend({
   computed: {
     isGeocoordinate(): boolean {
       return this.geocoordinate;
+    },
+    isPredictionOrResultsView(): boolean {
+      const routePath = routeGetters.getRoutePath(this.$store);
+      return routePath &&
+        (routePath === PREDICTION_ROUTE || routePath == RESULTS_ROUTE);
     },
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);
@@ -194,7 +199,8 @@ export default Vue.extend({
       return (
         hasFilterInRoute(this.field) ||
         (this.highlight && this.highlight.key === this.field) ||
-        this.isComputedFeature
+        this.isComputedFeature ||
+        (this.isGeocoordinate && this.isPredictionOrResultsView)
       );
     },
     isComputedFeature(): boolean {

--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -54,7 +54,7 @@
       :disabled="!isDisabled"
       target="type-change-dropdown"
     >
-      Cannot change type when actively filtering
+      Cannot change type when actively filtering or viewing models or predictions
     </b-tooltip>
   </div>
 </template>

--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -186,7 +186,6 @@ export default Vue.extend({
     },
 
     isGeocoordinateFacetAvailable(): boolean {
-      const foo = datasetGetters.getGeocoordinateTypes(this.$store).length > 0;
       return datasetGetters.getGeocoordinateTypes(this.$store).length > 0;
     },
 


### PR DESCRIPTION
- Set target in geocoordinate facets to their key rather than the target for the entire model
- Updated the type change menu to block explode in result model view and prediction view as discussed
- Removed unused assignment in variable facets.