### PR TITLE
Use the inference dataset name in prediction route

### DIFF
--- a/public/components/FileUploader.vue
+++ b/public/components/FileUploader.vue
@@ -98,8 +98,8 @@ export default Vue.extend({
         .catch(err => {
           uploadError = err;
         })
-        .then(() => {
-          this.$emit("uploadfinish", uploadError);
+        .then(response => {
+          this.$emit("uploadfinish", uploadError, response);
         });
     }
   }

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -179,18 +179,20 @@ export default Vue.extend({
       });
     },
     
-    onUploadFinish(err) {
+    onUploadFinish(err, response) {
       this.uploadStatus = err ? "error" : "success";
-      const routeArgs = {
-        solutionId: this.solutionId,
-        dataset: this.dataset,
-        produceRequestId: this.produceRequestId,
-        target: this.target
-      };
-      // fill out with call to app actions to new appAction.importInferenceData probably
-      // that for now will just be loading basically the model page again with stuff blanked out.
-      const entry = createRouteEntry(PREDICTION_ROUTE, routeArgs);
-      this.$router.push(entry);
+
+      if (this.uploadStatus !== "error") {
+        const inferenceDataset = response && response.data && response.data.dataset;
+        const routeArgs = {
+          solutionId: this.solutionId,
+          dataset: inferenceDataset,
+          produceRequestId: this.produceRequestId,
+          target: this.target
+        };
+        const entry = createRouteEntry(PREDICTION_ROUTE, routeArgs);
+        this.$router.push(entry);
+      }
     },
 
     onExport() {


### PR DESCRIPTION
Using the inference dataset name in the upload return when calling the prediction route to show the inferred data. 