### PR TITLE
#1403 - expand collapse geocoordinate lat & lon histograms

### DIFF
--- a/public/components/GeocoordinateFacet.vue
+++ b/public/components/GeocoordinateFacet.vue
@@ -9,6 +9,7 @@
         :geocoordinate="true"
         :dataset="dataset"
         :field="target"
+        :expandCollapse="expandCollapse"
       >
       </type-change-menu>
     </div>
@@ -37,6 +38,16 @@
         </button>
       </div>
     </div>
+    <div v-if="expand">
+      <facet-entry
+        :summary="latSummary"
+        :enabledTypeChanges="enabledTypeChanges"
+      ></facet-entry>
+      <facet-entry
+        :summary="lonSummary"
+        :enabledTypeChanges="enabledTypeChanges"
+      ></facet-entry>
+    </div>
   </div>
 </template>
 
@@ -61,12 +72,15 @@ import {
   Highlight
 } from "../store/dataset/index";
 import TypeChangeMenu from "../components/TypeChangeMenu";
+import FacetEntry from "../components/FacetEntry";
 import { updateHighlight, clearHighlight } from "../util/highlights";
 import {
   GEOCOORDINATE_TYPE,
   LATITUDE_TYPE,
   LONGITUDE_TYPE,
-  REAL_VECTOR_TYPE
+  REAL_VECTOR_TYPE,
+  EXPAND_ACTION_TYPE,
+  COLLAPSE_ACTION_TYPE
 } from "../util/types";
 import { overlayRouteEntry } from "../util/routes";
 import { Filter, removeFiltersByName } from "../util/filters";
@@ -140,7 +154,8 @@ export default Vue.extend({
   components: {
     TypeChangeMenu,
     IconBase,
-    IconCropFree
+    IconCropFree,
+    FacetEntry
   },
 
   props: {
@@ -159,12 +174,38 @@ export default Vue.extend({
       currentRect: null,
       selectedRect: null,
       baseLineLayer: null,
-      filteredLayer: null
+      filteredLayer: null,
+      expand: true,
+      enabledTypeChanges: new Array(0)
     };
   },
   computed: {
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);
+    },
+
+    latSummary(): VariableSummary {
+      const latSummary: VariableSummary = {
+        label: 'Latitude',
+        description: this.summary.description,
+        type: LATITUDE_TYPE + GEOCOORDINATE_TYPE,
+        key: this.summary.key,
+        dataset: this.summary.dataset,
+        baseline: this.summary.baseline
+      };
+      return latSummary;
+    },
+
+    lonSummary(): VariableSummary {
+      const latSummary: VariableSummary = {
+        label: 'Longitude',
+        description: this.summary.description,
+        type: LONGITUDE_TYPE + GEOCOORDINATE_TYPE,
+        key: this.summary.key,
+        dataset: this.summary.dataset,
+        baseline: this.summary.baseline
+      };
+      return latSummary;
     },
 
     target(): string {
@@ -324,6 +365,13 @@ export default Vue.extend({
     }
   },
   methods: {
+    expandCollapse(action) {
+      if (action === EXPAND_ACTION_TYPE) {
+        this.expand = true;
+      } else if (action === COLLAPSE_ACTION_TYPE) {
+        this.expand = false;
+      }
+    },
     selectFeature() {
       const training = routeGetters.getDecodedTrainingVariableNames(
         this.$store

--- a/public/components/GeocoordinateFacet.vue
+++ b/public/components/GeocoordinateFacet.vue
@@ -191,7 +191,8 @@ export default Vue.extend({
         type: LATITUDE_TYPE + GEOCOORDINATE_TYPE,
         key: this.summary.key,
         dataset: this.summary.dataset,
-        baseline: this.summary.baseline
+        baseline: this.summary.baseline,
+        filtered: this.summary.filtered
       };
       return latSummary;
     },
@@ -203,7 +204,8 @@ export default Vue.extend({
         type: LONGITUDE_TYPE + GEOCOORDINATE_TYPE,
         key: this.summary.key,
         dataset: this.summary.dataset,
-        baseline: this.summary.baseline
+        baseline: this.summary.baseline,
+        filtered: this.summary.filtered
       };
       return latSummary;
     },

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -464,7 +464,7 @@ function createNumericalSummaryFacet(summary: VariableSummary): Group {
 
 // to do update loops to reduce to the opposite axis to build latitude slices
 function createLatitudeFacet (summary: VariableSummary): Group {
-  const buckets = summary.baseline.buckets;
+  const buckets = summary.filtered ? summary.filtered.buckets : summary.baseline.buckets;
   const slices = new Array(buckets[0].buckets.length);
 
   for (let i = 0; i < slices.length; i++) {
@@ -507,7 +507,7 @@ function createLatitudeFacet (summary: VariableSummary): Group {
 }
 
 function createLongitudeFacet(summary: VariableSummary): Group {
-  const buckets = summary.baseline.buckets;
+  const buckets = summary.filtered ? summary.filtered.buckets : summary.baseline.buckets;
   const slices = new Array(buckets.length);
   buckets.forEach((lonBucket, i) => {
     const from = _.toNumber(lonBucket.key);

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -17,7 +17,10 @@ import {
   URI_TYPE,
   DATE_TIME_TYPE,
   IMAGE_TYPE,
-  DATE_TIME_LOWER_TYPE
+  DATE_TIME_LOWER_TYPE,
+  LATITUDE_TYPE,
+  GEOCOORDINATE_TYPE,
+  LONGITUDE_TYPE
 } from "../util/types";
 import { getTimeseriesSummaryTopCategories } from "../util/data";
 import {
@@ -191,6 +194,10 @@ export function createSummaryFacet(summary: VariableSummary): Group {
       } else {
         return createCategoricalSummaryFacet(summary);
       }
+    case LATITUDE_TYPE + GEOCOORDINATE_TYPE:
+      return createLatitudeFacet(summary);
+    case LONGITUDE_TYPE + GEOCOORDINATE_TYPE:
+      return createLongitudeFacet(summary);
     case NUMERICAL_SUMMARY:
       return createNumericalSummaryFacet(summary);
     case TIMESERIES_SUMMMARY:
@@ -437,6 +444,91 @@ function createNumericalSummaryFacet(summary: VariableSummary): Group {
     dataset: summary.dataset,
     colName: summary.key,
     label: summary.label,
+    description: summary.description,
+    key: `${summary.dataset}:${summary.key}`,
+    type: summary.varType,
+    collapsible: false,
+    collapsed: false,
+    facets: [
+      {
+        histogram: {
+          slices: slices
+        },
+        filterable: false,
+        selection: {} as any
+      }
+    ],
+    summary: summary
+  };
+}
+
+// to do update loops to reduce to the opposite axis to build latitude slices
+function createLatitudeFacet (summary: VariableSummary): Group {
+  const buckets = summary.baseline.buckets;
+  const slices = new Array(buckets[0].buckets.length);
+
+  for (let i = 0; i < slices.length; i++) {
+    const from = _.toNumber(buckets[0].buckets[i].key);
+    const to = i < slices.length - 1 ?
+      _.toNumber(buckets[0].buckets[i + 1].key) :
+      from + from - _.toNumber(buckets[0].buckets[i - 1].key);
+    slices[i] = {
+      label: from,
+      toLabel: to,
+      count: buckets.reduce((c, lonBucket) => {
+        if (lonBucket.buckets[i].count > 0) {
+          c += lonBucket.buckets[i].count;
+        }
+        return c;
+      }, 0)
+    }
+  }
+
+  return {
+    dataset: summary.dataset,
+    colName: summary.key,
+    label: 'Latitude',
+    description: summary.description,
+    key: `${summary.dataset}:${summary.key}`,
+    type: summary.varType,
+    collapsible: false,
+    collapsed: false,
+    facets: [
+      {
+        histogram: {
+          slices: slices
+        },
+        filterable: false,
+        selection: {} as any
+      }
+    ],
+    summary: summary
+  };
+}
+
+function createLongitudeFacet(summary: VariableSummary): Group {
+  const buckets = summary.baseline.buckets;
+  const slices = new Array(buckets.length);
+  buckets.forEach((lonBucket, i) => {
+    const from = _.toNumber(lonBucket.key);
+    const to = i < buckets.length - 1 ?
+      _.toNumber(buckets[i + 1].key) :
+      from + from - _.toNumber(buckets[i - 1].key);
+    slices[i] = {
+      label: from,
+      toLabel: to,
+      count: lonBucket.buckets.reduce((c, latBucket) => {
+        if (latBucket.count > 0) {
+          c += latBucket.count;
+        }
+        return c;
+      }, 0)
+    };
+  });
+  return {
+    dataset: summary.dataset,
+    colName: summary.key,
+    label: 'Longitude',
     description: summary.description,
     key: `${summary.dataset}:${summary.key}`,
     type: summary.varType,

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -11,6 +11,15 @@ export const GEOCODED_LAT_PREFIX = "_lat_";
 export const GEOCODED_LON_PREFIX = "_lon_";
 export const DATETIME_UNIX_ADJUSTMENT = 1000;
 
+// Action Types Reuse In Similar Places to Data Types
+// These are listed in the facet menu too, but Aren't Posted Back to 
+// as type change, but can take actions to change a compound facet
+// back to its components, or change aspects of the facet's display
+
+export const EXPLODE_ACTION_TYPE = "explode";
+export const EXPAND_ACTION_TYPE = "expand";
+export const COLLAPSE_ACTION_TYPE = "collapse";
+
 // NOTE: these are copied from `distil-compute/model/schema_types.go` and
 // should be kept up to date in case of changes.
 // TODO: Convert these to enums.


### PR DESCRIPTION
- additions & changes to geocoordinate facet component to support expand/collapsible menu and conditional dom displaying the histograms, and deriving latitude and longitude summaries from the geocoordinate summary to pass to the facet-entry component.
- changes to the type change menu component to expand and collapse to the menu options along with supporting conditional display logic.
- additions to the facets.ts utility to generate the collapsible latitude and longitude histograms in geocoordinate facet.
- additions to the types.ts utility to provide constants for expand, explode and collapse actions.
