### PR TITLE
Image Classification

### DIFF
--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/pipeline"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/result"
+	log "github.com/unchartedsoftware/plog"
 
 	api "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/util"
@@ -48,6 +49,8 @@ func (s *SolutionRequest) createExplainPipeline(client *compute.Client, desc *pi
 // ExplainFeatureOutput parses the explain feature output.
 func ExplainFeatureOutput(resultURI string, datasetURITest string, outputURI string) (*api.SolutionFeatureWeights, error) {
 	// get the d3m index lookup
+	log.Infof("explaining feature output")
+	log.Infof("reading raw dataset found in '%s'", datasetURITest)
 	rawData, err := readDatasetData(datasetURITest)
 	if err != nil {
 		return nil, err
@@ -56,10 +59,13 @@ func ExplainFeatureOutput(resultURI string, datasetURITest string, outputURI str
 	d3mIndexLookup := mapRowIndex(d3mIndexField, rawData[1:])
 
 	// parse the output for the explanations
+	log.Infof("parsing feature weight found in '%s' using results found in '%s'", outputURI, resultURI)
 	parsed, err := parseFeatureWeight(resultURI, outputURI, d3mIndexLookup)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to parse feature weight output")
 	}
+
+	log.Infof("done explaining feature output")
 
 	return parsed, nil
 }
@@ -237,8 +243,9 @@ func readDatasetData(uri string) ([][]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to load original schema file")
 	}
+	mainDR := meta.GetMainDataResource()
 
-	dataPath := path.Join(path.Dir(uriRaw), meta.DataResources[0].ResPath)
+	dataPath := path.Join(path.Dir(uriRaw), mainDR.ResPath)
 	res, err := util.ReadCSVFile(dataPath, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read raw input data")

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -653,11 +653,13 @@ func (s *SolutionRequest) dispatchSolution(statusChan chan SolutionStatus, clien
 			// explain features per-record if the explanation is available
 			explainFeatureURI, ok := outputKeyURIs[explainFeatureOutputkey]
 			if ok {
+				log.Infof("explaining feature output from URI '%s'", explainFeatureURI)
 				featureWeights, err := ExplainFeatureOutput(resultURI, datasetURITest, explainFeatureURI)
 				if err != nil {
 					log.Warnf("failed to fetch output explanantion - %v", err)
 				}
 				if featureWeights != nil {
+					log.Infof("persisting feature weights")
 					err = dataStorage.PersistSolutionFeatureWeight(dataset, model.NormalizeDatasetID(dataset), featureWeights.ResultURI, featureWeights.Weights)
 					if err != nil {
 						s.persistSolutionError(statusChan, solutionStorage, initialSearchID, initialSearchSolutionID, err)
@@ -669,6 +671,7 @@ func (s *SolutionRequest) dispatchSolution(statusChan chan SolutionStatus, clien
 			// explain the features at the model level if the explanation is available
 			explainSolutionURI, ok := outputKeyURIs[explainSolutionOutputkey]
 			if ok {
+				log.Infof("explaining solution output from URI '%s'", explainSolutionURI)
 				solutionWeights, err := s.explainSolutionOutput(resultURI, explainSolutionURI, initialSearchSolutionID, variables)
 				if err != nil {
 					log.Warnf("failed to fetch output explanantion - %v", err)
@@ -683,6 +686,7 @@ func (s *SolutionRequest) dispatchSolution(statusChan chan SolutionStatus, clien
 			}
 
 			// persist results
+			log.Infof("persisting results in URI '%s'", resultURI)
 			s.persistSolutionResults(statusChan, client, solutionStorage, dataStorage, searchID,
 				initialSearchID, dataset, solutionID, initialSearchSolutionID, fittedSolutionID, produceRequestID, resultID, resultURI)
 		}


### PR DESCRIPTION
Image classification was failing because the explain step was not handling multiple data resources properly. It now correctly uses only the main data resource to map d3m indices.

Also added a bit of logging to save time should issues appear in the future.