### PR TITLE
#1396 CSS constraints for timeseries display

### DIFF
--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -211,9 +211,6 @@ export default Vue.extend({
 <style>
 .sparkline-container {
   position: relative;
-  min-width: 400px;
-  max-width: 500px !important;
-  min-height: 50px;
 }
 
 .line-chart-big {

--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -211,6 +211,9 @@ export default Vue.extend({
 <style>
 .sparkline-container {
   position: relative;
+  min-width: 400px;
+  max-width: 500px !important;
+  min-height: 50px;
 }
 
 .line-chart-big {

--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -162,7 +162,7 @@ export default Vue.extend({
   position: relative;
   min-width: 400px;
   max-width: 500px !important;
-  min-height: 50px;
+  min-height: 45px;
 }
 
 .sparkline-preview-container:hover .zoom-sparkline-icon {

--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="sparkline-container" v-observe-visibility="visibilityChanged">
+  <div class="sparkline-preview-container" v-observe-visibility="visibilityChanged">
     <sparkline-svg
       :timeseries-extrema="timeseriesExtrema"
       :timeseries="timeseries"
@@ -158,12 +158,14 @@ export default Vue.extend({
   visibility: hidden;
 }
 
-.sparkline-container {
+.sparkline-preview-container {
   position: relative;
-  width: 100%;
+  min-width: 400px;
+  max-width: 500px !important;
+  min-height: 50px;
 }
 
-.sparkline-container:hover .zoom-sparkline-icon {
+.sparkline-preview-container:hover .zoom-sparkline-icon {
   visibility: visible;
 }
 

--- a/public/components/SparklineSvg.vue
+++ b/public/components/SparklineSvg.vue
@@ -269,7 +269,7 @@ export default Vue.extend({
 <style>
 svg.line-chart-row {
   position: relative;
-  max-height: 32px;
+  max-height: 40px;
   width: 100%;
 }
 

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -24,7 +24,7 @@
 
       <div class="col-12 col-md-6 d-flex flex-column">
         <result-target-variable
-          class="col-12 d-flex flex-column select-target-variables"
+          class="col-12 d-flex flex-column result-target-variables"
         ></result-target-variable>
       </div>
     </div>
@@ -182,5 +182,13 @@ export default Vue.extend({
   .results-result-summaries {
     height: unset;
   }
+}
+.result-target-variables {
+  min-width: 500px;
+  max-width: 600px !important;
+  align-self: flex-end;
+}
+.result-target-variables .facet-sparkline-container {
+  height: 30px !important;
 }
 </style>

--- a/public/views/SelectTraining.vue
+++ b/public/views/SelectTraining.vue
@@ -37,9 +37,11 @@
         </div>
 
         <div class="col-12 col-md-6 d-flex flex-column">
-          <target-variable
-            class="col-12 d-flex flex-column select-target-variables"
-          ></target-variable>
+          <div class="select-target-variables">
+            <target-variable
+              class="col-12 d-flex flex-column"
+            ></target-variable>
+          </div>
         </div>
       </div>
 
@@ -186,5 +188,13 @@ export default Vue.extend({
 .select-data-container {
   flex: 1;
   z-index: 1; /* to show the scroll bar */
+}
+.select-target-variables {
+  min-width: 500px;
+  max-width: 600px !important;
+  align-self: flex-end;
+}
+.select-target-variables .facet-sparkline-container {
+  height: 30px !important;
 }
 </style>


### PR DESCRIPTION
Fixes #1396 - By adding some minimum and maximum heights and widths, we can mostly keep the same dimensions between the table and and the top level summary.