### PR TITLE
Timeseries inference create

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -53,6 +53,9 @@ type DataStorage interface {
 	DeleteVariable(dataset string, storageName string, varName string) error
 	UpdateVariable(storageName string, varName string, d3mIndex string, value string) error
 	UpdateVariableBatch(storageName string, varName string, updates map[string]string) error
+
+	// Raw data queries
+	FetchRawDistinctValues(dataset string, storageName string, varName string) ([]string, error)
 }
 
 // SolutionStorageCtor represents a client constructor to instantiate a

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -295,3 +295,28 @@ func (s *Storage) FetchCategoryCounts(storageName string, variable *model.Variab
 	}
 	return counts, nil
 }
+
+// FetchRawDistinctValues fetches the distinct values for a variable from the base table.
+func (s *Storage) FetchRawDistinctValues(dataset string, storageName string, varName string) ([]string, error) {
+	sql := fmt.Sprintf("SELECT DISTINCT \"%s\" FROM %s;", varName, storageName)
+	rows, err := s.client.Query(sql)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to count categories for %s", varName)
+	}
+
+	// Exract into a (category,count) map
+	values := make([]string, 0)
+	if rows != nil {
+		defer rows.Close()
+
+		for rows.Next() {
+			var val string
+			err := rows.Scan(&val)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, val)
+		}
+	}
+	return values, nil
+}

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -298,7 +298,7 @@ func (s *Storage) FetchCategoryCounts(storageName string, variable *model.Variab
 
 // FetchRawDistinctValues fetches the distinct values for a variable from the base table.
 func (s *Storage) FetchRawDistinctValues(dataset string, storageName string, varName string) ([]string, error) {
-	sql := fmt.Sprintf("SELECT DISTINCT \"%s\" FROM %s;", varName, storageName)
+	sql := fmt.Sprintf("SELECT DISTINCT \"%s\" FROM %s_base;", varName, storageName)
 	rows, err := s.client.Query(sql)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to count categories for %s", varName)

--- a/api/routes/predictions.go
+++ b/api/routes/predictions.go
@@ -195,7 +195,7 @@ func createTimeseriesFromRequest(dataStorage api.DataStorage, datasetES *api.Dat
 
 	// generate timestamps to use for prediction based on type of timestamp
 	var timestampPredictionValues []string
-	if model.IsTimestamp(timestampVar.Type) {
+	if model.IsDateTime(timestampVar.Type) {
 		timestampPredictionValues, err = generateTimestampValues(timestampValues, startStr, stepCount)
 	} else if model.IsNumerical(timestampVar.Type) {
 		timestampPredictionValues, err = generateIntValues(timestampValues, startStr, stepCount)

--- a/main.go
+++ b/main.go
@@ -283,7 +283,7 @@ func main() {
 	registerRoutePost(mux, "/distil/geocode/:dataset/:variable", routes.GeocodingHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/cluster/:dataset/:variable", routes.ClusteringHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/upload/:dataset", routes.UploadHandler(path.Join(config.D3MOutputDir, config.AugmentedSubFolder), ingestConfig))
-	registerRoutePost(mux, "/distil/predict/:dataset/:fitted-solution-id", routes.PredictionsHandler(path.Join(config.D3MOutputDir, config.AugmentedSubFolder), pgDataStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor, &config, ingestConfig))
+	registerRoutePost(mux, "/distil/predict/:dataset/:target-type/:fitted-solution-id", routes.PredictionsHandler(path.Join(config.D3MOutputDir, config.AugmentedSubFolder), pgDataStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor, &config, ingestConfig))
 	registerRoutePost(mux, "/distil/join", routes.JoinHandler(esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries/:dataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:invert", routes.TimeseriesHandler(pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries-forecast/:dataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:result-uuid", routes.TimeseriesForecastHandler(pgDataStorageCtor, pgSolutionStorageCtor))

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -347,7 +347,7 @@ export const actions = {
           return null;
         }
         return axios
-          .post(`/distil/predict/${args.datasetID}/${args.solutionId}`, data, {
+          .post(`/distil/predict/${args.datasetID}/tabular/${args.solutionId}`, data, {
             headers: { "Content-Type": "multipart/form-data" }
           })
           .then(response => {


### PR DESCRIPTION
Added backend support to generate a timeseries dataset for inference from a start date and a count of steps. Only supports datetime and int representations of the time component for the timeseries.