### PR TITLE
#1418 - Block access to later analysis steps based on current view/step

### DIFF
--- a/public/components/NavBar.vue
+++ b/public/components/NavBar.vue
@@ -32,7 +32,7 @@
         @click="onSelectTarget"
         v-if="!isTask2"
         :active="isActive(SELECT_TARGET_ROUTE)"
-        :disabled="!hasSelectTargetView()"
+        :disabled="!hasView(SELECT_TARGET_ROUTE)"
         v-bind:class="{ active: isActive(SELECT_TARGET_ROUTE) }"
       >
         <i class="fa fa-angle-right nav-arrow"></i>
@@ -42,7 +42,7 @@
       <b-nav-item
         @click="onSelectData"
         :active="isActive(SELECT_TRAINING_ROUTE)"
-        :disabled="!hasSelectTrainingView()"
+        :disabled="!hasView(SELECT_TRAINING_ROUTE)"
         v-bind:class="{ active: isActive(SELECT_TRAINING_ROUTE) }"
       >
         <i class="fa fa-angle-right nav-arrow"></i>
@@ -62,7 +62,7 @@
       <b-nav-item
         @click="onResults"
         :active="isActive(RESULTS_ROUTE)"
-        :disabled="!hasResultView()"
+        :disabled="!hasView(RESULTS_ROUTE)"
         v-bind:class="{ active: isActive(RESULTS_ROUTE) }"
       >
         <i class="fa fa-angle-right nav-arrow"></i>
@@ -72,7 +72,7 @@
       <b-nav-item
         @click="onResults"
         :active="isActive(PREDICTION_ROUTE)"
-        :disabled="!hasPredictionView()"
+        :disabled="!hasView(PREDICTION_ROUTE)"
         v-bind:class="{ active: isActive(PREDICTION_ROUTE) }"
       >
         <i class="fa fa-angle-right nav-arrow"></i>
@@ -153,6 +153,16 @@ export default Vue.extend({
     },
     isJoinDatasets(): boolean {
       return this.joinDatasets.length === 2 || this.hasJoinDatasetView();
+    },
+    activeSteps(): string[] {
+      const steps = [
+        SELECT_TARGET_ROUTE,
+        SELECT_TRAINING_ROUTE,
+        RESULTS_ROUTE,
+        PREDICTION_ROUTE,
+      ]
+      const currentStep = steps.indexOf(this.$route.path)+1;
+      return steps.slice(0, currentStep);
     }
   },
 
@@ -178,21 +188,12 @@ export default Vue.extend({
     onResults() {
       gotoResults(this.$router);
     },
+    hasView (view: string): boolean {
+      return !!restoreView(view, this.dataset) && this.activeSteps.indexOf(view) > -1
+    },
     hasJoinDatasetView(): boolean {
       return !!restoreView(JOIN_DATASETS_ROUTE, this.joinDatasetsHash);
     },
-    hasSelectTargetView(): boolean {
-      return !!restoreView(SELECT_TARGET_ROUTE, this.dataset);
-    },
-    hasSelectTrainingView(): boolean {
-      return !!restoreView(SELECT_TRAINING_ROUTE, this.dataset);
-    },
-    hasResultView(): boolean {
-      return !!restoreView(RESULTS_ROUTE, this.dataset);
-    },
-    hasPredictionView(): boolean {
-      return !!restoreView(PREDICTION_ROUTE, this.dataset);
-    }
   }
 });
 </script>

--- a/public/util/view.ts
+++ b/public/util/view.ts
@@ -16,9 +16,6 @@ export function saveView(args: { view: string; key: string; route: Location }) {
 }
 
 export function restoreView(view: string, key: string): Location {
-  let res = localStorage.get(`${view}:${key}`);
-  if (!res) {
-    res = localStorage.get(`${view}:${LAST_STATE}`);
-  }
+  const res = localStorage.get(`${view}:${key}`);
   return res || null;
 }


### PR DESCRIPTION
Fixes #1418 - I've set it up such that we don't try to fall back to views for other datasets when using the top navigation as it seemed confusing and encouraged the issue with accessing models/predictions when we should not be able to, and I've essentially blocked navigating ahead of the current view via the nav bar, as it may not always be defined or make sense should other changes occur (IE: I don't want the user to change something in build models, then click ahead back to view models or view prediction thinking that will update or generate a fresh model or prediction - though actions have to be taken through the single buttons in the view that allow that, or you have to go to the front page to look at your existing models.) This setup should also ensure that when the docker containers are updated and the existing models are lost, we can't access previously accessed states easily from normal user interactions due to retained local state.