### PR TITLE
Cap Timeseries Facet Height

### DIFF
--- a/public/components/FacetTimeseries.vue
+++ b/public/components/FacetTimeseries.vue
@@ -175,6 +175,9 @@ export default Vue.extend({
 </script>
 
 <style>
+.facet-timeseries .facets-group .group-facet-container {
+  max-height: 150px !important;
+}
 .facet-timeseries .facets-root:first-child {
   margin-bottom: 1px;
 }


### PR DESCRIPTION
Might be worth moving some other CSS rules around into this component, but for now this caps the height to 150px. Can be adjusted, but it looks good to me.