### PR TITLE
Wait for a valid describe message before fitting.

### DIFF
--- a/api/model/storage/postgres/timeseries_test.go
+++ b/api/model/storage/postgres/timeseries_test.go
@@ -8,22 +8,22 @@ import (
 
 func TestRemoveDuplicates(t *testing.T) {
 	data := [][]float64{
-		[]float64{1, 10},
-		[]float64{2, 20},
-		[]float64{2, 30},
-		[]float64{3, 40},
-		[]float64{4, 50},
-		[]float64{4, 60},
-		[]float64{4, 70},
-		[]float64{5, 80},
+		{1, 10},
+		{2, 20},
+		{2, 30},
+		{3, 40},
+		{4, 50},
+		{4, 60},
+		{4, 70},
+		{5, 80},
 	}
 
 	expected := [][]float64{
-		[]float64{1, 10},
-		[]float64{2, 50},
-		[]float64{3, 40},
-		[]float64{4, 180},
-		[]float64{5, 80},
+		{1, 10},
+		{2, 50},
+		{3, 40},
+		{4, 180},
+		{5, 80},
 	}
 
 	result := removeDuplicates(data)
@@ -33,10 +33,10 @@ func TestRemoveDuplicates(t *testing.T) {
 func TestRemoveDuplicatesNoDuplicates(t *testing.T) {
 
 	data := [][]float64{
-		[]float64{1, 10},
-		[]float64{2, 20},
-		[]float64{3, 30},
-		[]float64{4, 40},
+		{1, 10},
+		{2, 20},
+		{3, 30},
+		{4, 40},
 	}
 	result := removeDuplicates(data)
 	assert.Equal(t, data, result)
@@ -44,14 +44,14 @@ func TestRemoveDuplicatesNoDuplicates(t *testing.T) {
 
 func TestRemoveDuplicatesAllDuplicates(t *testing.T) {
 	data := [][]float64{
-		[]float64{1, 10},
-		[]float64{1, 20},
-		[]float64{1, 30},
-		[]float64{1, 40},
+		{1, 10},
+		{1, 20},
+		{1, 30},
+		{1, 40},
 	}
 
 	expected := [][]float64{
-		[]float64{1, 100},
+		{1, 100},
 	}
 
 	result := removeDuplicates(data)


### PR DESCRIPTION
Solution ids can be returned before they are valid. Distil needs to wait until a valid pipeline is returned from the describe call before attempting to fit.