### PR TITLE
Cluster cache fixes and View Models data refresh

### DIFF
--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -110,6 +110,7 @@ import {
 } from "../store/app/module";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
+import { actions as viewActions } from "../store/view/module";
 import { RESULTS_ROUTE } from "../store/route/index";
 import { actions as solutionActions } from "../store/solutions/module";
 import { Solution, NUM_SOLUTIONS } from "../store/solutions/index";
@@ -208,10 +209,7 @@ export default Vue.extend({
           metrics: this.metrics,
           maxSolutions: NUM_SOLUTIONS,
           // intentionally nulled for now - should be made user settable in the future
-          maxTime: null,
-          onClose: () => {
-            this.$router.go(0);
-          }
+          maxTime: null
         })
         .then((res: Solution) => {
           this.pending = false;

--- a/public/store/solutions/actions.ts
+++ b/public/store/solutions/actions.ts
@@ -29,7 +29,6 @@ interface CreateSolutionRequest {
   maxSolutions: number;
   maxTime: number;
   filters: FilterParams;
-  onClose: Function;
 }
 
 interface SolutionStatus {

--- a/public/store/solutions/getters.ts
+++ b/public/store/solutions/getters.ts
@@ -139,9 +139,5 @@ export const getters = {
     const target = getters.getRouteTargetVariable;
     const variables = getters.getVariables;
     return variables.filter(variable => variable.colName === target);
-  },
-
-  getRequestStreams(state: SolutionState, getters: any): Dictionary<Stream> {
-    return state.streams;
   }
 };

--- a/public/store/solutions/index.ts
+++ b/public/store/solutions/index.ts
@@ -53,10 +53,8 @@ export interface SolutionRequest {
 
 export interface SolutionState {
   requests: SolutionRequest[];
-  streams: Dictionary<Stream>;
 }
 
 export const state: SolutionState = {
-  requests: [],
-  streams: {}
+  requests: []
 };

--- a/public/store/solutions/module.ts
+++ b/public/store/solutions/module.ts
@@ -33,8 +33,7 @@ export const getters = {
   ),
   getActiveSolutionTargetVariable: read(
     moduleGetters.getActiveSolutionTargetVariable
-  ),
-  getRequestStreams: read(moduleGetters.getRequestStreams)
+  )
 };
 
 export const actions = {
@@ -45,7 +44,5 @@ export const actions = {
 
 export const mutations = {
   updateSolutionRequests: commit(moduleMutations.updateSolutionRequests),
-  clearSolutionRequests: commit(moduleMutations.clearSolutionRequests),
-  addRequestStream: commit(moduleMutations.addRequestStream),
-  removeRequestStream: commit(moduleMutations.removeRequestStream)
+  clearSolutionRequests: commit(moduleMutations.clearSolutionRequests)
 };

--- a/public/store/solutions/mutations.ts
+++ b/public/store/solutions/mutations.ts
@@ -2,7 +2,6 @@ import _ from "lodash";
 import moment from "moment";
 import Vue from "vue";
 import { SolutionState, SolutionRequest } from "./index";
-import { Stream } from "../../util/ws";
 import { sortSolutionsByScore } from "./getters";
 
 export const mutations = {
@@ -31,7 +30,8 @@ export const mutations = {
           // otherwise replace
           if (
             moment(solution.timestamp) >
-            moment(existing.solutions[solutionIndex].timestamp)
+              moment(existing.solutions[solutionIndex].timestamp) ||
+            solution.progress !== existing.solutions[solutionIndex].progress
           ) {
             Vue.set(existing.solutions, solutionIndex, solution);
           }

--- a/public/store/solutions/mutations.ts
+++ b/public/store/solutions/mutations.ts
@@ -44,16 +44,5 @@ export const mutations = {
 
   clearSolutionRequests(state: SolutionState) {
     state.requests = [];
-  },
-
-  addRequestStream(
-    state: SolutionState,
-    args: { requestId: string; stream: Stream }
-  ) {
-    Vue.set(state.streams, args.requestId, args.stream);
-  },
-
-  removeRequestStream(state: SolutionState, args: { requestId: string }) {
-    Vue.delete(state.streams, args.requestId);
   }
 };

--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ fi
 export SOLUTION_COMPUTE_ENDPOINT=localhost:45042
 export ES_ENDPOINT=http://localhost:9200
 export SOLUTION_COMPUTE_TRACE=true
-export PG_LOG_LEVEL=debug # debug, error, warn, info, none
+export PG_LOG_LEVEL=none # debug, error, warn, info, none
 export SKIP_INGEST=true
 export SOLUTION_SEARCH_MAX_TIME=30000
 export SOLUTION_COMPUTE_PULL_MAX=900000


### PR DESCRIPTION
Fixes #1458 

1. Ensures that cluster function is properly integrated into caching mechanism provided by the `view` module
1. Ensures that cluster + ranking cache state is not wiped out by forced refresh of result data
1. Bonus websocket fix - websockets were never being cleaned up, and associated `Stream` objects were kept in the Vue store (which they shouldn't be, because they are a complex object that is not driving UI)