### PR TITLE
#1476 Sparkline Cutoff Fix.

### DIFF
--- a/public/components/FixedHeaderTable.vue
+++ b/public/components/FixedHeaderTable.vue
@@ -79,9 +79,9 @@ export default Vue.extend({
             ? cellOffsetWidth > remainingCellWidth
               ? cellOffsetWidth
               : remainingCellWidth
-            : cellOffsetWidth < maxCellWidth
-            ? cellOffsetWidth
-            : maxCellWidth;
+            : cellOffsetWidth < maxCellWidth || !!tbodyCells[i].querySelector("div")
+              ? cellOffsetWidth
+              : maxCellWidth;
         remainingCellWidth = remainingCellWidth - headCellWidth;
         headCells.push({ elem: theadCells[i], width: headCellWidth });
         allBodyCellsAsRows.forEach(row => {


### PR DESCRIPTION
Fixes #1476 - checks the table body cell for a child div before setting column width. handles not only the sparkline issue, but any other fixed width content we need to add to the table in future.