### PR TITLE
Ranking execution constraints

### DIFF
--- a/public/components/AvailableTargetVariables.vue
+++ b/public/components/AvailableTargetVariables.vue
@@ -32,7 +32,7 @@ import {
   VariableSummary,
   SummaryMode
 } from "../store/dataset/index";
-import { hasComputedVarPrefix, UNSUPPORTED_TARGET_TYPES } from "../util/types";
+import { hasComputedVarPrefix, isUnsupportedTargetVar } from "../util/types";
 import {
   AVAILABLE_TARGET_VARS_INSTANCE,
   SELECT_TRAINING_ROUTE
@@ -75,11 +75,7 @@ export default Vue.extend({
     unsupportedTargets(): Set<string> {
       return new Set(
         this.variables
-          .filter(
-            v =>
-              UNSUPPORTED_TARGET_TYPES.has(v.colType) ||
-              hasComputedVarPrefix(v.colName)
-          )
+          .filter(v => isUnsupportedTargetVar(v.colName, v.colType))
           .map(v => v.colName)
       );
     },

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -274,6 +274,20 @@ export const UNSUPPORTED_TARGET_TYPES = new Set([
   TEXT_TYPE
 ]);
 
+export const RANKABLE_VARIABLE_TYPES = new Set([
+  ...INTEGER_TYPES,
+  ...FLOATING_POINT_TYPES,
+  BOOL_TYPE,
+  DATE_TIME_TYPE,
+  TIMESTAMP_TYPE,
+  CATEGORICAL_TYPE,
+  ORDINAL_TYPE,
+  CITY_TYPE,
+  STATE_TYPE,
+  COUNTRY_TYPE,
+  COUNTRY_CODE_TYPE
+]);
+
 export function isEquivalentType(a: string, b: string): boolean {
   const equiv = EQUIV_TYPES[a];
   if (!equiv) {
@@ -400,6 +414,24 @@ export function isJoinable(type: string, otherType: string): boolean {
   const isSameType = type === otherType;
   const isBothNumericType = isNumericType(type) && isNumericType(otherType);
   return isSameType || isBothNumericType;
+}
+
+/**
+ * Returns true if a given variable can act as a target, false otherwise.
+ */
+export function isUnsupportedTargetVar(
+  varName: string,
+  varType: string
+): boolean {
+  return UNSUPPORTED_TARGET_TYPES.has(varType) || hasComputedVarPrefix(varName);
+}
+
+/**
+ * Returns ture if a given variable type can be processed as part of the feature ranking
+ * pipeline, false otherwise.
+ */
+export function isRankableVariableType(varType: string): boolean {
+  return RANKABLE_VARIABLE_TYPES.has(varType);
 }
 
 export function addTypeSuggestions(types: any[]): string[] {


### PR DESCRIPTION
fixes #1431 

1. Ensures that we don't display the red update dot for rankings that are either empty, or are the same as the previous ranking run.
1. Skips ranking when vars and target aren't going to produce meaningful ranks (ie. image data).
1. Ensures that we don't display red update dot for clustering when it hasn't been run