### PR TITLE
#1428 Data Fix For Expanded Lat/Lon in Geocoords

### DIFF
--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -50,8 +50,12 @@
             <template v-else-if="summary.varType === 'geocoordinate'">
               <geocoordinate-facet
                 :summary="summary"
+                :enable-highlighting="[enableHighlighting, enableHighlighting]"
+                :ignore-highlights="[ignoreHighlights, ignoreHighlights]"
                 :isAvailableFeatures="isAvailableFeatures"
                 :isFeaturesToModel="isFeaturesToModel"
+                @histogram-numerical-click="onNumericalClick"
+                @histogram-range-change="onRangeChange"
               >
               </geocoordinate-facet>
             </template>

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -17,10 +17,7 @@ import {
   URI_TYPE,
   DATE_TIME_TYPE,
   IMAGE_TYPE,
-  DATE_TIME_LOWER_TYPE,
-  LATITUDE_TYPE,
-  GEOCOORDINATE_TYPE,
-  LONGITUDE_TYPE
+  DATE_TIME_LOWER_TYPE
 } from "../util/types";
 import { getTimeseriesSummaryTopCategories } from "../util/data";
 import {
@@ -191,10 +188,6 @@ export function createSummaryFacet(summary: VariableSummary): Group {
       } else {
         return createCategoricalSummaryFacet(summary);
       }
-    case LATITUDE_TYPE + GEOCOORDINATE_TYPE:
-      return createLatitudeFacet(summary);
-    case LONGITUDE_TYPE + GEOCOORDINATE_TYPE:
-      return createLongitudeFacet(summary);
     case NUMERICAL_SUMMARY:
       return createNumericalSummaryFacet(summary);
     case TIMESERIES_SUMMMARY:
@@ -437,97 +430,6 @@ function createNumericalSummaryFacet(summary: VariableSummary): Group {
     dataset: summary.dataset,
     colName: summary.key,
     label: summary.label,
-    description: summary.description,
-    key: `${summary.dataset}:${summary.key}`,
-    type: summary.varType,
-    collapsible: false,
-    collapsed: false,
-    facets: [
-      {
-        histogram: {
-          slices: slices
-        },
-        filterable: false,
-        selection: {} as any
-      }
-    ],
-    summary: summary
-  };
-}
-
-// to do update loops to reduce to the opposite axis to build latitude slices
-function createLatitudeFacet(summary: VariableSummary): Group {
-  const buckets = summary.filtered
-    ? summary.filtered.buckets
-    : summary.baseline.buckets;
-  const slices = new Array(buckets[0].buckets.length);
-
-  for (let i = 0; i < slices.length; i++) {
-    const from = _.toNumber(buckets[0].buckets[i].key);
-    const to =
-      i < slices.length - 1
-        ? _.toNumber(buckets[0].buckets[i + 1].key)
-        : from + from - _.toNumber(buckets[0].buckets[i - 1].key);
-    slices[i] = {
-      label: from,
-      toLabel: to,
-      count: buckets.reduce((c, lonBucket) => {
-        if (lonBucket.buckets[i].count > 0) {
-          c += lonBucket.buckets[i].count;
-        }
-        return c;
-      }, 0)
-    };
-  }
-
-  return {
-    dataset: summary.dataset,
-    colName: summary.key,
-    label: "Latitude",
-    description: summary.description,
-    key: `${summary.dataset}:${summary.key}`,
-    type: summary.varType,
-    collapsible: false,
-    collapsed: false,
-    facets: [
-      {
-        histogram: {
-          slices: slices
-        },
-        filterable: false,
-        selection: {} as any
-      }
-    ],
-    summary: summary
-  };
-}
-
-function createLongitudeFacet(summary: VariableSummary): Group {
-  const buckets = summary.filtered
-    ? summary.filtered.buckets
-    : summary.baseline.buckets;
-  const slices = new Array(buckets.length);
-  buckets.forEach((lonBucket, i) => {
-    const from = _.toNumber(lonBucket.key);
-    const to =
-      i < buckets.length - 1
-        ? _.toNumber(buckets[i + 1].key)
-        : from + from - _.toNumber(buckets[i - 1].key);
-    slices[i] = {
-      label: from,
-      toLabel: to,
-      count: lonBucket.buckets.reduce((c, latBucket) => {
-        if (latBucket.count > 0) {
-          c += latBucket.count;
-        }
-        return c;
-      }, 0)
-    };
-  });
-  return {
-    dataset: summary.dataset,
-    colName: summary.key,
-    label: "Longitude",
     description: summary.description,
     key: `${summary.dataset}:${summary.key}`,
     type: summary.varType,


### PR DESCRIPTION
Fixes #1428. Updates the geocoordinate facet to generate data from the geocoordinate data that mimics the numerical summary normally returned by latitude and longitude such that filter changes are correctly reflected in those expanded facets with baseline and filtered data. Also includes some initial work for #1427 as part of making the facets interactive ties to leveraging the same existing numerical facet, but can be merged back as is without blocking further work on #1427 and without putting the front into a confusing state.