### PR TITLE
1427 - interactive lat/lon for geocoords

### DIFF
--- a/public/components/VariableFacets.vue
+++ b/public/components/VariableFacets.vue
@@ -50,10 +50,11 @@
             <template v-else-if="summary.varType === 'geocoordinate'">
               <geocoordinate-facet
                 :summary="summary"
-                :enable-highlighting="[enableHighlighting, enableHighlighting]"
-                :ignore-highlights="[ignoreHighlights, ignoreHighlights]"
+                :enable-highlighting="enableHighlighting"
+                :ignore-highlights="ignoreHighlights"
                 :isAvailableFeatures="isAvailableFeatures"
                 :isFeaturesToModel="isFeaturesToModel"
+                :log-activity="logActivity"
                 @histogram-numerical-click="onNumericalClick"
                 @histogram-range-change="onRangeChange"
               >


### PR DESCRIPTION
Fixes #1427 - changes to geocooordinate to map the highlight back and forth to the correct formats such that you can set or edit a range in either and it reflects on the map, and changes to the map selection reflect in the histogram ranges.