### PR TITLE
Removed dataset source from image route.

### DIFF
--- a/api/routes/image.go
+++ b/api/routes/image.go
@@ -21,7 +21,6 @@ import (
 
 	"goji.io/v3/pat"
 
-	api "github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil/api/env"
 	"github.com/uncharted-distil/distil/api/model"
 )
@@ -35,7 +34,6 @@ func ImageHandler(ctor model.MetadataStorageCtor, config *env.Config) func(http.
 	return func(w http.ResponseWriter, r *http.Request) {
 		// resources can either be local or remote
 		dataset := pat.Param(r, "dataset")
-		source := pat.Param(r, "source")
 		file := pat.Param(r, "file")
 		path := path.Join(imageFolder, file)
 
@@ -52,7 +50,7 @@ func ImageHandler(ctor model.MetadataStorageCtor, config *env.Config) func(http.
 			return
 		}
 
-		sourcePath := env.ResolvePath(api.DatasetSource(source), res.Folder)
+		sourcePath := env.ResolvePath(res.Source, res.Folder)
 
 		bytes, err := fetchResourceBytes(sourcePath, dataset, path)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -273,7 +273,7 @@ func main() {
 	registerRoutePost(mux, "/distil/event", routes.UserEventHandler(discoveryLogger))
 
 	// static
-	registerRoute(mux, "/distil/image/:dataset/:source/:file", routes.ImageHandler(esMetadataStorageCtor, &config))
+	registerRoute(mux, "/distil/image/:dataset/:file", routes.ImageHandler(esMetadataStorageCtor, &config))
 	registerRoute(mux, "/distil/graphs/:dataset/:file", routes.GraphsHandler(config.D3MInputDir))
 	registerRoute(mux, "/*", routes.FileHandler("./dist"))
 

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -207,7 +207,6 @@ export default Vue.extend({
       datasetActions
         .fetchImage(this.$store, {
           dataset: this.dataset,
-          source: "seed",
           url: this.imageUrl
         })
         .then(() => {

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1019,7 +1019,6 @@ export const actions = {
         if (type === IMAGE_TYPE) {
           return actions.fetchImage(context, {
             dataset: args.dataset,
-            source: "seed",
             url: url
           });
         }
@@ -1039,7 +1038,7 @@ export const actions = {
 
   async fetchImage(
     context: DatasetContext,
-    args: { dataset: string; source: string; url: string }
+    args: { dataset: string; url: string }
   ) {
     if (!args.url) {
       console.warn("`url` argument is missing");
@@ -1051,7 +1050,7 @@ export const actions = {
     }
     try {
       const response = await loadImage(
-        `distil/image/${args.dataset}/${args.source}/${args.url}`
+        `distil/image/${args.dataset}/${args.url}`
       );
       mutations.updateFile(context, { url: args.url, file: response });
     } catch (error) {


### PR DESCRIPTION
Updated the image route to no longer require the dataset source. Instead, the source from the dataset metadata is used. This means non seed datasets will have images returned properly.