### PR TITLE
1499 mosaic view fix

### DIFF
--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -107,12 +107,12 @@ export default Vue.extend({
     },
 
     fields(): Dictionary<TableColumn> {
-      if (this.dataFields) {
-        return this.dataFields;
-      }
-      return this.includedActive
+      const currentFields = this.dataFields
+        ? this.dataFields
+        : this.includedActive
         ? datasetGetters.getIncludedTableDataFields(this.$store)
         : datasetGetters.getExcludedTableDataFields(this.$store);
+      return currentFields;
     },
 
     rowSelection(): RowSelection {
@@ -175,14 +175,14 @@ export default Vue.extend({
 
 <style>
 .image-mosaic {
-  display: flex;
-  overflow: auto;
-  flex-flow: wrap;
+  display: block;
+  overflow: visible;
 }
 
 .image-tile {
-  display: flex;
+  display: inline-block;
   position: relative;
+  vertical-align: bottom;
   margin: 2px;
 }
 

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -2,6 +2,7 @@
   <div
     v-observe-visibility="visibilityChanged"
     v-bind:class="{ 'is-hidden': !isVisible && !preventHiding }"
+    v-bind:style="{ width: `${width}px`, height: `${height}px` }"
   >
     <div
       class="image-container"
@@ -14,11 +15,7 @@
         @click.stop="handleClick"
         v-bind:style="{ 'max-width': `${width}px` }"
       >
-        <div
-          v-if="!isLoaded"
-          v-html="spinnerHTML"
-          v-bind:style="{ width: `${width}px`, height: `${height}px` }"
-        ></div>
+        <div v-if="!isLoaded" v-html="spinnerHTML"></div>
       </div>
     </div>
     <b-modal
@@ -74,6 +71,8 @@ export default Vue.extend({
   watch: {
     imageUrl(newUrl, oldUrl) {
       if (newUrl !== oldUrl) {
+        this.hasRendered = false;
+        this.hasRequested = false;
         if (!this.image) {
           this.clearImage();
           this.requestImage();
@@ -105,7 +104,7 @@ export default Vue.extend({
       return datasetGetters.getFiles(this.$store);
     },
     isLoaded(): boolean {
-      return !!this.files[this.imageUrl];
+      return !!this.files[this.imageUrl] || !this.hasRendered;
     },
     image(): HTMLImageElement {
       return this.files[this.imageUrl];

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -104,7 +104,7 @@ export default Vue.extend({
       return datasetGetters.getFiles(this.$store);
     },
     isLoaded(): boolean {
-      return !!this.files[this.imageUrl] || !this.hasRendered;
+      return !!this.files[this.imageUrl];
     },
     image(): HTMLImageElement {
       return this.files[this.imageUrl];


### PR DESCRIPTION
Fixed #1499. image mosaic loading issues. Changes to image preview to reset render and request state when the image url changes as well simplifying styling in image preview and mosaic components such that images previews just wrap as inline-blocks, no flex box fanciness where we don't want it, and setting any width/height inputs on higher level dom elements as well. Also some simplified computed logic in the mosaic.