### PR TITLE
#1479 fixes firefox images

### DIFF
--- a/api/middleware/gzip.go
+++ b/api/middleware/gzip.go
@@ -36,6 +36,10 @@ func isGzipSupported(r *http.Request) bool {
 	return strings.Contains(r.Header.Get("Accept-Encoding"), "gzip")
 }
 
+func isImage(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "image")
+}
+
 func isWebsocketUpgrade(r *http.Request) bool {
 	return r.Header.Get("Upgrade") == "websocket"
 }
@@ -43,7 +47,7 @@ func isWebsocketUpgrade(r *http.Request) bool {
 // Gzip represents a middleware handler to support gzip compression.
 func Gzip(h http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		if !isGzipSupported(r) || isWebsocketUpgrade(r) {
+		if !isGzipSupported(r) || isWebsocketUpgrade(r) || isImage(r) {
 			// do not use gzip
 			h.ServeHTTP(w, r)
 			return


### PR DESCRIPTION
Fixes #1479 - Firefox recently changed it's headers relating to images such that our general gzipping broke image returns for Firefox. Since images are usually already compressed, there was no gain in gzipping them anyway, so checking requests to see if they're for an image and bypassing gzip is fine, and solves the firefox image problem.