### PR TITLE
Queue pipeline requests

### DIFF
--- a/api/compute/pipeline.go
+++ b/api/compute/pipeline.go
@@ -103,6 +103,7 @@ func (q *Queue) Enqueue(key string, data interface{}) chan *QueueResponse {
 	if queuedItem != nil {
 		log.Infof("'%s' already in queue so adding one more channel to output", key)
 		queuedItem.output = append(queuedItem.output, output)
+		queuedItem.data = data
 		q.mu.Unlock()
 
 		return output

--- a/api/compute/pipeline.go
+++ b/api/compute/pipeline.go
@@ -35,15 +35,35 @@ var (
 )
 
 type pipelineQueueTask struct {
-	client        *compute.Client
-	request       *compute.ExecPipelineRequest
-	searchRequest *pipeline.SearchSolutionsRequest
-	step          *pipeline.PipelineDescription
+	client          *compute.Client
+	request         *compute.ExecPipelineRequest
+	searchRequest   *pipeline.SearchSolutionsRequest
+	step            *pipeline.PipelineDescription
+	datasets        []string
+	datasetsProduce []string
+}
+
+func (t *pipelineQueueTask) hash() (string, error) {
+	// use the json representation of the step since the nested structures
+	// require casting that the library can't handle
+	stepString, err := marshalSteps(t.step)
+	if err != nil {
+		return "", err
+	}
+
+	hashedPipeline, err := hashstructure.Hash([]interface{}{stepString, t.datasets, t.datasetsProduce, t.searchRequest}, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to hash pipeline")
+	}
+	hashedPipelineKey := fmt.Sprintf("%d", hashedPipeline)
+
+	return hashedPipelineKey, nil
 }
 
 // QueueItem is the wrapper for the data to process and the response channel.
 type QueueItem struct {
-	output chan *QueueResponse
+	key    string
+	output []chan *QueueResponse
 	data   interface{}
 }
 
@@ -55,17 +75,36 @@ type QueueResponse struct {
 
 // Queue uses a buffered channel to queue tasks and provides the result via channels.
 type Queue struct {
-	tasks chan *QueueItem
+	mu            sync.RWMutex
+	tasks         chan *QueueItem
+	alreadyQueued map[string]*QueueItem
 }
 
 // Enqueue adds one entry to the queue, providing the response channel as result.
-func (q *Queue) Enqueue(data interface{}) chan *QueueResponse {
-	log.Infof("enqueuing data on the queue")
+// If the key is already in the queue, then the data is not added a second time.
+// Rather, a new output channel is added
+func (q *Queue) Enqueue(key string, data interface{}) chan *QueueResponse {
+	log.Infof("enqueuing data in the queue")
 	output := make(chan *QueueResponse, 1)
-	item := &QueueItem{
-		data:   data,
-		output: output,
+
+	// use key to check if it is already in the queue
+	q.mu.Lock()
+	queuedItem := q.alreadyQueued[key]
+	if queuedItem != nil {
+		log.Infof("'%s' already in queue so adding one more channel to output", key)
+		queuedItem.output = append(queuedItem.output, output)
+		q.mu.Unlock()
+
+		return output
 	}
+	log.Infof("'%s' not in queue so creating new item", key)
+	item := &QueueItem{
+		key:    key,
+		data:   data,
+		output: []chan *QueueResponse{output},
+	}
+	q.alreadyQueued[key] = item
+	q.mu.Unlock()
 
 	q.tasks <- item
 
@@ -75,7 +114,13 @@ func (q *Queue) Enqueue(data interface{}) chan *QueueResponse {
 // Dequeue removes one item from the queue.
 func (q *Queue) Dequeue() *QueueItem {
 	log.Infof("dequeuing data from the queue")
-	return <-q.tasks
+	item := <-q.tasks
+
+	q.mu.Lock()
+	q.alreadyQueued[item.key] = nil
+	q.mu.Unlock()
+
+	return item
 }
 
 // Cache uses a simple map to lookup data stored in memory. Access to the cache
@@ -108,10 +153,13 @@ func InitializeCache() {
 	}
 }
 
+// InitializeQueue creates the pipeline queue and runs go routine to process pipeline requests
 func InitializeQueue(config *env.Config) {
 	queue = &Queue{
 		tasks: make(chan *QueueItem, config.PipelineQueueSize),
 	}
+
+	go runPipelineQueue(queue)
 }
 
 // SubmitPipeline executes pipelines using the client and returns the result URI.
@@ -120,31 +168,27 @@ func SubmitPipeline(client *compute.Client, datasets []string, datasetsProduce [
 
 	request := compute.NewExecPipelineRequest(datasets, datasetsProduce, step)
 
+	queueTask := &pipelineQueueTask{
+		request:         request,
+		searchRequest:   searchRequest,
+		client:          client,
+		step:            step,
+		datasets:        datasets,
+		datasetsProduce: datasetsProduce,
+	}
+
 	// check cache to see if results are already available
-	stepString, err := marshalSteps(step)
+	hashedPipelineKey, err := queueTask.hash()
 	if err != nil {
 		return "", err
 	}
-
-	hashedPipeline, err := hashstructure.Hash([]interface{}{stepString, datasets, datasetsProduce, searchRequest}, nil)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to hash pipeline")
-	}
-	hashedPipelineKey := fmt.Sprintf("%d", hashedPipeline)
-	log.Infof("hash key: %s\traw: %v", hashedPipelineKey, hashedPipeline)
-
 	entry, found := pipelineCache.Get(hashedPipelineKey)
 	if found {
 		log.Infof("returning cached entry for pipeline")
 		return entry.(string), nil
 	}
 
-	resultChan := queue.Enqueue(&pipelineQueueTask{
-		request:       request,
-		searchRequest: searchRequest,
-		client:        client,
-		step:          step,
-	})
+	resultChan := queue.Enqueue(hashedPipelineKey, queueTask)
 
 	result := <-resultChan
 	if result.Error != nil {
@@ -167,23 +211,22 @@ func marshalSteps(step *pipeline.PipelineDescription) (string, error) {
 }
 
 func runPipelineQueue(queue *Queue) {
-	for {
-		queueTask := <-queue.tasks
+	for queueTask := range queue.tasks {
 		log.Infof("processing data pulled from the queue")
 
 		pipelineTask, ok := queueTask.data.(*pipelineQueueTask)
 		if !ok {
-			queueTask.output <- &QueueResponse{
+			queueTask.returnResult(&QueueResponse{
 				Error: errors.Errorf("data pulled from queue is not a pipeline"),
-			}
+			})
 			continue
 		}
 
 		err := pipelineTask.request.Dispatch(pipelineTask.client, pipelineTask.searchRequest)
 		if err != nil {
-			queueTask.output <- &QueueResponse{
+			queueTask.returnResult(&QueueResponse{
 				Error: errors.Wrap(err, "unable to dispatch pipeline"),
-			}
+			})
 			continue
 		}
 
@@ -201,23 +244,27 @@ func runPipelineQueue(queue *Queue) {
 			}
 		})
 		if err != nil {
-			queueTask.output <- &QueueResponse{
+			queueTask.returnResult(&QueueResponse{
 				Error: errors.Wrap(err, "unable to listen to pipeline"),
-			}
+			})
 			continue
 		}
 
 		if errPipeline != nil {
-			queueTask.output <- &QueueResponse{
+			queueTask.returnResult(&QueueResponse{
 				Error: errors.Wrap(errPipeline, "error executing pipeline"),
-			}
+			})
 			continue
 		}
 
 		datasetURI = strings.Replace(datasetURI, "file://", "", -1)
 
-		queueTask.output <- &QueueResponse{
-			Output: datasetURI,
-		}
+		queueTask.returnResult(&QueueResponse{Output: datasetURI})
+	}
+}
+
+func (qi *QueueItem) returnResult(response *QueueResponse) {
+	for _, oc := range qi.output {
+		oc <- response
 	}
 }

--- a/api/env/config.go
+++ b/api/env/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	MaxTestRows                        int     `env:"MAX_TEST_ROWS" envDefault:"10000"`
 	MergedOutputDataPath               string  `env:"MERGED_OUTPUT_DATA_PATH" envDefault:"merged/tables/learningData.csv"`
 	MergedOutputSchemaPath             string  `env:"MERGED_OUTPUT_SCHEMA_PATH" envDefault:"merged/datasetDoc.json"`
+	PipelineQueueSize                  int     `env:"PIPELINE_QUEUE_SIZE" envDefault:"10"`
 	PostgresBatchSize                  int     `env:"PG_BATCH_SIZE" envDefault:"1000"`
 	PostgresHost                       string  `env:"PG_HOST" envDefault:"localhost"`
 	PostgresPort                       int     `env:"PG_PORT" envDefault:"5432"`

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
-	"github.com/uncharted-distil/distil-compute/pipeline"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/result"
 
@@ -133,7 +132,7 @@ func Cluster(datasetInputDir string, dataset string, variable string, features [
 		}
 	}
 
-	var step *pipeline.PipelineDescription
+	var step *description.FullySpecifiedPipeline
 	var err error
 	addMeta := false
 	if model.IsImage(clusteringVar.Type) {

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	ingestMetadata "github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
-	"github.com/uncharted-distil/distil-compute/pipeline"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil/api/env"
@@ -40,7 +39,7 @@ const (
 )
 
 type primitiveSubmitter interface {
-	submit(datasetURIs []string, pipelineDesc *pipeline.PipelineDescription) (string, error)
+	submit(datasetURIs []string, pipelineDesc *description.FullySpecifiedPipeline) (string, error)
 }
 
 // JoinSpec stores information for one side of a join operation.
@@ -113,7 +112,7 @@ func join(joinLeft *JoinSpec, joinRight *JoinSpec, varsLeft []*model.Variable,
 
 type defaultSubmitter struct{}
 
-func (defaultSubmitter) submit(datasetURIs []string, pipelineDesc *pipeline.PipelineDescription) (string, error) {
+func (defaultSubmitter) submit(datasetURIs []string, pipelineDesc *description.FullySpecifiedPipeline) (string, error) {
 	return submitPipeline(datasetURIs, pipelineDesc)
 }
 

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -23,14 +23,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/uncharted-distil/distil-compute/model"
-	"github.com/uncharted-distil/distil-compute/pipeline"
+	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil/api/env"
 	apiModel "github.com/uncharted-distil/distil/api/model"
 )
 
 type testSubmitter struct{}
 
-func (testSubmitter) submit(datasetURIs []string, pipelineDesc *pipeline.PipelineDescription) (string, error) {
+func (testSubmitter) submit(datasetURIs []string, pipelineDesc *description.FullySpecifiedPipeline) (string, error) {
 	return "file://test_data/result.csv", nil
 }
 

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -25,7 +25,6 @@ import (
 	"github.com/uncharted-distil/distil-compute/metadata"
 
 	"github.com/uncharted-distil/distil-compute/model"
-	"github.com/uncharted-distil/distil-compute/pipeline"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil/api/util"
@@ -45,7 +44,7 @@ func Merge(datasetSource metadata.DatasetSource, schemaFile string, index string
 	}
 
 	// create & submit the solution request
-	var pip *pipeline.PipelineDescription
+	var pip *description.FullySpecifiedPipeline
 	timeseries, _, _ := isTimeseriesDataset(meta)
 	if timeseries {
 		pip, err = description.CreateTimeseriesFormatterPipeline("Time Cop", "", compute.DefaultResourceID)

--- a/api/task/pipelines.go
+++ b/api/task/pipelines.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/model"
-	"github.com/uncharted-distil/distil-compute/pipeline"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/result"
@@ -47,7 +46,7 @@ type FeatureRequest struct {
 	FeatureVariableName string
 	OutputVariableName  string
 	Variable            *model.Variable
-	Step                *pipeline.PipelineDescription
+	Step                *description.FullySpecifiedPipeline
 	Clustering          bool
 }
 
@@ -63,7 +62,7 @@ func SetClient(computeClient *compute.Client) {
 	client = computeClient
 }
 
-func submitPipeline(datasets []string, step *pipeline.PipelineDescription) (string, error) {
+func submitPipeline(datasets []string, step *description.FullySpecifiedPipeline) (string, error) {
 	return sr.SubmitPipeline(client, datasets, nil, nil, step)
 }
 
@@ -135,7 +134,7 @@ func getClusterVariables(meta *model.Metadata, prefix string) ([]*FeatureRequest
 					model.CategoricalType, "", []string{"attribute"}, model.VarRoleMetadata, nil, mainDR.Variables, false)
 
 				// create the required pipeline
-				var step *pipeline.PipelineDescription
+				var step *description.FullySpecifiedPipeline
 				var err error
 				outputName := ""
 				if colNames, ok := getTimeValueCols(res); ok {

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/shopspring/decimal v0.0.0-20191009025716-f1972eb1d1f5 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/uncharted-distil/distil-compute v0.0.0-20200306180146-c5d7410d83a5
+	github.com/uncharted-distil/distil-compute v0.0.0-20200309191427-cb4ce6f26930
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
 	github.com/zenazn/goji v0.9.0

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/shopspring/decimal v0.0.0-20191009025716-f1972eb1d1f5 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/uncharted-distil/distil-compute v0.0.0-20200225133502-8e2d58b299b2
+	github.com/uncharted-distil/distil-compute v0.0.0-20200306180146-c5d7410d83a5
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
 	github.com/zenazn/goji v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/uncharted-distil/distil-compute v0.0.0-20200225133502-8e2d58b299b2 h1:RjJObumqKU4O8QHi2+M45G1jv8QO3ElWxWzdOs9M0DM=
-github.com/uncharted-distil/distil-compute v0.0.0-20200225133502-8e2d58b299b2/go.mod h1:0OFz5vP7mV1nuvKvINOG7hdz8YU0+rWhjppdYBzOSew=
+github.com/uncharted-distil/distil-compute v0.0.0-20200306180146-c5d7410d83a5 h1:8wZjRU2WdzlZ13ea8kJLgIJpcqjelkZRrC3dlsOFCFc=
+github.com/uncharted-distil/distil-compute v0.0.0-20200306180146-c5d7410d83a5/go.mod h1:0OFz5vP7mV1nuvKvINOG7hdz8YU0+rWhjppdYBzOSew=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9/go.mod h1:PrytgQ5GjTc6Z5/pbL5vj1UhD716wDobDeimrd7lRKY=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48 h1:XYef2jcFEKziHl4rv/21jrNeQg6Z3gL345u16fHWVDo=

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/uncharted-distil/distil-compute v0.0.0-20200306180146-c5d7410d83a5 h1:8wZjRU2WdzlZ13ea8kJLgIJpcqjelkZRrC3dlsOFCFc=
-github.com/uncharted-distil/distil-compute v0.0.0-20200306180146-c5d7410d83a5/go.mod h1:0OFz5vP7mV1nuvKvINOG7hdz8YU0+rWhjppdYBzOSew=
+github.com/uncharted-distil/distil-compute v0.0.0-20200309191427-cb4ce6f26930 h1:KR/+u8bFZF1ysLwqqqvip0xyqwrQGWcSUfiB5OsVX/E=
+github.com/uncharted-distil/distil-compute v0.0.0-20200309191427-cb4ce6f26930/go.mod h1:0OFz5vP7mV1nuvKvINOG7hdz8YU0+rWhjppdYBzOSew=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9/go.mod h1:PrytgQ5GjTc6Z5/pbL5vj1UhD716wDobDeimrd7lRKY=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48 h1:XYef2jcFEKziHl4rv/21jrNeQg6Z3gL345u16fHWVDo=

--- a/main.go
+++ b/main.go
@@ -87,8 +87,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// initialize the pipeline cache
+	// initialize the pipeline cache and queue
 	api.InitializeCache()
+	api.InitializeQueue(&config)
 
 	// initialize the user event logger - records user interactions with the system in a CSV file for post-run
 	// analysis


### PR DESCRIPTION
Added a queue for fully specified pipeline processing. If an equivalent pipeline is already in the queue, then both requests will use the same result instead of duplicating processing.

Equivalent pipelines are determined by using the equivalent fields of fully specified pipelines. The main idea is that MI ranking pipelines are equivalent if the datasets and target are the same.