### PR TITLE
Persist Pipeline Cache

### DIFF
--- a/api/compute/pipeline.go
+++ b/api/compute/pipeline.go
@@ -253,7 +253,10 @@ func SubmitPipeline(client *compute.Client, datasets []string, datasetsProduce [
 
 	datasetURI := result.Output.(string)
 	cache.cache.Set(hashedPipelineUniqueKey, datasetURI, gc.DefaultExpiration)
-	cache.PersistCache()
+	err = cache.PersistCache()
+	if err != nil {
+		log.Warnf("error persisting cache: %v", err)
+	}
 
 	return datasetURI, nil
 }

--- a/api/env/config.go
+++ b/api/env/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	MaxTestRows                        int     `env:"MAX_TEST_ROWS" envDefault:"10000"`
 	MergedOutputDataPath               string  `env:"MERGED_OUTPUT_DATA_PATH" envDefault:"merged/tables/learningData.csv"`
 	MergedOutputSchemaPath             string  `env:"MERGED_OUTPUT_SCHEMA_PATH" envDefault:"merged/datasetDoc.json"`
+	PipelineCacheFilename              string  `env:"PIPELINE_CACHE_FILENAME" envDefault:"cache.bin"`
 	PipelineQueueSize                  int     `env:"PIPELINE_QUEUE_SIZE" envDefault:"10"`
 	PostgresBatchSize                  int     `env:"PG_BATCH_SIZE" envDefault:"1000"`
 	PostgresHost                       string  `env:"PG_HOST" envDefault:"localhost"`

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/onsi/ginkgo v1.10.3 // indirect
 	github.com/onsi/gomega v1.7.1 // indirect
 	github.com/otiai10/copy v1.0.2
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.8.1
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/satori/go.uuid v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ry
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -87,8 +87,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// initialize the pipeline cache and queue
-	api.InitializeCache()
+	// initialize the pipeline cache and
+	pipelineCacheFilename := path.Join(env.GetTmpPath(), config.PipelineCacheFilename)
+	api.InitializeCache(pipelineCacheFilename)
 	api.InitializeQueue(&config)
 
 	// initialize the user event logger - records user interactions with the system in a CSV file for post-run

--- a/main.go
+++ b/main.go
@@ -89,7 +89,11 @@ func main() {
 
 	// initialize the pipeline cache and
 	pipelineCacheFilename := path.Join(env.GetTmpPath(), config.PipelineCacheFilename)
-	api.InitializeCache(pipelineCacheFilename)
+	err = api.InitializeCache(pipelineCacheFilename)
+	if err != nil {
+		log.Errorf("%+v", err)
+		os.Exit(1)
+	}
 	api.InitializeQueue(&config)
 
 	// initialize the user event logger - records user interactions with the system in a CSV file for post-run


### PR DESCRIPTION
Added go-cache for the pipeline cache. This lets us persist a bit easier and makes it simpler to expire cached data.