### PR TITLE
Sparkline normalization & other minor fixes

### DIFF
--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -174,8 +174,11 @@ func (s *Storage) FetchTimeseries(dataset string, storageName string, timeseries
 	where := fmt.Sprintf("WHERE %s", strings.Join(wheres, " AND "))
 
 	// Get count by category.
-	query := fmt.Sprintf("SELECT \"%s\", \"%s\" FROM %s %s",
-		xColName, yColName, storageName, where)
+	query := fmt.Sprintf("SELECT timeline.TimeStamps, COALESCE(filteredEvents.Counts, 0) FROM "+
+		"(SELECT DISTINCT \"%s\" as TimeStamps FROM %s) timeline LEFT JOIN "+
+		"(SELECT \"%s\" as TimeStamps, \"%s\" as Counts FROM %s %s ) filteredEvents "+
+		"ON timeline.TimeStamps = filteredEvents.TimeStamps ORDER BY timeline.TimeStamps",
+		xColName, storageName, xColName, yColName, storageName, where)
 
 	// execute the postgres query
 	res, err := s.client.Query(query, params...)

--- a/public/components/FacetEntry.vue
+++ b/public/components/FacetEntry.vue
@@ -510,6 +510,8 @@ export default Vue.extend({
         highlightValue &&
         facet &&
         facet.value &&
+        typeof highlightValue === "string" &&
+        typeof facet.value === "string" &&
         highlightValue.toLowerCase() === facet.value.toLowerCase()
       );
     },

--- a/public/components/SparklineRow.vue
+++ b/public/components/SparklineRow.vue
@@ -11,6 +11,7 @@
       :timeseries="timeseries"
       :forecast="forecast"
       :highlightRange="highlightRange"
+      :isDateTime="isDateTime"
     >
     </sparkline-svg>
     <div
@@ -114,6 +115,23 @@ export default Vue.extend({
     },
     max(): number {
       return this.timeseries ? d3.max(this.timeseries, d => d[1]) : 0;
+    },
+    isDateTime(): boolean {
+      if (this.solutionId) {
+        const timeseries = resultsGetters.getPredictedTimeseries(this.$store);
+        const solutions = timeseries[this.solutionId];
+        if (!solutions) {
+          return null;
+        }
+        return solutions.isDateTime[this.timeseriesId];
+      } else {
+        const timeseries = datasetGetters.getTimeseries(this.$store);
+        const datasets = timeseries[this.dataset];
+        if (!datasets) {
+          return null;
+        }
+        return datasets.isDateTime[this.timeseriesId];
+      }
     }
   },
 

--- a/public/components/SparklineSvg.vue
+++ b/public/components/SparklineSvg.vue
@@ -43,6 +43,9 @@ export default Vue.extend({
     },
     forecastExtrema: {
       type: Object as () => TimeseriesExtrema
+    },
+    isDateTime: {
+      type: Boolean as () => Boolean
     }
   },
   data() {
@@ -323,6 +326,15 @@ export default Vue.extend({
 
       return true;
     },
+    formatExtremaX(extrema): string {
+      return this.isDateTime
+        ? new Date(extrema)
+            .toISOString()
+            .slice(0, 10)
+            .replace(/-/g, "/")
+            .toString()
+        : extrema.toString();
+    },
     injectAxis(): boolean {
       if (!this.$svg || !this.timeseries || this.timeseries.length === 0) {
         return false;
@@ -352,14 +364,8 @@ export default Vue.extend({
         );
       }
 
-      const dateMinX = new Date(minX)
-        .toISOString()
-        .slice(0, 10)
-        .replace(/-/g, "/");
-      const dateMaxX = new Date(maxX)
-        .toISOString()
-        .slice(0, 10)
-        .replace(/-/g, "/");
+      const dateMinX = this.formatExtremaX(minX);
+      const dateMaxX = this.formatExtremaX(maxX);
 
       this.xScale = d3
         .scaleLinear()
@@ -391,7 +397,7 @@ export default Vue.extend({
         .attr("class", "sparkline-axis-title")
         .attr("x", 0)
         .attr("y", 10)
-        .style("text-anchor", "left")
+        .style("text-anchor", "start")
         .text(maxY);
       // Create y-min & x-min
       this.svg
@@ -399,15 +405,15 @@ export default Vue.extend({
         .attr("class", "sparkline-axis-title")
         .attr("x", 0)
         .attr("y", 40)
-        .style("text-anchor", "left")
+        .style("text-anchor", "start")
         .text(`${minY} ${dateMinX}`);
       // Create x-max
       this.svg
         .append("text")
         .attr("class", "sparkline-axis-title")
-        .attr("x", 330)
+        .attr("x", 400)
         .attr("y", 40)
-        .style("text-anchor", "right")
+        .style("text-anchor", "end")
         .text(dateMaxX);
       return true;
     },

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1091,7 +1091,13 @@ export const actions = {
 
     try {
       const response = await axios.post(
-        `distil/timeseries/${args.dataset}/${args.timeseriesColName}/${args.xColName}/${args.yColName}/${args.timeseriesID}/false`,
+        `distil/timeseries/${encodeURIComponent(
+          args.dataset
+        )}/${encodeURIComponent(args.timeseriesColName)}/${encodeURIComponent(
+          args.xColName
+        )}/${encodeURIComponent(args.yColName)}/${encodeURIComponent(
+          args.timeseriesID
+        )}/false`,
         {}
       );
       mutations.updateTimeseries(context, {


### PR DESCRIPTION
Fixes #1517 - Inccorrect Extrema for non-datetime timeseries. Checks if timeseries is date time before formatting extrema, also reduces code duplication for extrema parsing. 

Also fixes issues with unescaped characters in URLs breaking calls for timeseries data & issues with highlights being assumed to be strings when they're object for date ranges from a timeseries clustered facet.

Has draft code normalizing the data return for timeseries against the set of all dates by doing a join on the set of all dates with existing db select call such that we return all dates even when we don't have data for all dates for a given category - missing data is currently filled with zeroes, but this code will be extend to take a bins count and binning Op such that we can better normalize the data still in the case of missing information while making the data more clear/accurate/informative.