### PR TITLE
#1510 Allow & Detect zip file uploads for image datasets.

### DIFF
--- a/public/components/FileUploader.vue
+++ b/public/components/FileUploader.vue
@@ -12,12 +12,12 @@
       @ok="handleOk()"
       @show="clearFile()"
     >
-      <p>Select a csv file to import</p>
+      <p>{{ modalText }}</p>
       <b-form-file
         ref="fileinput"
         v-model="file"
         :state="Boolean(file)"
-        accept=".csv"
+        :accept="allowedTypes"
         plain
       />
       <div class="mt-3">Selected file: {{ file ? file.name : "" }}</div>
@@ -58,6 +58,25 @@ export default Vue.extend({
           return "Import File";
       }
     },
+    modalText(): string {
+      switch (this.uploadType) {
+        case PREDICTION_UPLOAD:
+          return "Select a csv file to import";
+        case DATASET_UPLOAD:
+        default:
+          return "Select a csv or zip file to import";
+      }
+    },
+    allowedTypes(): string {
+      switch (this.uploadType) {
+        case PREDICTION_UPLOAD:
+          return ".csv";
+        case DATASET_UPLOAD:
+        default:
+          return ".csv, .zip";
+      }
+    },
+
     filename(): string {
       return this.file ? this.file.name : "";
     },
@@ -79,7 +98,7 @@ export default Vue.extend({
     clearFile() {
       this.file = null;
       const $refs = this.$refs as any;
-      $refs.fileinput.reset();
+      if ($refs && $refs.fileinput) $refs.fileinput.reset();
     },
     handleOk() {
       if (!this.file) {

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -40,8 +40,6 @@ import {
   isRankableVariableType
 } from "../../util/types";
 
-import { DATASET_UPLOAD, PREDICTION_UPLOAD } from "../../util/uploads";
-
 // fetches variables and add dataset name to each variable
 async function getVariables(dataset: string): Promise<Variable[]> {
   const response = await axios.get(`/distil/variables/${dataset}`);
@@ -335,8 +333,18 @@ export const actions = {
     }
     const data = new FormData();
     data.append("file", args.file);
-
-    await axios.post(`/distil/upload/${args.datasetID}?type=table`, data, {
+    let options = "";
+    switch (args.file.type) {
+      case "text/csv":
+        options = "type=table";
+        break;
+      case "application/zip":
+        options = "type=image&image=jpg";
+        break;
+      default:
+        options = "type=table";
+    }
+    await axios.post(`/distil/upload/${args.datasetID}?${options}`, data, {
       headers: { "Content-Type": "multipart/form-data" }
     });
     return actions.importDataset(context, {


### PR DESCRIPTION
Fixes #1510. Updated the file uploader to component to allow zip uploads for dataset uploads (blocking it for regression uploads as it's end point hasn't been revised as far as I know,) and updated the upload data file action to detect the file type and change the call on that basis.  It will then call importDataset right after that just like if it were a csv that had uploaded successfully.