### PR TITLE
Fix prediction output

### DIFF
--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -193,11 +193,12 @@ func (s *SolutionRequest) explainablePipeline(solutionDesc *pipeline.DescribeSol
 		if primitive != nil {
 			explainFunctions := explainablePrimitiveFunctions(primitive.Primitive.Id)
 			for _, ef := range explainFunctions {
+				outputName := fmt.Sprintf("outputs.%d", len(outputs)+1)
 				primitive.Outputs = append(primitive.Outputs, &pipeline.StepOutput{
 					Id: ef.produceFunction,
 				})
 				pipelineDesc.Outputs = append(pipelineDesc.Outputs, &pipeline.PipelineDescriptionOutput{
-					Name: ef.explainableType,
+					Name: outputName,
 					Data: fmt.Sprintf("steps.%d.%s", si, ef.produceFunction),
 				})
 				explainable = true
@@ -205,7 +206,7 @@ func (s *SolutionRequest) explainablePipeline(solutionDesc *pipeline.DescribeSol
 				// output 0 is the produce call
 				outputs[ef.explainableType] = &pipelineOutput{
 					typ: ef.explainableType,
-					key: fmt.Sprintf("outputs.%d", len(outputs)+1),
+					key: outputName,
 				}
 			}
 		}

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -332,7 +332,8 @@ func GeneratePredictions(datasetURI string, explainedSolutionID string,
 	}
 
 	outputs := getPipelineOutputs(desc)
-	keys := extractOutputKeys(outputs)
+	keys := []string{defaultExposedOutputKey}
+	keys = append(keys, extractOutputKeys(outputs)...)
 
 	produceRequest := createProduceSolutionRequest(datasetURI, fittedSolutionID, keys)
 	produceRequestID, predictionResponses, err := client.GeneratePredictions(context.Background(), produceRequest)
@@ -352,8 +353,8 @@ func GeneratePredictions(datasetURI string, explainedSolutionID string,
 			return nil, err
 		}
 		var explainFeatureURI string
-		if outputs[explainFeatureOutputkey] != nil {
-			explainFeatureURI, err = getFileFromOutput(response, outputs[explainFeatureOutputkey].key)
+		if outputs[explainableTypeStep] != nil {
+			explainFeatureURI, err = getFileFromOutput(response, outputs[explainableTypeStep].key)
 			if err != nil {
 				return nil, err
 			}

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -87,14 +87,14 @@ type Feature struct {
 
 // Solution is a container for a TA2 solution.
 type Solution struct {
-	SolutionID              string            `json:"solutionId"`
-	InitialSearchSolutionID string            `json:"initialSolutionId"`
-	RequestID               string            `json:"requestId"`
-	CreatedTime             time.Time         `json:"timestamp"`
-	State                   *SolutionState    `json:"state"`
-	Results                 []*SolutionResult `json:"results"`
-	Scores                  []*SolutionScore  `json:"scores"`
-	IsBad                   bool              `json:"isBad"`
+	SolutionID          string            `json:"solutionId"`
+	ExplainedSolutionID string            `json:"explainedSolutionId"`
+	RequestID           string            `json:"requestId"`
+	CreatedTime         time.Time         `json:"timestamp"`
+	State               *SolutionState    `json:"state"`
+	Results             []*SolutionResult `json:"results"`
+	Scores              []*SolutionScore  `json:"scores"`
+	IsBad               bool              `json:"isBad"`
 }
 
 // SolutionState represents the state updates for a solution.

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -76,12 +76,13 @@ type SolutionStorage interface {
 	PersistRequest(requestID string, dataset string, progress string, createdTime time.Time) error
 	PersistRequestFeature(requestID string, featureName string, featureType string) error
 	PersistRequestFilters(requestID string, filters *FilterParams) error
-	PersistSolution(requestID string, solutionID string, initialSearchSolutionID string, createdTime time.Time) error
+	PersistSolution(requestID string, solutionID string, explainedSolutionID string, createdTime time.Time) error
 	PersistSolutionWeight(solutionID string, featureName string, featureIndex int64, weight float64) error
 	PersistSolutionState(solutionID string, progress string, createdTime time.Time) error
 	PersistSolutionResult(solutionID string, fittedSolutionID string, produceRequestID string, resultType string, resultUUID string, resultURI string, progress string, createdTime time.Time) error
 	PersistSolutionScore(solutionID string, metric string, score float64) error
 	UpdateRequest(requestID string, progress string, updatedTime time.Time) error
+	UpdateSolution(solutionID string, explainedSolutionID string) error
 	FetchRequest(requestID string) (*Request, error)
 	FetchRequestBySolutionID(solutionID string) (*Request, error)
 	FetchRequestByFittedSolutionID(fittedSolutionID string) (*Request, error)

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -44,16 +44,25 @@ const (
 
 	// PredictionTableName is the name of the table for prediction requests.
 	PredictionTableName = "prediction"
-	RequestTableName    = "request"
+	// RequestTableName is the name of the table for solution requests.
+	RequestTableName = "request"
 
-	SolutionTableName              = "solution"
+	// SolutionTableName is the name of the table for solutions.
+	SolutionTableName = "solution"
+	// SolutionFeatureWeightTableName is the name of the table for solution feature weights.
 	SolutionFeatureWeightTableName = "solution_weight"
-	SolutionStateTableName         = "solution_state"
-	SolutionResultTableName        = "solution_result"
-	SolutionScoreTableName         = "solution_score"
-	RequestFeatureTableName        = "request_feature"
-	RequestFilterTableName         = "request_filter"
-	WordStemTableName              = "word_stem"
+	// SolutionStateTableName is the name of the table for solution state.
+	SolutionStateTableName = "solution_state"
+	// SolutionResultTableName is the name of the table for the result.
+	SolutionResultTableName = "solution_result"
+	// SolutionScoreTableName is the name of the table for the score.
+	SolutionScoreTableName = "solution_score"
+	// RequestFeatureTableName is the name of the table for the request features.
+	RequestFeatureTableName = "request_feature"
+	// RequestFilterTableName is the name of the table for the request filters.
+	RequestFilterTableName = "request_filter"
+	// WordStemTableName is the name of the table for the word stems.
+	WordStemTableName = "word_stem"
 
 	requestTableCreationSQL = `CREATE TABLE %s (
 			request_id			varchar(200),
@@ -74,7 +83,7 @@ const (
 	solutionTableCreationSQL = `CREATE TABLE %s (
 			request_id		varchar(200),
 			solution_id		varchar(200),
-			initial_search_solution_id varchar(200),
+			explained_solution_id varchar(200),
 			created_time	timestamp,
 			deleted         boolean
 		);`

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -177,8 +177,14 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 		return nil, errors.Wrap(err, "unable to update dataset doc")
 	}
 
+	// get the explained solution id
+	solution, err := params.SolutionStorage.FetchSolution(params.SolutionID)
+	if err != nil {
+		return nil, err
+	}
+
 	// submit the new dataset for predictions
-	predictionResult, err := comp.GeneratePredictions(datasetPath, params.SolutionID, params.FittedSolutionID, client)
+	predictionResult, err := comp.GeneratePredictions(datasetPath, solution.ExplainedSolutionID, params.FittedSolutionID, client)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When producing predictions, the explain call now sets the outputs properly and parses the results as expected. The overall structure is a bit cleaner for future expansion as more work is done on explainability.

Note that this has a breaking change to the database so version 0.16.0 is required.