### PR TITLE
Make a copy of solutions list before in-place sort to avoid mutation

### DIFF
--- a/public/util/solutions.ts
+++ b/public/util/solutions.ts
@@ -34,7 +34,7 @@ export const SOLUTION_PROGRESS: Dictionary<number> = {
 
 export function getSolutionIndex(solutionId: string) {
   // Get the solutions sorted by score.
-  const solutions = requestGetters.getRelevantSolutions(store);
+  const solutions = [...requestGetters.getRelevantSolutions(store)];
 
   // Sort the solutions by timestamp if they are not part of the same request.
   solutions.sort((a, b) => {


### PR DESCRIPTION
Solution sort used in ordering solution facets was in place, which was leading to the vuex store's solution list being modified.  This resulted in unexpected ordering, and is also a Vuex usage issue, as only mutations are allowed to modify store contents.  Making a copy of the list cleans everything up.