### PR TITLE
#1542 Call Model Search On Search and See Results

### DIFF
--- a/public/components/DatasetSearchResults.vue
+++ b/public/components/DatasetSearchResults.vue
@@ -29,7 +29,7 @@ import { getters as datasetGetters } from "../store/dataset/module";
 import { Dataset } from "../store/dataset/index";
 
 export default Vue.extend({
-  name: "search-results",
+  name: "dataset-search-results",
 
   components: {
     DatasetPreview

--- a/public/components/ModelPreview.vue
+++ b/public/components/ModelPreview.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="card card-result">
+    <div class="model-header hover card-header" variant="dark">
+      <a class="nav-link"><b>Model Name:</b> {{ model.modelName }}</a>
+      <a class="nav-link"><b>Dateset Name:</b> {{ model.datasetName }}</a>
+      <a class="nav-link"><b>Features:</b> {{ model.variables.length }}</a>
+      <a class="nav-link"><b>Target:</b> {{ model.target }}</a>
+    </div>
+    <div class="card-body">
+      <div class="row">
+        <div class="col-4">
+          <span><b>Features:</b></span>
+          <ul>
+            <li :key="variable.name" v-for="variable in model.variables">
+              {{ variable }}
+            </li>
+          </ul>
+        </div>
+        <div class="col-8">
+          <span><b>Description:</b></span>
+          <p class="small-text">
+            {{ model.modelDescription || "n/a" }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import _ from "lodash";
+import Vue from "vue";
+import { Model } from "../store/model/index";
+
+export default Vue.extend({
+  name: "model-preview",
+
+  props: {
+    model: Object as () => Model
+  }
+});
+</script>
+
+<style>
+.highlight {
+  background-color: #87cefa;
+}
+.model-header {
+  display: flex;
+  padding: 4px 8px;
+  color: white;
+  justify-content: space-between;
+  border: none;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}
+.card-result .card-header {
+  background-color: #424242;
+}
+.card-result .card-header:hover {
+  color: #fff;
+  background-color: #535353;
+}
+.model-header:hover {
+  text-decoration: underline;
+}
+</style>

--- a/public/components/ModelSearchResults.vue
+++ b/public/components/ModelSearchResults.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="model-search-results">
+    <div class="row justify-content-center" v-if="isPending">
+      <div v-html="spinnerHTML"></div>
+    </div>
+    <div class="model-search-results-container" ref="modelResults">
+      <div class="mb-3" :key="model.fittedSolutionId" v-for="model in models">
+        <model-preview :model="model"> </model-preview>
+      </div>
+      <div
+        class="row justify-content-center"
+        v-if="!isPending && (!models || models.length === 0)"
+      >
+        <h5>No models found for search</h5>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import $ from "jquery";
+import ModelPreview from "../components/ModelPreview";
+import Vue from "vue";
+import { spinnerHTML } from "../util/spinner";
+import { getters as modelGetters } from "../store/model/module";
+import { Model } from "../store/model/index";
+
+export default Vue.extend({
+  name: "model-search-results",
+
+  components: {
+    ModelPreview
+  },
+
+  props: {
+    isPending: Boolean as () => boolean
+  },
+
+  computed: {
+    models(): Model[] {
+      return modelGetters.getModels(this.$store);
+    },
+    spinnerHTML(): string {
+      return spinnerHTML();
+    }
+  },
+
+  watch: {
+    models() {
+      // reset back to top on model change
+      const $results = this.$refs.modelResults as Element;
+      $results.scrollTop = 0;
+    }
+  }
+});
+</script>
+
+<style>
+.model-search-results {
+  width: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.model-search-results-container {
+  width: 100%;
+}
+</style>

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -167,7 +167,6 @@ export default Vue.extend({
       });
       appActions
         .saveModel(this.$store, {
-          solutionId: this.activeSolution.solutionId,
           fittedSolutionId: this.fittedSolutionId
         })
         .then(err => {

--- a/public/store/app/actions.ts
+++ b/public/store/app/actions.ts
@@ -9,17 +9,10 @@ import { Feature, Activity, SubActivity } from "../../util/userEvents";
 export type AppContext = ActionContext<AppState, DistilState>;
 
 export const actions = {
-  async saveModel(
-    context: AppContext,
-    args: { solutionId: string; fittedSolutionId: string }
-  ) {
+  async saveModel(context: AppContext, args: { fittedSolutionId: string }) {
     try {
-      await axios.post(
-        `/distil/save/${args.solutionId}/${args.fittedSolutionId}`
-      );
-      console.warn(
-        `User saved model for ${args.solutionId} and ${args.fittedSolutionId}`
-      );
+      await axios.post(`/distil/save/${args.fittedSolutionId}/true`);
+      console.warn(`User saved model for ${args.fittedSolutionId}`);
     } catch (error) {
       // If there's a proxy involved (NGINX) we will end up getting a 502 on a successful export because
       // the server exits.  We need to explicitly check for the condition here so that we don't interpret
@@ -28,9 +21,7 @@ export const actions = {
         return new Error(error.response.data);
       } else {
         // NOTE: request always fails because we exit on the server
-        console.warn(
-          `User saved model for ${args.solutionId} and ${args.fittedSolutionId}`
-        );
+        console.warn(`User saved model for ${args.fittedSolutionId}`);
       }
     }
   },

--- a/public/store/model/actions.ts
+++ b/public/store/model/actions.ts
@@ -1,0 +1,22 @@
+import _ from "lodash";
+import axios from "axios";
+import { ActionContext } from "vuex";
+import { ModelState } from "./index";
+import { mutations } from "./module";
+import { DistilState } from "../store";
+
+export type ModelContext = ActionContext<ModelState, DistilState>;
+
+export const actions = {
+  // searches model descriptions and column names for supplied terms
+  async searchModels(context: ModelContext, terms: string): Promise<void> {
+    const params = !_.isEmpty(terms) ? `?search=${terms}` : "";
+    try {
+      const response = await axios.get(`/distil/models${params}`);
+      mutations.setModels(context, response.data.models);
+    } catch (error) {
+      console.error(error);
+      mutations.setModels(context, []);
+    }
+  }
+};

--- a/public/store/model/getters.ts
+++ b/public/store/model/getters.ts
@@ -1,0 +1,7 @@
+import { Model, ModelState } from "./index";
+
+export const getters = {
+  getModels(state: ModelState): Model[] {
+    return state.models;
+  }
+};

--- a/public/store/model/index.ts
+++ b/public/store/model/index.ts
@@ -1,0 +1,18 @@
+export interface Model {
+  modelName: string;
+  modelDescription: string;
+  filePath: string;
+  fittedSolutionId: string;
+  datasetId: string;
+  datasetName: string;
+  target: string;
+  variables: string[];
+}
+
+export interface ModelState {
+  models: Model[];
+}
+
+export const state: ModelState = {
+  models: []
+};

--- a/public/store/model/module.ts
+++ b/public/store/model/module.ts
@@ -1,0 +1,31 @@
+import { Module } from "vuex";
+import { getters as moduleGetters } from "./getters";
+import { actions as moduleActions } from "./actions";
+import { mutations as moduleMutations } from "./mutations";
+import { state, ModelState } from "./index";
+
+import { DistilState } from "../store";
+import { getStoreAccessors } from "vuex-typescript";
+
+export const modelModule: Module<ModelState, DistilState> = {
+  getters: moduleGetters,
+  actions: moduleActions,
+  mutations: moduleMutations,
+  state: state
+};
+
+const { commit, read, dispatch } = getStoreAccessors<ModelState, DistilState>(
+  null
+);
+
+export const getters = {
+  getModels: read(moduleGetters.getModels)
+};
+
+export const actions = {
+  searchModels: dispatch(moduleActions.searchModels)
+};
+
+export const mutations = {
+  setModels: commit(moduleMutations.setModels)
+};

--- a/public/store/model/mutations.ts
+++ b/public/store/model/mutations.ts
@@ -1,0 +1,25 @@
+import Vue from "vue";
+import { Model, ModelState } from "./index";
+
+export const mutations = {
+  setModels(state: ModelState, models: Model[]) {
+    // individually add models if they do not exist
+    if (models) {
+      const lookup = {};
+      state.models.forEach((m, index) => {
+        lookup[m.fittedSolutionId] = index;
+      });
+      models.forEach(m => {
+        const index = lookup[m.fittedSolutionId];
+        if (index !== undefined) {
+          // update if it already exists
+          Vue.set(state.models, index, m);
+        } else {
+          state.models.push(m);
+        }
+      });
+    } else {
+      Vue.set(state, "models", []);
+    }
+  }
+};

--- a/public/store/store.ts
+++ b/public/store/store.ts
@@ -10,6 +10,8 @@ import { requestsModule } from "./requests/module";
 import { RequestState } from "./requests/index";
 import { predictionsModule } from "./predictions/module";
 import { PredictionState } from "./predictions/index";
+import { modelModule } from "./model/module";
+import { ModelState } from "./model/index";
 import { viewModule } from "./view/module";
 import { ViewState } from "./view/index";
 import { appModule } from "./app/module";
@@ -23,6 +25,7 @@ export interface DistilState {
   requestsModule: RequestState;
   resultsModule: ResultsState;
   predictionsModule: PredictionState;
+  modelModule: ModelState;
   viewModule: ViewState;
   appModule: AppState;
 }
@@ -34,6 +37,7 @@ const store = new Store<DistilState>({
     requestsModule,
     resultsModule,
     predictionsModule,
+    modelModule,
     viewModule,
     appModule
   },

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -10,8 +10,7 @@ import {
 } from "../dataset/module";
 import {
   actions as requestActions,
-  mutations as requestMutations,
-  getters as requestGetters
+  mutations as requestMutations
 } from "../requests/module";
 import {
   actions as resultActions,
@@ -21,6 +20,7 @@ import {
   actions as predictionActions,
   mutations as predictionMutations
 } from "../predictions/module";
+import { actions as modelActions } from "../model/module";
 import { getters as routeGetters } from "../route/module";
 import { TaskTypes, SummaryMode, Variable, Highlight } from "../dataset";
 import { getPredictionsById } from "../../util/predictions";
@@ -196,7 +196,9 @@ export const actions = {
         dataset: id
       });
     });
+
     promises.push(datasetActions.searchDatasets(store, terms));
+    promises.push(modelActions.searchModels(store, terms));
 
     return Promise.all(promises);
   },

--- a/public/views/Search.vue
+++ b/public/views/Search.vue
@@ -30,8 +30,20 @@
     </div>
     <div class="row flex-10 justify-content-center pb-3">
       <div class="search-container col-12 col-md-10 d-flex">
-        <search-results class="search-search-results" :is-pending="isPending">
-        </search-results>
+        <dataset-search-results
+          class="search-search-results"
+          :is-pending="isPending"
+        >
+        </dataset-search-results>
+      </div>
+    </div>
+    <div class="row flex-10 justify-content-center pb-3">
+      <div class="search-container col-12 col-md-10 d-flex">
+        <model-search-results
+          class="search-search-results"
+          :is-pending="isPending"
+        >
+        </model-search-results>
       </div>
     </div>
   </div>
@@ -44,8 +56,10 @@ import FileUploader from "../components/FileUploader";
 import FileUploaderStatus from "../components/FileUploaderStatus";
 import DatasetPreviewCard from "../components/DatasetPreviewCard";
 import SearchBar from "../components/SearchBar";
-import SearchResults from "../components/SearchResults";
+import DatasetSearchResults from "../components/DatasetSearchResults";
+import ModelSearchResults from "../components/ModelSearchResults";
 import { Dataset } from "../store/dataset/index";
+import { Model } from "../store/model/index";
 import { createRouteEntry, overlayRouteEntry } from "../util/routes";
 import { getters as routeGetters } from "../store/route/module";
 import { actions as viewActions } from "../store/view/module";
@@ -53,6 +67,7 @@ import {
   getters as datasetGetters,
   actions as datasetActions
 } from "../store/dataset/module";
+import { getters as modelGetters } from "../store/model/module";
 import { SEARCH_ROUTE, JOIN_DATASETS_ROUTE } from "../store/route/index";
 import { DATASET_UPLOAD } from "../util/uploads";
 
@@ -61,7 +76,8 @@ export default Vue.extend({
 
   components: {
     SearchBar,
-    SearchResults,
+    DatasetSearchResults,
+    ModelSearchResults,
     DatasetPreviewCard,
     FileUploader,
     FileUploaderStatus
@@ -79,9 +95,6 @@ export default Vue.extend({
   computed: {
     terms(): string {
       return routeGetters.getRouteTerms(this.$store);
-    },
-    datasets(): Dataset[] {
-      return datasetGetters.getDatasets(this.$store);
     }
   },
 


### PR DESCRIPTION
Fixes #1542 - Built support for model data in the store including actions, getters, index, module and mutations with relevant search call, built new model preview and model search result components, added model search results to the search view and updated the save action to call the correct end point with the correct information and updated the result summary component to match the revised save.