### PR TITLE
#1524 Filter Computed Variables From View

### DIFF
--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -28,7 +28,12 @@ import {
   actions as datasetActions
 } from "../store/dataset/module";
 import { getters as requestGetters } from "../store/requests/module";
-import { formatValue, isIntegerType, isTimeType } from "../util/types";
+import {
+  formatValue,
+  isIntegerType,
+  isTimeType,
+  hasComputedVarPrefix
+} from "../util/types";
 
 // Postfixes for special variable names
 export const PREDICTED_SUFFIX = "_predicted";
@@ -274,7 +279,7 @@ export function filterSummariesByDataset(
   dataset: string
 ): VariableSummary[] {
   return summaries.filter(summary => {
-    return summary.dataset === dataset;
+    return summary.dataset === dataset && !hasComputedVarPrefix(summary.key);
   });
 }
 


### PR DESCRIPTION
Fixes #1524. Just edited the data utility function filterSummariesByDataset which many other parts of the application leverage to list variables/summaries/features to also use the existing hasComputerVarPrefix function to filter those variables from the return as well so we have them in the store when we need them, but they won't display where we don't want them nor should they effect available feature counts.