### PR TITLE
Add time type

### DIFF
--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -290,7 +290,7 @@ func Ingest(originalSchemaFile string, schemaFile string, storage api.MetadataSt
 	}
 
 	// ingest the data
-	err = IngestPostgres(originalSchemaFile, schemaFile, index, dataset, source, config, false, false, fallbackMerged)
+	err = IngestPostgres(originalSchemaFile, schemaFile, index, dataset, source, config, true, false, fallbackMerged)
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/shopspring/decimal v0.0.0-20191009025716-f1972eb1d1f5 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/uncharted-distil/distil-compute v0.0.0-20200415165850-724bce441681
+	github.com/uncharted-distil/distil-compute v0.0.0-20200416220053-4c1c057380fe
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
 	github.com/zenazn/goji v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,6 @@ github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/uncharted-distil/distil-compute v0.0.0-20200415165850-724bce441681 h1:9beC7H8CA9Oki20YP6p2zYfWAyoDw9xhv9q6zTbcvv4=
-github.com/uncharted-distil/distil-compute v0.0.0-20200415165850-724bce441681/go.mod h1:y+IwSCHwnfJh7lXYrjyYayYeUcuE4oHGFf7wozYmPhM=
 github.com/uncharted-distil/distil-compute v0.0.0-20200416220053-4c1c057380fe h1:cnibNMR1f4u4n5CTz3sTOkt4SL2mdZpQk2OrttahqTE=
 github.com/uncharted-distil/distil-compute v0.0.0-20200416220053-4c1c057380fe/go.mod h1:y+IwSCHwnfJh7lXYrjyYayYeUcuE4oHGFf7wozYmPhM=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/uncharted-distil/distil-compute v0.0.0-20200415165850-724bce441681 h1:9beC7H8CA9Oki20YP6p2zYfWAyoDw9xhv9q6zTbcvv4=
 github.com/uncharted-distil/distil-compute v0.0.0-20200415165850-724bce441681/go.mod h1:y+IwSCHwnfJh7lXYrjyYayYeUcuE4oHGFf7wozYmPhM=
+github.com/uncharted-distil/distil-compute v0.0.0-20200416220053-4c1c057380fe h1:cnibNMR1f4u4n5CTz3sTOkt4SL2mdZpQk2OrttahqTE=
+github.com/uncharted-distil/distil-compute v0.0.0-20200416220053-4c1c057380fe/go.mod h1:y+IwSCHwnfJh7lXYrjyYayYeUcuE4oHGFf7wozYmPhM=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9/go.mod h1:PrytgQ5GjTc6Z5/pbL5vj1UhD716wDobDeimrd7lRKY=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48 h1:XYef2jcFEKziHl4rv/21jrNeQg6Z3gL345u16fHWVDo=


### PR DESCRIPTION
Updated to latest compute version to have basic support for time only types. Postgres ingest also checks to make sure the metadata matches the data for datetime types to ensure that ES and PG have consistent typing.