### PR TITLE
#1550 Timeseries Error Fix

### DIFF
--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -672,7 +672,13 @@ export const actions = {
 
     try {
       const response = await axios.post(
-        `distil/timeseries-forecast/${args.dataset}/${args.timeseriesColName}/${args.xColName}/${args.yColName}/${args.timeseriesID}/${solution.resultId}`,
+        `distil/timeseries-forecast/${encodeURIComponent(
+          args.dataset
+        )}/${encodeURIComponent(args.timeseriesColName)}/${encodeURIComponent(
+          args.xColName
+        )}/${encodeURIComponent(args.yColName)}/${encodeURIComponent(
+          args.timeseriesID
+        )}/${encodeURIComponent(solution.resultId)}`,
         {}
       );
       mutations.updatePredictedTimeseries(context, {

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -27,6 +27,7 @@ import {
   getters as datasetGetters,
   actions as datasetActions
 } from "../store/dataset/module";
+import { getters as routeGetters } from "../store/route/module";
 import { getters as requestGetters } from "../store/requests/module";
 import {
   formatValue,
@@ -176,15 +177,23 @@ export function fetchSummaryExemplars(
     if (variable.grouping) {
       if (variable.grouping.type === "timeseries") {
         // if there a linked exemplars, fetch those before resolving
+        const solutionId = routeGetters.getRouteSolutionId(store);
+
         return Promise.all(
           exemplars.map(exemplar => {
-            return datasetActions.fetchTimeseries(store, {
+            const args = {
               dataset: datasetName,
               timeseriesColName: variable.grouping.idCol,
               xColName: variable.grouping.properties.xCol,
               yColName: variable.grouping.properties.yCol,
-              timeseriesID: exemplar
-            });
+              timeseriesID: exemplar,
+              solutionId: solutionId
+            };
+            if (solutionId) {
+              return resultsActions.fetchForecastedTimeseries(store, args);
+            } else {
+              return datasetActions.fetchTimeseries(store, args);
+            }
           })
         );
       }

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -29,8 +29,8 @@ import {
 import store from "../store/store";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as resultGetters } from "../store/results/module";
+import { getters as routeGetters } from "../store/route/module";
 import { Forecast } from "../store/results";
-import { getIDFromKey } from "./summaries";
 
 export const CATEGORICAL_CHUNK_SIZE = 5;
 export const IMAGE_CHUNK_SIZE = 5;
@@ -284,7 +284,8 @@ function createTimeseriesSummaryFacet(summary: VariableSummary): Group {
 
   let timeseries = null as TimeSeries;
   let forecasts = null as Forecast;
-  const solutionId = getIDFromKey(summary.key);
+  const solutionId = routeGetters.getRouteSolutionId(store);
+
   if (solutionId) {
     timeseries = resultGetters.getPredictedTimeseries(store)[solutionId];
     forecasts = resultGetters.getPredictedForecasts(store)[solutionId];
@@ -293,7 +294,7 @@ function createTimeseriesSummaryFacet(summary: VariableSummary): Group {
   }
 
   group.all.forEach((facet: CategoricalFacet) => {
-    if (solutionId) {
+    if (solutionId && timeseries && forecasts) {
       facet.multipleTimeseries = [
         timeseries.timeseriesData[facet.file],
         forecasts.forecastData[facet.file]


### PR DESCRIPTION
Fixes #1550. Missing in data.ts & facets.ts were checks to see if we were in a view with a solution id in the route (the most reliable way to check/retrieve the solution id) and thus should be loading the predicted timeseries data in the facet for exemplars in the same way we would for other views. With that fixed, I also noticed that the prediction timeseries route was missing the URL escaping that'd already been added to the regular timeseries route, so I fixed that too.