### PR TITLE
No scroll bars on image tile view #1570

### DIFF
--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -182,6 +182,7 @@ export default Vue.extend({
 .image-mosaic {
   display: block;
   overflow: visible;
+  padding-bottom: 0.5rem; /* To add some spacing on overflow. */
 }
 
 .image-tile {

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -359,13 +359,15 @@ export default Vue.extend({
 
 <style>
 .select-data-container {
-  position: relative;
-  display: flex;
   background-color: white;
+  display: flex;
   flex-flow: wrap;
   height: 100%;
+  overflow: scroll;
+  position: relative;
   width: 100%;
 }
+
 .select-data-no-results {
   position: absolute;
   display: block;


### PR DESCRIPTION
Add a scroll bar

The `image-mosaic` component did not include an overflow.
A small padding was added on the bottom to make sure the images are not flush with its container.