### PR TITLE
Timeseries predictions

### DIFF
--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -128,7 +128,7 @@ func (s *Storage) IsValidDataType(dataset string, storageName string, varName st
 
 	// update field type in lookup.
 	if fields[varName] == nil {
-		return false, fmt.Errorf("field '%s' not found in existing fields", varName)
+		return false, errors.Errorf("field '%s' not found in existing fields", varName)
 	}
 	fields[varName].Type = varType
 
@@ -161,7 +161,7 @@ func (s *Storage) SetDataType(dataset string, storageName string, varName string
 
 	// update field type in lookup.
 	if fields[varName] == nil {
-		return fmt.Errorf("field '%s' not found in existing fields", varName)
+		return errors.Errorf("field '%s' not found in existing fields", varName)
 	}
 	fields[varName].Type = varType
 

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
+	log "github.com/unchartedsoftware/plog"
 )
 
 const (
@@ -143,6 +144,9 @@ func (s *Storage) fetchExtremaByURI(storageName string, resultURI string, variab
 	queryString := fmt.Sprintf("SELECT %s FROM %s data INNER JOIN %s result ON data.\"%s\" = result.index WHERE result.result_id = $1;",
 		aggQuery, storageName, s.getResultTable(storageName), model.D3MIndexFieldName)
 
+	log.Warnf("============> %s", queryString)
+	log.Warnf("============> %s", resultURI)
+
 	// execute the postgres query
 	// NOTE: We may want to use the regular Query operation since QueryRow
 	// hides db exceptions.
@@ -159,7 +163,6 @@ func (s *Storage) fetchExtremaByURI(storageName string, resultURI string, variab
 
 // FetchExtremaByURI return extrema of a variable in a result set.
 func (s *Storage) FetchExtremaByURI(dataset string, storageName string, resultURI string, varName string) (*api.Extrema, error) {
-
 	variable, err := s.metadata.FetchVariable(dataset, varName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch variable description for summary")

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
-	log "github.com/unchartedsoftware/plog"
 )
 
 const (
@@ -143,9 +142,6 @@ func (s *Storage) fetchExtremaByURI(storageName string, resultURI string, variab
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s data INNER JOIN %s result ON data.\"%s\" = result.index WHERE result.result_id = $1;",
 		aggQuery, storageName, s.getResultTable(storageName), model.D3MIndexFieldName)
-
-	log.Warnf("============> %s", queryString)
-	log.Warnf("============> %s", resultURI)
 
 	// execute the postgres query
 	// NOTE: We may want to use the regular Query operation since QueryRow

--- a/api/routes/prediction_result_summary.go
+++ b/api/routes/prediction_result_summary.go
@@ -39,7 +39,6 @@ func fetchPredictionResultExtrema(meta api.MetadataStorage, data api.DataStorage
 		return nil, nil
 	}
 
-	// get extrema
 	min := math.MaxFloat64
 	max := -math.MaxFloat64
 	// predicted extrema
@@ -49,13 +48,6 @@ func fetchPredictionResultExtrema(meta api.MetadataStorage, data api.DataStorage
 	}
 	max = math.Max(max, predictedExtrema.Max)
 	min = math.Min(min, predictedExtrema.Min)
-	// result extrema
-	resultExtrema, err := data.FetchExtremaByURI(dataset, storageName, resultURI, target)
-	if err != nil {
-		return nil, err
-	}
-	max = math.Max(max, resultExtrema.Max)
-	min = math.Min(min, resultExtrema.Min)
 
 	return api.NewExtrema(min, max)
 }

--- a/api/routes/timeseries_forecast.go
+++ b/api/routes/timeseries_forecast.go
@@ -38,13 +38,15 @@ type TimeseriesForecastResult struct {
 func TimeseriesForecastHandler(dataCtor api.DataStorageCtor, solutionCtor api.SolutionStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		dataset := pat.Param(r, "dataset")
+		truthDataset := pat.Param(r, "truthDataset")
+		forecastDataset := pat.Param(r, "forecastDataset")
 		timeseriesColName := pat.Param(r, "timeseriesColName")
 		xColName := pat.Param(r, "xColName")
 		yColName := pat.Param(r, "yColName")
 		resultUUID := pat.Param(r, "result-uuid")
 		timeseriesURI := pat.Param(r, "timeseriesURI")
-		storageName := model.NormalizeDatasetID(dataset)
+		truthStorageName := model.NormalizeDatasetID(truthDataset)
+		predictedStorageName := model.NormalizeDatasetID(forecastDataset)
 
 		// parse POST params
 		params, err := getPostParameters(r)
@@ -73,8 +75,8 @@ func TimeseriesForecastHandler(dataCtor api.DataStorageCtor, solutionCtor api.So
 			return
 		}
 
-		// fetch timeseries
-		timeseries, err := data.FetchTimeseries(dataset, storageName, timeseriesColName, xColName, yColName, timeseriesURI, filterParams, false)
+		// fetch the ground truth timeseries
+		timeseries, err := data.FetchTimeseries(truthDataset, truthStorageName, timeseriesColName, xColName, yColName, timeseriesURI, filterParams, false)
 		if err != nil {
 			handleError(w, err)
 			return
@@ -87,7 +89,8 @@ func TimeseriesForecastHandler(dataCtor api.DataStorageCtor, solutionCtor api.So
 			return
 		}
 
-		forecast, err := data.FetchTimeseriesForecast(dataset, storageName, timeseriesColName, xColName, yColName, timeseriesURI, res.ResultURI, filterParams)
+		// fetch the predicted timeseries
+		forecast, err := data.FetchTimeseriesForecast(forecastDataset, predictedStorageName, timeseriesColName, xColName, yColName, timeseriesURI, res.ResultURI, filterParams)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/main.go
+++ b/main.go
@@ -269,7 +269,7 @@ func main() {
 	registerRoutePost(mux, "/distil/predict/:dataset/:target-type/:fitted-solution-id", routes.InferenceHandler(path.Join(config.D3MOutputDir, config.AugmentedSubFolder), pgDataStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor, &config))
 	registerRoutePost(mux, "/distil/join", routes.JoinHandler(esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries/:dataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:invert", routes.TimeseriesHandler(pgDataStorageCtor))
-	registerRoutePost(mux, "/distil/timeseries-forecast/:dataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:result-uuid", routes.TimeseriesForecastHandler(pgDataStorageCtor, pgSolutionStorageCtor))
+	registerRoutePost(mux, "/distil/timeseries-forecast/:truthDataset/:forecastDataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:result-uuid", routes.TimeseriesForecastHandler(pgDataStorageCtor, pgSolutionStorageCtor))
 	registerRoutePost(mux, "/distil/event", routes.UserEventHandler(discoveryLogger))
 	registerRoutePost(mux, "/distil/save/:solution-id/:fitted", routes.SaveHandler(esExportedModelStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor))
 

--- a/public/components/PredictionSummaries.vue
+++ b/public/components/PredictionSummaries.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
         const routeEntry = overlayRouteEntry(this.$route, {
           produceRequestId: requestId,
           highlights: null,
-          dataset: dataset
+          predictionsDataset: dataset
         });
         this.$router.push(routeEntry);
       }

--- a/public/components/PredictionsDataTable.vue
+++ b/public/components/PredictionsDataTable.vue
@@ -44,6 +44,24 @@
           {{ data.value.value }}
         </div>
       </template>
+
+      <template
+        v-for="timeseriesGrouping in timeseriesGroupings"
+        v-slot:[cellSlot(timeseriesGrouping.idCol)]="data"
+      >
+        <sparkline-preview
+          :key="data.item[timeseriesGrouping.idCol].value"
+          :truth-dataset="truthDataset"
+          :forecast-dataset="predictions.dataset"
+          :x-col="timeseriesGrouping.properties.xCol"
+          :y-col="timeseriesGrouping.properties.yCol"
+          :timeseries-col="timeseriesGrouping.idCol"
+          :timeseries-id="data.item[timeseriesGrouping.idCol].value"
+          :predictions-id="predictions.requestId"
+          :include-forecast="true"
+        >
+        </sparkline-preview>
+      </template>
     </b-table>
   </fixed-header-table>
 </template>
@@ -128,9 +146,8 @@ export default Vue.extend({
       return this.predictions ? `${this.predictions.predictedKey}` : "";
     },
 
-    isTargetTimeseries(): boolean {
-      const target = this.predictions.feature;
-      return getVarType(target) === "timeseries";
+    truthDataset(): string {
+      return routeGetters.getRouteDataset(this.$store);
     },
 
     hasData(): boolean {

--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -55,35 +55,18 @@
     <div class="result-group-body" v-if="isMaximized">
       <template v-if="isCompleted">
         <div v-for="summary in predictedSummaries" :key="summary.key">
-          <template v-if="summary.varType === 'timeseries'">
-            <facet-timeseries
-              :summary="summary"
-              :highlight="highlight"
-              :row-selection="rowSelection"
-              :instanceName="predictedInstanceName"
-              :enabled-type-changes="[]"
-              :enable-highlighting="[true, true]"
-              @numerical-click="onResultNumericalClick"
-              @range-change="onResultRangeChange"
-              @histogram-numerical-click="onResultNumericalClick"
-              @histogram-range-change="onResultRangeChange"
-            >
-            </facet-timeseries>
-          </template>
-          <template v-else>
-            <facet-entry
-              enable-highlighting
-              :summary="summary"
-              :highlight="highlight"
-              :enabled-type-changes="[]"
-              :row-selection="rowSelection"
-              :instanceName="predictedInstanceName"
-              @numerical-click="onResultNumericalClick"
-              @range-change="onResultRangeChange"
-              @facet-click="onResultCategoricalClick"
-            >
-            </facet-entry>
-          </template>
+          <facet-entry
+            enable-highlighting
+            :summary="summary"
+            :highlight="highlight"
+            :enabled-type-changes="[]"
+            :row-selection="rowSelection"
+            :instanceName="predictedInstanceName"
+            @numerical-click="onResultNumericalClick"
+            @range-change="onResultRangeChange"
+            @facet-click="onResultCategoricalClick"
+          >
+          </facet-entry>
         </div>
 
         <div class="residual-group-container">
@@ -129,7 +112,6 @@
 
 import Vue from "vue";
 import FacetEntry from "../components/FacetEntry";
-import FacetTimeseries from "../components/FacetTimeseries";
 import {
   Extrema,
   VariableSummary,
@@ -158,8 +140,7 @@ export default Vue.extend({
   name: "result-group",
 
   components: {
-    FacetEntry,
-    FacetTimeseries
+    FacetEntry
   },
 
   props: {

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -88,7 +88,7 @@ import vueSlider from "vue-slider-component";
 import Vue from "vue";
 import { Solution } from "../store/requests/index";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
-import { createRouteEntry } from "../util/routes";
+import { createRouteEntry, varModesToString } from "../util/routes";
 import { PREDICTION_UPLOAD } from "../util/uploads";
 import { getPredictionsById } from "../util/predictions";
 
@@ -138,12 +138,14 @@ export default Vue.extend({
       return datasetGetters.getVariables(this.$store);
     },
 
-    taskArgs(): string {
-      return routeGetters.getRouteTask(this.$store);
+    taskArgs(): string[] {
+      return routeGetters.getRouteTask(this.$store).split(",");
     },
 
     showResiduals(): boolean {
-      return this.taskArgs && this.taskArgs.includes(TaskTypes.REGRESSION);
+      return this.taskArgs &&
+        !!this.taskArgs.find
+          (t => t ===  TaskTypes.REGRESSION || t === TaskTypes.FORECASTING);
     },
 
     solutionId(): string {
@@ -195,11 +197,14 @@ export default Vue.extend({
           response.produceRequestId
         ).dataset;
 
+        const varModes = varModesToString(routeGetters.getDecodedVarModes(this.$store));
+
         const routeArgs = {
           fittedSolutionId: this.fittedSolutionId,
           produceRequestId: response.produceRequestId,
           target: this.target,
-          dataset: dataset
+          dataset: dataset,
+          varModes: varModes
         };
         const entry = createRouteEntry(PREDICTION_ROUTE, routeArgs);
         this.$router.push(entry);

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -192,7 +192,7 @@ export default Vue.extend({
       this.uploadStatus = err ? "error" : "success";
 
       if (this.uploadStatus !== "error" && !response.complete) {
-        const dataset = getPredictionsById(
+        const predictionDataset = getPredictionsById(
           requestGetters.getPredictions(this.$store),
           response.produceRequestId
         ).dataset;
@@ -203,7 +203,8 @@ export default Vue.extend({
           fittedSolutionId: this.fittedSolutionId,
           produceRequestId: response.produceRequestId,
           target: this.target,
-          dataset: dataset,
+          predictionDataset: predictionDataset,
+          dataset: this.dataset,
           varModes: varModes
         };
         const entry = createRouteEntry(PREDICTION_ROUTE, routeArgs);

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -47,7 +47,7 @@
       >
         <sparkline-preview
           :key="data.item[timeseriesGrouping.idCol].value"
-          :dataset="dataset"
+          :truth-dataset="dataset"
           :x-col="timeseriesGrouping.properties.xCol"
           :y-col="timeseriesGrouping.properties.yCol"
           :timeseries-col="timeseriesGrouping.idCol"

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -37,7 +37,7 @@
         <div class="container" :key="data.item[timeseriesGrouping.idCol].value">
           <div class="row">
             <sparkline-preview
-              :dataset="dataset"
+              :truth-dataset="dataset"
               :x-col="timeseriesGrouping.properties.xCol"
               :y-col="timeseriesGrouping.properties.yCol"
               :timeseries-col="timeseriesGrouping.idCol"

--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -38,6 +38,9 @@ export default Vue.extend({
     },
     xAxisDateTime: {
       type: Boolean as () => boolean
+    },
+    joinForecast: {
+      type: Boolean as () => boolean
     }
   },
   data() {
@@ -84,6 +87,14 @@ export default Vue.extend({
       return this.forecast
         ? Math.max(max, d3.max(this.forecast, d => d[1]))
         : max;
+    },
+    displayForecast(): number[][] {
+      // Join the last element of the truth timeseries and the first element of the forecast
+      // time series.  Used when not visualizing an in-sample forecast.
+      if (this.joinForecast) {
+        return [_.last(this.timeseries)].concat(this.forecast);
+      }
+      return this.forecast;
     }
   },
   mounted() {
@@ -183,7 +194,7 @@ export default Vue.extend({
         .attr("transform", `translate(${this.margin.left}, 0)`)
         .attr("class", "line-chart");
 
-      g.datum(this.forecast);
+      g.datum(this.displayForecast);
 
       g.append("path")
         .attr("fill", "none")

--- a/public/components/SparklineRow.vue
+++ b/public/components/SparklineRow.vue
@@ -151,7 +151,7 @@ export default Vue.extend({
           xColName: this.xCol,
           yColName: this.yCol,
           timeseriesColName: this.timeseriesCol,
-          timeseriesID: this.timeseriesId,
+          timeseriesId: this.timeseriesId,
           solutionId: this.solutionId
         });
       } else {
@@ -160,7 +160,7 @@ export default Vue.extend({
           xColName: this.xCol,
           yColName: this.yCol,
           timeseriesColName: this.timeseriesCol,
-          timeseriesID: this.timeseriesId
+          timeseriesId: this.timeseriesId
         });
       }
     }

--- a/public/components/SparklineSvg.vue
+++ b/public/components/SparklineSvg.vue
@@ -46,6 +46,12 @@ export default Vue.extend({
     },
     isDateTime: {
       type: Boolean as () => Boolean
+    },
+    // join last element of timeseries to first element of forecast, or display both
+    // seperately
+    joinForecast: {
+      type: Boolean as () => Boolean,
+      default: false
     }
   },
   data() {
@@ -83,6 +89,14 @@ export default Vue.extend({
     },
     max(): number {
       return this.timeseries ? d3.max(this.timeseries, d => d[1]) : 0;
+    },
+    displayForecast(): number[][] {
+      // Join the last element of the truth timeseries and the first element of the forecast
+      // time series.  Used when not visualizing an in-sample forecast.
+      if (this.joinForecast) {
+        return [_.last(this.timeseries)].concat(this.forecast);
+      }
+      return this.forecast;
     },
     showTooltip(): boolean {
       return (
@@ -316,7 +330,7 @@ export default Vue.extend({
           `translate(${this.margin.left}, ${this.margin.top})`
         );
 
-      g.datum(this.forecast);
+      g.datum(this.displayForecast);
 
       g.append("path")
         .attr("fill", "none")

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1040,7 +1040,7 @@ export const actions = {
       xColName: string;
       yColName: string;
       timeseriesColName: string;
-      timeseriesID: any;
+      timeseriesId: any;
     }
   ) {
     if (!args.dataset) {
@@ -1059,8 +1059,8 @@ export const actions = {
       console.warn("`timeseriesColName` argument is missing");
       return null;
     }
-    if (!args.timeseriesID) {
-      console.warn("`timeseriesID` argument is missing");
+    if (!args.timeseriesId) {
+      console.warn("`timeseriesId` argument is missing");
       return null;
     }
 
@@ -1071,13 +1071,13 @@ export const actions = {
         )}/${encodeURIComponent(args.timeseriesColName)}/${encodeURIComponent(
           args.xColName
         )}/${encodeURIComponent(args.yColName)}/${encodeURIComponent(
-          args.timeseriesID
+          args.timeseriesId
         )}/false`,
         {}
       );
       mutations.updateTimeseries(context, {
         dataset: args.dataset,
-        id: args.timeseriesID,
+        id: args.timeseriesId,
         timeseries: response.data.timeseries,
         isDateTime: response.data.isDateTime
       });

--- a/public/store/predictions/actions.ts
+++ b/public/store/predictions/actions.ts
@@ -286,16 +286,21 @@ export const actions = {
   async fetchForecastedTimeseries(
     context: PredictionContext,
     args: {
-      dataset: string;
+      truthDataset: string;
+      forecastDataset: string;
       xColName: string;
       yColName: string;
       timeseriesColName: string;
-      timeseriesID: any;
-      solutionId: string;
+      timeseriesId: any;
+      predictionsId: string;
     }
   ) {
-    if (!args.dataset) {
-      console.warn("`dataset` argument is missing");
+    if (!args.truthDataset) {
+      console.warn("`truthDataset` argument is missing");
+      return null;
+    }
+    if (!args.forecastDataset) {
+      console.warn("`forecastDataset` argument is missing");
       return null;
     }
     if (!args.xColName) {
@@ -310,38 +315,40 @@ export const actions = {
       console.warn("`timeseriesColName` argument is missing");
       return null;
     }
-    if (!args.timeseriesID) {
+    if (!args.timeseriesId) {
       console.warn("`timeseriesID` argument is missing");
       return null;
     }
-    if (!args.solutionId) {
+    if (!args.predictionsId) {
       console.warn("`solutionId` argument is missing");
       return null;
     }
 
-    const solution = getSolutionById(
-      context.rootState.requestsModule.solutions,
-      args.solutionId
+    const predictions = getPredictionsById(
+      context.rootState.requestsModule.predictions,
+      args.predictionsId
     );
-    if (!solution.resultId) {
+    if (!predictions.resultId) {
       // no results ready to pull
       return null;
     }
 
     try {
       const response = await axios.post(
-        `distil/timeseries-forecast/${args.dataset}/${args.timeseriesColName}/${args.xColName}/${args.yColName}/${args.timeseriesID}/${solution.resultId}`,
+        `distil/timeseries-forecast/${args.truthDataset}/${args.forecastDataset}` +
+          `/${args.timeseriesColName}/${args.xColName}/${args.yColName}/${args.timeseriesId}` +
+          `/${predictions.resultId}`,
         {}
       );
       mutations.updatePredictedTimeseries(context, {
-        solutionId: args.solutionId,
-        id: args.timeseriesID,
+        predictionsId: args.predictionsId,
+        id: args.timeseriesId,
         timeseries: response.data.timeseries,
         isDateTime: response.data.isDateTime
       });
       mutations.updatePredictedForecast(context, {
-        solutionId: args.solutionId,
-        id: args.timeseriesID,
+        predictionsId: args.predictionsId,
+        id: args.timeseriesId,
         forecast: response.data.forecast,
         forecastTestRange: response.data.forecastRange,
         isDateTime: response.data.isDateTime

--- a/public/store/predictions/index.ts
+++ b/public/store/predictions/index.ts
@@ -1,16 +1,6 @@
 import { Dictionary } from "../../util/dict";
-import {
-  VariableSummary,
-  Extrema,
-  TableData,
-  TimeSeries
-} from "../dataset/index";
-
-export interface Forecast {
-  forecastData: Dictionary<number[][]>;
-  forecastRange: Dictionary<number[]>;
-  isDateTime: Dictionary<boolean>;
-}
+import { VariableSummary, TableData, TimeSeries } from "../dataset/index";
+import { Forecast } from "../results";
 
 export interface PredictionState {
   // table data

--- a/public/store/predictions/module.ts
+++ b/public/store/predictions/module.ts
@@ -67,7 +67,10 @@ export const actions = {
 
   // predicted value summary
   fetchPredictedSummary: dispatch(moduleActions.fetchPredictionSummary),
-  fetchPredictedSummaries: dispatch(moduleActions.fetchPredictionSummaries)
+  fetchPredictedSummaries: dispatch(moduleActions.fetchPredictionSummaries),
+
+  // time series forecast data
+  fetchForecastedTimeseries: dispatch(moduleActions.fetchForecastedTimeseries)
 };
 
 // Typed mutations

--- a/public/store/predictions/mutations.ts
+++ b/public/store/predictions/mutations.ts
@@ -41,25 +41,28 @@ export const mutations = {
   updatePredictedTimeseries(
     state: PredictionState,
     args: {
-      solutionId: string;
+      predictionsId: string;
       id: string;
       timeseries: number[][];
       isDateTime: boolean;
     }
   ) {
-    if (!state.timeseries[args.solutionId]) {
-      Vue.set(state.timeseries, args.solutionId, {});
+    if (!state.timeseries[args.predictionsId]) {
+      Vue.set(state.timeseries, args.predictionsId, {});
     }
-    if (!state.timeseries[args.solutionId].timeseriesData) {
-      Vue.set(state.timeseries[args.solutionId], "timeseriesData", {});
+    if (!state.timeseries[args.predictionsId].timeseriesData) {
+      Vue.set(state.timeseries[args.predictionsId], "timeseriesData", {});
+    }
+    if (!state.timeseries[args.predictionsId].isDateTime) {
+      Vue.set(state.timeseries[args.predictionsId], "isDateTime", {});
     }
     Vue.set(
-      state.timeseries[args.solutionId].timeseriesData,
+      state.timeseries[args.predictionsId].timeseriesData,
       args.id,
       args.timeseries
     );
     Vue.set(
-      state.timeseries[args.solutionId].isDateTime,
+      state.timeseries[args.predictionsId].isDateTime,
       args.id,
       args.isDateTime
     );
@@ -68,37 +71,37 @@ export const mutations = {
   updatePredictedForecast(
     state: PredictionState,
     args: {
-      solutionId: string;
+      predictionsId: string;
       id: string;
       forecast: number[][];
       forecastTestRange: number[];
       isDateTime: boolean;
     }
   ) {
-    if (!state.forecasts[args.solutionId]) {
-      Vue.set(state.forecasts, args.solutionId, {});
+    if (!state.forecasts[args.predictionsId]) {
+      Vue.set(state.forecasts, args.predictionsId, {});
     }
-    if (!state.forecasts[args.solutionId].forecastData) {
-      Vue.set(state.forecasts[args.solutionId], "forecastData", {});
+    if (!state.forecasts[args.predictionsId].forecastData) {
+      Vue.set(state.forecasts[args.predictionsId], "forecastData", {});
     }
-    if (!state.forecasts[args.solutionId].forecastRange) {
-      Vue.set(state.forecasts[args.solutionId], "forecastRange", {});
+    if (!state.forecasts[args.predictionsId].forecastRange) {
+      Vue.set(state.forecasts[args.predictionsId], "forecastRange", {});
     }
-    if (!state.forecasts[args.solutionId].isDateTime) {
-      Vue.set(state.forecasts[args.solutionId], "isDateTime", {});
+    if (!state.forecasts[args.predictionsId].isDateTime) {
+      Vue.set(state.forecasts[args.predictionsId], "isDateTime", {});
     }
     Vue.set(
-      state.forecasts[args.solutionId].forecastData,
+      state.forecasts[args.predictionsId].forecastData,
       args.id,
       args.forecast
     );
     Vue.set(
-      state.forecasts[args.solutionId].forecastRange,
+      state.forecasts[args.predictionsId].forecastRange,
       args.id,
       args.forecastTestRange
     );
     Vue.set(
-      state.forecasts[args.solutionId].isDateTime,
+      state.forecasts[args.predictionsId].isDateTime,
       args.id,
       args.isDateTime
     );

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -632,7 +632,7 @@ export const actions = {
       xColName: string;
       yColName: string;
       timeseriesColName: string;
-      timeseriesID: any;
+      timeseriesId: any;
       solutionId: string;
     }
   ) {
@@ -652,7 +652,7 @@ export const actions = {
       console.warn("`timeseriesColName` argument is missing");
       return null;
     }
-    if (!args.timeseriesID) {
+    if (!args.timeseriesId) {
       console.warn("`timeseriesID` argument is missing");
       return null;
     }
@@ -672,24 +672,25 @@ export const actions = {
 
     try {
       const response = await axios.post(
-        `distil/timeseries-forecast/${encodeURIComponent(
-          args.dataset
-        )}/${encodeURIComponent(args.timeseriesColName)}/${encodeURIComponent(
-          args.xColName
-        )}/${encodeURIComponent(args.yColName)}/${encodeURIComponent(
-          args.timeseriesID
-        )}/${encodeURIComponent(solution.resultId)}`,
+        `distil/timeseries-forecast/` +
+          `${encodeURIComponent(args.dataset)}/` +
+          `${encodeURIComponent(args.dataset)}/` +
+          `${encodeURIComponent(args.timeseriesColName)}/` +
+          `${encodeURIComponent(args.xColName)}/` +
+          `${encodeURIComponent(args.yColName)}/` +
+          `${encodeURIComponent(args.timeseriesId)}/` +
+          `${encodeURIComponent(solution.resultId)}`,
         {}
       );
       mutations.updatePredictedTimeseries(context, {
         solutionId: args.solutionId,
-        id: args.timeseriesID,
+        id: args.timeseriesId,
         timeseries: response.data.timeseries,
         isDateTime: response.data.isDateTime
       });
       mutations.updatePredictedForecast(context, {
         solutionId: args.solutionId,
-        id: args.timeseriesID,
+        id: args.timeseriesId,
         forecast: response.data.forecast,
         forecastTestRange: response.data.forecastTestRange,
         isDateTime: response.data.isDateTime

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -407,5 +407,13 @@ export const getters = {
       return null;
     }
     return id;
+  },
+
+  getRoutePredictionsDataset(state: Route, getters: any): string {
+    const dataset = <string>state.query.predictionsDataset;
+    if (!dataset) {
+      return null;
+    }
+    return dataset;
   }
 };

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -3,6 +3,7 @@ import { Route } from "vue-router";
 import { getters as moduleGetters } from "./getters";
 import { DistilState } from "../store";
 import { getStoreAccessors } from "vuex-typescript";
+import { modelModule } from "../model/module";
 
 export const routeModule: Module<Route, DistilState> = {
   getters: moduleGetters
@@ -85,5 +86,6 @@ export const getters = {
   getGeoZoom: read(moduleGetters.getGeoZoom),
   getGroupingType: read(moduleGetters.getGroupingType),
   getRouteTask: read(moduleGetters.getRouteTask),
-  getRouteFittedSolutionID: read(moduleGetters.getRouteFittedSolutionId)
+  getRouteFittedSolutionID: read(moduleGetters.getRouteFittedSolutionId),
+  getRoutePredictionsDataset: read(moduleGetters.getRoutePredictionsDataset)
 };

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -186,7 +186,7 @@ export function fetchSummaryExemplars(
               timeseriesColName: variable.grouping.idCol,
               xColName: variable.grouping.properties.xCol,
               yColName: variable.grouping.properties.yCol,
-              timeseriesID: exemplar,
+              timeseriesId: exemplar,
               solutionId: solutionId
             };
             if (solutionId) {
@@ -238,7 +238,7 @@ export function fetchResultExemplars(
               timeseriesColName: variable.grouping.idCol,
               xColName: variable.grouping.properties.xCol,
               yColName: variable.grouping.properties.yCol,
-              timeseriesID: exemplar,
+              timeseriesId: exemplar,
               solutionId: solutionId
             });
           })

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -300,7 +300,7 @@ function createTimeseriesSummaryFacet(summary: VariableSummary): Group {
         forecasts.forecastData[facet.file]
       ];
       facet.colors = ["#000", "#00c6e1"];
-    } else {
+    } else if (timeseries) {
       facet.timeseries = timeseries.timeseriesData[facet.file];
     }
   });

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { Route, Location } from "vue-router";
+import { Route, Location, RouteRecord } from "vue-router";
 import { Dictionary } from "./dict";
 import {
   JOINED_VARS_INSTANCE_PAGE,
@@ -37,6 +37,7 @@ export interface RouteArgs {
   varRanked?: string;
   produceRequestId?: string;
   fittedSolutionId?: string;
+  predictionsDataset?: string;
 
   // we currently don't have a way to add these to the interface
   //
@@ -79,103 +80,16 @@ export function getRouteFacetPage(key: string, route: Route): number {
 }
 
 function validateQueryArgs(args: RouteArgs): RouteArgs {
-  const query: RouteArgs = {};
-
-  // If `undefined` or empty array do not add property. This is to allow args
-  // of `''` and `null` to overwrite existing values.
-
-  if (!_.isUndefined(args.clustering)) {
-    query.clustering = args.clustering;
-  }
-  if (!_.isUndefined(args.dataset)) {
-    query.dataset = args.dataset;
-  }
-  if (!_.isUndefined(args.terms)) {
-    query.terms = args.terms;
-  }
-  if (!_.isUndefined(args.target)) {
-    query.target = args.target;
-  }
-  if (!_.isUndefined(args.include)) {
-    query.include = args.include;
-  }
-  if (!_.isUndefined(args.solutionId)) {
-    query.solutionId = args.solutionId;
-  }
-  if (!_.isUndefined(args.filters)) {
-    query.filters = args.filters;
-  }
-  if (!_.isUndefined(args.training)) {
-    query.training = args.training;
-  }
-  if (!_.isUndefined(args.residualThresholdMin)) {
-    query.residualThresholdMin = args.residualThresholdMin;
-  }
-  if (!_.isUndefined(args.residualThresholdMax)) {
-    query.residualThresholdMax = args.residualThresholdMax;
-  }
-  if (!_.isUndefined(args.highlights)) {
-    query.highlights = args.highlights;
-  }
-  if (!_.isUndefined(args.row)) {
-    query.row = args.row;
-  }
-  if (!_.isUndefined(args.joinDatasets)) {
-    query.joinDatasets = args.joinDatasets;
-  }
-  if (!_.isUndefined(args.joinColumnA)) {
-    query.joinColumnA = args.joinColumnA;
-  }
-  if (!_.isUndefined(args.joinColumnB)) {
-    query.joinColumnB = args.joinColumnB;
-  }
-  if (!_.isUndefined(args.baseColumnSuggestions)) {
-    query.baseColumnSuggestions = args.baseColumnSuggestions;
-  }
-  if (!_.isUndefined(args.joinColumnSuggestions)) {
-    query.joinColumnSuggestions = args.joinColumnSuggestions;
-  }
-  if (!_.isUndefined(args.joinAccuracy)) {
-    query.joinAccuracy = args.joinAccuracy;
-  }
-  if (!_.isUndefined(args.groupingType)) {
-    query.groupingType = args.groupingType;
-  }
-  if (!_.isUndefined(args.task)) {
-    query.task = args.task;
-  }
-  if (!_.isUndefined(args.produceRequestId)) {
-    query.produceRequestId = args.produceRequestId;
-  }
-  if (!_.isUndefined(args.varModes)) {
-    query.varModes = args.varModes;
-  }
-  if (!_.isUndefined(args.varRanked)) {
-    query.varRanked = args.varRanked;
-  }
-  if (!_.isUndefined(args.fittedSolutionId)) {
-    query.fittedSolutionId = args.fittedSolutionId;
-  }
-  if (args[JOINED_VARS_INSTANCE_PAGE]) {
-    query[JOINED_VARS_INSTANCE_PAGE] = args[JOINED_VARS_INSTANCE_PAGE];
-  }
-  if (args[AVAILABLE_TARGET_VARS_INSTANCE_PAGE]) {
-    query[AVAILABLE_TARGET_VARS_INSTANCE_PAGE] =
-      args[AVAILABLE_TARGET_VARS_INSTANCE_PAGE];
-  }
-  if (args[AVAILABLE_TRAINING_VARS_INSTANCE_PAGE]) {
-    query[AVAILABLE_TRAINING_VARS_INSTANCE_PAGE] =
-      args[AVAILABLE_TRAINING_VARS_INSTANCE_PAGE];
-  }
-  if (args[TRAINING_VARS_INSTANCE_PAGE]) {
-    query[TRAINING_VARS_INSTANCE_PAGE] = args[TRAINING_VARS_INSTANCE_PAGE];
-  }
-  if (args[RESULT_TRAINING_VARS_INSTANCE_PAGE]) {
-    query[RESULT_TRAINING_VARS_INSTANCE_PAGE] =
-      args[RESULT_TRAINING_VARS_INSTANCE_PAGE];
-  }
-
-  return query;
+  return _.reduce(
+    args,
+    (query, value, arg) => {
+      if (!_.isUndefined(value)) {
+        query[arg] = value;
+      }
+      return query;
+    },
+    {} as RouteArgs
+  );
 }
 
 export function varModesToString(varModes: Map<string, SummaryMode>): string {


### PR DESCRIPTION
Fixes #1539.  There is a need for a UI for specifying prediction horizon, but I'll open a new issue for that as it likely requires support for binning as well.

- Fixes some issues with ingest of prediction datasets related to compound timeseries variables
- Splits `dataset` argument for `SparklinePreview` in two values - one for ground truth dataset, one for forecast dataset.  In train/test scenario, the values are the same.  In prediction scenario we pass in the original model dataset, and the dataset that contains the info to make predictions.