### PR TITLE
Image import error

### DIFF
--- a/api/dataset/image.go
+++ b/api/dataset/image.go
@@ -132,7 +132,7 @@ func (i *Image) CreateDataset(rootDataPath string, config *env.Config) (*api.Raw
 
 			imageLoaded, err := readImage(imageFilenameFull, i.ImageType)
 			if err != nil {
-				log.Warnf("unable to read image: %v", err)
+				log.Warnf("unable to read image '%s': %v", imageFilename, err)
 				continue
 			}
 
@@ -145,13 +145,13 @@ func (i *Image) CreateDataset(rootDataPath string, config *env.Config) (*api.Raw
 
 			imageOutput, err := toJPEG(&imageLoaded)
 			if err != nil {
-				log.Warnf("unable to convert image: %v", err)
+				log.Warnf("unable to convert image '%s': %v", imageFilename, err)
 				continue
 			}
 
 			err = util.WriteFileWithDirs(targetImageFilename, imageOutput, os.ModePerm)
 			if err != nil {
-				log.Warnf("unable to save processed image file: %v", err)
+				log.Warnf("unable to save processed image file '%s': %v", imageFilename, err)
 				continue
 			}
 
@@ -163,7 +163,7 @@ func (i *Image) CreateDataset(rootDataPath string, config *env.Config) (*api.Raw
 	// check counts and flag if too many errors
 	for label, count := range totalCounts {
 		successes := successCounts[label]
-		if count*int((1.0-config.ImportErrorThreshold)) < successes {
+		if successes < int(float64(count)*(1.0-config.ImportErrorThreshold)) {
 			return nil, errors.Errorf("too many errors when processing label '%s' (%d out of %d failed)", label, count-successes, count)
 		}
 	}

--- a/api/env/config.go
+++ b/api/env/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	GeocodingOutputDataRelative        string  `env:"GEOCODING_OUTPUT_DATA" envDefault:"geocoded/tables/learningData.csv"`
 	GeocodingOutputSchemaRelative      string  `env:"GEOCODING_OUTPUT_SCHEMA" envDefault:"geocoded/datasetDoc.json"`
 	GeocodingEnabled                   bool    `env:"GEOCODING_ENABLED" envDefault:"false"`
+	ImportErrorThreshold               float64 `env:"IMPORT_ERROR_THRESHOLD" envDefault:"0.1"`
 	IngestHardFail                     bool    `env:"INGEST_HARD_FAIL" envDefault:"false"`
 	InitialDataset                     string  `env:"INITIAL_DATASET" envDefault:""`
 	MaxTrainingRows                    int     `env:"MAX_TRAINING_ROWS" envDefault:"10000"`


### PR DESCRIPTION
Fixes #1572 

The error is due to some issue in the image being raised by the jpeg library. Once any error occurs, the whole import process fails.

Errors processing images are now logged. If more errors occur (on a per label basis) than the error threshold, then the import process fails.