### PR TITLE
#1575 Set Dataset Name On Import + Table Fixes

### DIFF
--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -363,7 +363,6 @@ export default Vue.extend({
   display: flex;
   flex-flow: wrap;
   height: 100%;
-  overflow: scroll;
   position: relative;
   width: 100%;
 }

--- a/public/views/Predictions.vue
+++ b/public/views/Predictions.vue
@@ -119,6 +119,17 @@ export default Vue.extend({
   color: rgba(0, 0, 0, 0.87);
 }
 
+.predictions-view .table td {
+  text-align: left;
+  padding: 0px;
+}
+.predictions-view .table td > div {
+  text-align: left;
+  padding: 0.3rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .variable-summaries {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Fixes #1575. Adds whatever the user enters for in modal for a name to the filename then uses that for the dataset name for imports for prediction. Also fixes some table display issues in select data and predictions. This isn't enforcing strict uniqueness client side, but could be extended for that.