### PR TITLE
Duplicate dataset names

### DIFF
--- a/api/dataset/image.go
+++ b/api/dataset/image.go
@@ -85,9 +85,11 @@ func NewImageDataset(dataset string, imageType string, rawData []byte, config *e
 }
 
 // CreateDataset processes the raw image dataset and creates a raw D3M dataset.
-func (i *Image) CreateDataset(rootDataPath string, config *env.Config) (*api.RawDataset, error) {
-	outputPath := path.Join(config.D3MOutputDir, config.AugmentedSubFolder)
-	outputDatasetPath := path.Join(outputPath, i.Dataset)
+func (i *Image) CreateDataset(rootDataPath string, datasetName string, config *env.Config) (*api.RawDataset, error) {
+	if datasetName == "" {
+		datasetName = i.Dataset
+	}
+	outputDatasetPath := rootDataPath
 	dataFilePath := path.Join(compute.D3MDataFolder, compute.D3MLearningData)
 
 	imageFolders := make([]string, 0)
@@ -165,8 +167,8 @@ func (i *Image) CreateDataset(rootDataPath string, config *env.Config) (*api.Raw
 	log.Infof("creating metadata")
 
 	// create the dataset schema doc
-	datasetID := model.NormalizeDatasetID(i.Dataset)
-	meta := model.NewMetadata(i.Dataset, i.Dataset, "", datasetID)
+	datasetID := model.NormalizeDatasetID(datasetName)
+	meta := model.NewMetadata(datasetName, datasetName, "", datasetID)
 	dr := model.NewDataResource(compute.DefaultResourceID, model.ResTypeTable, map[string][]string{compute.D3MResourceFormat: {"csv"}})
 	dr.ResPath = dataFilePath
 	dr.Variables = append(dr.Variables,
@@ -193,7 +195,7 @@ func (i *Image) CreateDataset(rootDataPath string, config *env.Config) (*api.Raw
 
 	return &api.RawDataset{
 		ID:       datasetID,
-		Name:     i.Dataset,
+		Name:     datasetName,
 		Data:     csvData,
 		Metadata: meta,
 	}, nil

--- a/api/dataset/image.go
+++ b/api/dataset/image.go
@@ -61,22 +61,16 @@ type Image struct {
 
 // NewImageDataset creates a new image dataset from raw byte data, assuming json.
 func NewImageDataset(dataset string, imageType string, rawData []byte, config *env.Config) (*Image, error) {
-	outputPath := path.Join(config.D3MOutputDir, config.AugmentedSubFolder)
-	outputDatasetPath := path.Join(outputPath, dataset)
-
-	// clear the output dataset path location
-	err := util.RemoveContents(outputDatasetPath)
-	if err != nil {
-		log.Warnf("unable to remove contents: %v", err)
-	}
-
 	// store and expand raw data
-	zipFilename := path.Join(outputDatasetPath, "raw.zip")
-	err = util.WriteFileWithDirs(zipFilename, rawData, os.ModePerm)
+	tmpPath := env.GetTmpPath()
+	zipFilename := path.Join(tmpPath, fmt.Sprintf("%s_raw.zip", dataset))
+	zipFilename = getUniqueName(zipFilename)
+	err := util.WriteFileWithDirs(zipFilename, rawData, os.ModePerm)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to write raw image data archive")
 	}
-	extractedArchivePath := outputDatasetPath
+
+	extractedArchivePath := getUniqueFolder(path.Join(tmpPath, dataset))
 	err = util.Unzip(zipFilename, extractedArchivePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to extract raw image data archive")

--- a/api/dataset/table.go
+++ b/api/dataset/table.go
@@ -48,19 +48,22 @@ func NewTableDataset(dataset string, rawData []byte, config *env.Config) (*Table
 }
 
 // CreateDataset structures a raw csv file into a valid D3M dataset.
-func (t *Table) CreateDataset(rootDataPath string, config *env.Config) (*api.RawDataset, error) {
+func (t *Table) CreateDataset(rootDataPath string, datasetName string, config *env.Config) (*api.RawDataset, error) {
+	if datasetName == "" {
+		datasetName = t.Dataset
+	}
 	dataFilePath := path.Join(compute.D3MDataFolder, compute.D3MLearningData)
 
 	// create the raw dataset schema doc
-	datasetID := model.NormalizeDatasetID(t.Dataset)
-	meta := model.NewMetadata(t.Dataset, t.Dataset, "", datasetID)
+	datasetID := model.NormalizeDatasetID(datasetName)
+	meta := model.NewMetadata(datasetName, datasetName, "", datasetID)
 	dr := model.NewDataResource(compute.DefaultResourceID, model.ResTypeRaw, map[string][]string{compute.D3MResourceFormat: {"csv"}})
 	dr.ResPath = dataFilePath
 	meta.DataResources = []*model.DataResource{dr}
 
 	return &api.RawDataset{
 		ID:       datasetID,
-		Name:     t.Dataset,
+		Name:     datasetName,
 		Data:     t.CSVData,
 		Metadata: meta,
 	}, nil

--- a/api/env/config.go
+++ b/api/env/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	GeocodingOutputSchemaRelative      string  `env:"GEOCODING_OUTPUT_SCHEMA" envDefault:"geocoded/datasetDoc.json"`
 	GeocodingEnabled                   bool    `env:"GEOCODING_ENABLED" envDefault:"false"`
 	IngestHardFail                     bool    `env:"INGEST_HARD_FAIL" envDefault:"false"`
+	IngestOverwrite                    bool    `env:"INGEST_OVERWRITE" envDefault:"false"`
 	InitialDataset                     string  `env:"INITIAL_DATASET" envDefault:""`
 	MaxTrainingRows                    int     `env:"MAX_TRAINING_ROWS" envDefault:"10000"`
 	MaxTestRows                        int     `env:"MAX_TEST_ROWS" envDefault:"10000"`

--- a/api/env/path.go
+++ b/api/env/path.go
@@ -133,6 +133,11 @@ func GetTmpPath() string {
 	return outputPath
 }
 
+// GetAugmentedPath returns the augmented path as initialized.
+func GetAugmentedPath() string {
+	return augmentedPath
+}
+
 // ResolvePath returns an absolute path based on the dataset source.
 func ResolvePath(datasetSource metadata.DatasetSource, relativePath string) string {
 	switch datasetSource {

--- a/api/model/storage/datamart/isi.go
+++ b/api/model/storage/datamart/isi.go
@@ -276,7 +276,7 @@ func materializeISIDataset(datamart *Storage, id string, uri string) (string, er
 	if err != nil {
 		return "", errors.Wrap(err, "unable to create raw dataset from ISI datamart materialized dataset")
 	}
-	datasetPath, err := task.CreateDataset(id, ds, datamart.outputPath, api.DatasetTypeModelling, datamart.config)
+	_, datasetPath, err := task.CreateDataset(id, ds, datamart.outputPath, api.DatasetTypeModelling, datamart.config)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to store dataset from ISI datamart")
 	}

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -194,6 +194,10 @@ func (s *Storage) FetchDataset(datasetName string, includeIndex bool, includeMet
 	if err != nil {
 		return nil, err
 	}
+	if len(datasets) < 1 {
+		return nil, nil
+	}
+
 	return datasets[0], nil
 }
 

--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -98,14 +98,14 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 		}
 
 		// ingest the imported dataset
-		err = task.IngestDataset(source, dataCtor, esMetaCtor, cfg.ESDatasetsIndex, datasetID, origins, &ingestConfig)
+		datasetID, err = task.IngestDataset(source, dataCtor, esMetaCtor, cfg.ESDatasetsIndex, datasetID, origins, &ingestConfig)
 		if err != nil {
 			handleError(w, err)
 			return
 		}
 
 		// marshal data and sent the response back
-		err = handleJSON(w, map[string]interface{}{"result": "ingested"})
+		err = handleJSON(w, map[string]interface{}{"dataset": datasetID, "result": "ingested"})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
 			return

--- a/api/routes/inference.go
+++ b/api/routes/inference.go
@@ -218,7 +218,7 @@ func getTarget(request *api.Request) string {
 
 func createImageFromRequest(data []byte, dataset string, outputPath string, imageType string, config *env.Config) (bool, []byte, error) {
 	// raw request is zip file of image dataset that needs to be imported
-	formattedPath, err := uploadImageDataset(dataset, outputPath, config, data, imageType)
+	_, formattedPath, err := uploadImageDataset(dataset, outputPath, config, data, imageType)
 	if err != nil {
 		return false, nil, err
 	}

--- a/api/routes/upload.go
+++ b/api/routes/upload.go
@@ -48,7 +48,7 @@ func UploadHandler(outputPath string, config *env.Config) func(http.ResponseWrit
 
 		formattedPath := ""
 		if typ == "table" {
-			formattedPath, err = uploadTableDataset(dataset, outputPath, config, data)
+			dataset, formattedPath, err = uploadTableDataset(dataset, outputPath, config, data)
 		} else if typ == "image" {
 			imageType, ok := queryValues["image"]
 			if !ok {
@@ -56,7 +56,7 @@ func UploadHandler(outputPath string, config *env.Config) func(http.ResponseWrit
 				return
 			}
 
-			formattedPath, err = uploadImageDataset(dataset, outputPath, config, data, imageType[0])
+			dataset, formattedPath, err = uploadImageDataset(dataset, outputPath, config, data, imageType[0])
 		} else if typ == "" {
 			handleError(w, errors.Errorf("upload type parameter not specified"))
 			return
@@ -72,7 +72,7 @@ func UploadHandler(outputPath string, config *env.Config) func(http.ResponseWrit
 
 		log.Infof("uploaded new dataset %s at %s", dataset, formattedPath)
 		// marshal data and sent the response back
-		err = handleJSON(w, map[string]interface{}{"result": "uploaded"})
+		err = handleJSON(w, map[string]interface{}{"dataset": dataset, "result": "uploaded"})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
 			return
@@ -80,34 +80,34 @@ func UploadHandler(outputPath string, config *env.Config) func(http.ResponseWrit
 	}
 }
 
-func uploadTableDataset(datasetName string, outputPath string, config *env.Config, data []byte) (string, error) {
+func uploadTableDataset(datasetName string, outputPath string, config *env.Config, data []byte) (string, string, error) {
 	ds, err := dataset.NewTableDataset(datasetName, data, config)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to create raw dataset")
+		return "", "", errors.Wrap(err, "unable to create raw dataset")
 	}
 
 	// create the raw dataset schema doc
-	_, formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, api.DatasetTypeModelling, config)
+	datasetName, formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, api.DatasetTypeModelling, config)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to create dataset")
+		return "", "", errors.Wrap(err, "unable to create dataset")
 	}
 
-	return formattedPath, nil
+	return datasetName, formattedPath, nil
 }
 
-func uploadImageDataset(datasetName string, outputPath string, config *env.Config, data []byte, imageType string) (string, error) {
+func uploadImageDataset(datasetName string, outputPath string, config *env.Config, data []byte, imageType string) (string, string, error) {
 	ds, err := dataset.NewImageDataset(datasetName, imageType, data, config)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to create raw dataset")
+		return "", "", errors.Wrap(err, "unable to create raw dataset")
 	}
 
 	// create the raw dataset schema doc
-	_, formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, api.DatasetTypeModelling, config)
+	datasetName, formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, api.DatasetTypeModelling, config)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to create dataset")
+		return "", "", errors.Wrap(err, "unable to create dataset")
 	}
 
-	return formattedPath, nil
+	return datasetName, formattedPath, nil
 }
 
 func receiveFile(r *http.Request) ([]byte, error) {

--- a/api/routes/upload.go
+++ b/api/routes/upload.go
@@ -87,7 +87,7 @@ func uploadTableDataset(datasetName string, outputPath string, config *env.Confi
 	}
 
 	// create the raw dataset schema doc
-	formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, api.DatasetTypeModelling, config)
+	_, formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, api.DatasetTypeModelling, config)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to create dataset")
 	}
@@ -102,7 +102,7 @@ func uploadImageDataset(datasetName string, outputPath string, config *env.Confi
 	}
 
 	// create the raw dataset schema doc
-	formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, api.DatasetTypeModelling, config)
+	_, formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, api.DatasetTypeModelling, config)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to create dataset")
 	}

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -48,7 +48,7 @@ var (
 
 // DatasetConstructor is used to build a dataset.
 type DatasetConstructor interface {
-	CreateDataset(rootDataPath string, config *env.Config) (*api.RawDataset, error)
+	CreateDataset(rootDataPath string, datasetName string, config *env.Config) (*api.RawDataset, error)
 }
 
 // CreateDataset structures a raw csv file into a valid D3M dataset.
@@ -70,7 +70,7 @@ func CreateDataset(dataset string, datasetCtor DatasetConstructor, outputPath st
 	dataFilePath := path.Join(compute.D3MDataFolder, compute.D3MLearningData)
 	dataPath := path.Join(outputDatasetPath, dataFilePath)
 
-	ds, err := datasetCtor.CreateDataset(outputDatasetPath, config)
+	ds, err := datasetCtor.CreateDataset(outputDatasetPath, dataset, config)
 	if err != nil {
 		return "", "", err
 	}

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -185,9 +185,7 @@ func getUniqueOutputFolder(dataset string, outputPath string) (string, error) {
 		}
 	}
 
-	uniqueDataset := getUniqueString(dataset, dirs)
-
-	return uniqueDataset, nil
+	return getUniqueString(dataset, dirs), nil
 }
 
 func getUniqueString(base string, existing []string) string {
@@ -198,7 +196,7 @@ func getUniqueString(base string, existing []string) string {
 	}
 
 	unique := base
-	for count := 1; !existingMap[unique]; count++ {
+	for count := 1; existingMap[unique]; count++ {
 		unique = fmt.Sprintf("%s_%d", base, count)
 	}
 

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -586,15 +586,10 @@ func getUniqueDatasetName(meta *model.Metadata, storage api.MetadataStorage) (st
 		return "", err
 	}
 
-	datasetNames := make(map[string]bool)
+	datasetNames := make([]string, 0)
 	for _, ds := range datasets {
-		datasetNames[ds.Name] = true
+		datasetNames = append(datasetNames, ds.Name)
 	}
 
-	uniqueName := meta.Name
-	for count := 1; !datasetNames[uniqueName]; count++ {
-		uniqueName = fmt.Sprintf("%s_%d", meta.Name, count)
-	}
-
-	return uniqueName, nil
+	return getUniqueString(meta.Name, datasetNames), nil
 }

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -108,7 +108,7 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 		}
 
 		// create the dataset to be used for predictions
-		_, err = CreateDataset(params.Dataset, predictionDatasetCtor, params.OutputPath, api.DatasetTypeInference, params.Config)
+		_, _, err = CreateDataset(params.Dataset, predictionDatasetCtor, params.OutputPath, api.DatasetTypeInference, params.Config)
 		if err != nil {
 			return nil, err
 		}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -41,9 +41,9 @@ type predictionDataset struct {
 	params *PredictParams
 }
 
-func (p *predictionDataset) CreateDataset(rootDataPath string, config *env.Config) (*api.RawDataset, error) {
+func (p *predictionDataset) CreateDataset(rootDataPath string, datasetName string, config *env.Config) (*api.RawDataset, error) {
 	// need to do a bit of processing on the usual setup
-	ds, err := p.params.DatasetConstructor.CreateDataset(rootDataPath, config)
+	ds, err := p.params.DatasetConstructor.CreateDataset(rootDataPath, datasetName, config)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -214,7 +214,7 @@ func main() {
 			log.Errorf("%+v", err)
 			os.Exit(1)
 		}
-		err = task.IngestDataset(metadata.Contrib, pgDataStorageCtor, esMetadataStorageCtor, config.ESDatasetsIndex, "initial", nil, ingestConfig)
+		_, err = task.IngestDataset(metadata.Contrib, pgDataStorageCtor, esMetadataStorageCtor, config.ESDatasetsIndex, "initial", nil, ingestConfig)
 		if err != nil {
 			log.Errorf("%+v", err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -87,6 +87,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	createOutputFolders(&config)
+
 	// initialize the pipeline cache and
 	pipelineCacheFilename := path.Join(env.GetTmpPath(), config.PipelineCacheFilename)
 	err = api.InitializeCache(pipelineCacheFilename)
@@ -313,4 +315,10 @@ func updateExtremas(metaStorage model.MetadataStorage, dataStorage model.DataSto
 	log.Infof("done updating all extremas")
 
 	return nil
+}
+
+func createOutputFolders(config *env.Config) {
+	// create the augmented data folder
+	augmentPath := env.GetAugmentedPath()
+	os.MkdirAll(augmentPath, os.ModePerm)
 }


### PR DESCRIPTION
Fixes #1574 

There were a few points that assumed either a unique name was provided or that the existing dataset should be overwritten. A new configuration option has been added to control the behaviour if names get reused. 

On upload, if the dataset already exists, then a unique name will be created using numbered suffix (if configured for this behaviour) and the new dataset id will be returned to the client. Similar functionality has been implemented for the ingest functions as those can be called from datamart imports or outside libraries.