### PR TITLE
Multi band combo fetch + remote sensing task

### DIFF
--- a/api/compute/task.go
+++ b/api/compute/task.go
@@ -48,6 +48,10 @@ func ResolveTask(storage api.DataStorage, datasetStorageName string, targetVaria
 				tasks = append(tasks, compute.ImageTask)
 				return &Task{tasks}, nil
 			}
+			if model.IsMultiBandImage(feature.Type) {
+				tasks = append(tasks, compute.RemoteSensingTask)
+				return &Task{tasks}, nil
+			}
 			if model.IsTimeSeries(feature.Type) {
 				tasks = append(tasks, compute.TimeSeriesTask)
 				return &Task{tasks}, nil
@@ -68,8 +72,9 @@ func ResolveTask(storage api.DataStorage, datasetStorageName string, targetVaria
 		for _, feature := range features {
 			if model.IsImage(feature.Type) {
 				task = append(task, compute.ImageTask)
-			}
-			if model.IsTimeSeries(feature.Type) {
+			} else if model.IsMultiBandImage(feature.Type) {
+				task = append(task, compute.RemoteSensingTask)
+			} else if model.IsTimeSeries(feature.Type) {
 				task = append(task, compute.TimeSeriesTask)
 			}
 		}

--- a/api/routes/multiband_combinations.go
+++ b/api/routes/multiband_combinations.go
@@ -1,0 +1,56 @@
+//
+//   Copyright © 2020 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"net/http"
+
+	"github.com/pkg/errors"
+	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/util"
+)
+
+// MultiBandCombinationDesc provides a band combination ID and display name.
+type MultiBandCombinationDesc struct {
+	ID          util.BandCombinationID `json:"id"`
+	DisplayName string                 `json:"displayName"`
+}
+
+// MultiBandCombinations provides a lit of combinations to be serialized to JSON for transport to the
+// client.
+type MultiBandCombinations struct {
+	Combinations []*MultiBandCombinationDesc `json:"combinations"`
+}
+
+// MultiBandCombinationsHandler fetches a list of available band combination names for a given dataset.
+func MultiBandCombinationsHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// dataset := pat.Param(r, "dataset")
+		// This currently just fetches band combos for sentinel 2 data so we don't read the dataset parameter yet.
+		combinationsList := make([]*MultiBandCombinationDesc, len(util.SentinelBandCombinations))
+		idx := 0
+		for _, value := range util.SentinelBandCombinations {
+			combinationsList[idx] = &MultiBandCombinationDesc{value.ID, value.DisplayName}
+			idx++
+		}
+		combinations := MultiBandCombinations{combinationsList}
+		err := handleJSON(w, combinations)
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
+			return
+		}
+	}
+}

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -78,9 +78,9 @@ type BandCombinationID string
 
 // BandCombination defines a mapping of satellite bands to image RGB channels.
 type BandCombination struct {
-	id          BandCombinationID
-	displayName string
-	mapping     []string
+	ID          BandCombinationID
+	DisplayName string
+	Mapping     []string
 }
 
 var (
@@ -104,7 +104,7 @@ var (
 func ImageFromCombination(datasetDir string, fileID string, bandCombination BandCombinationID) (*image.RGBA, error) {
 	filePaths := []string{}
 	if bandCombo, ok := SentinelBandCombinations[strings.ToLower(string(bandCombination))]; ok {
-		for _, bandLabel := range bandCombo.mapping {
+		for _, bandLabel := range bandCombo.Mapping {
 			filePath := getFilePath(datasetDir, fileID, bandLabel)
 			filePaths = append(filePaths, filePath)
 		}

--- a/go.mod
+++ b/go.mod
@@ -45,5 +45,3 @@ require (
 	gopkg.in/olivere/elastic.v5 v5.0.83
 	mellium.im/sasl v0.2.1 // indirect
 )
-
-replace github.com/uncharted-distil/distil-compute => ../distil-compute

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/shopspring/decimal v0.0.0-20191009025716-f1972eb1d1f5 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/uncharted-distil/distil-compute v0.0.0-20200505120409-2a541d506d85
+	github.com/uncharted-distil/distil-compute v0.0.0-20200505195801-b22a80cf9d31
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
@@ -45,3 +45,5 @@ require (
 	gopkg.in/olivere/elastic.v5 v5.0.83
 	mellium.im/sasl v0.2.1 // indirect
 )
+
+replace github.com/uncharted-distil/distil-compute => ../distil-compute

--- a/main.go
+++ b/main.go
@@ -249,6 +249,7 @@ func main() {
 	registerRoute(mux, "/distil/task/:dataset/:target/:variables", routes.TaskHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor))
 	registerRoute(mux, "/distil/:multiband-image/dataset/:image-id/:band-combination", routes.MultiBandImageHandler(esMetadataStorageCtor))
+	registerRoute(mux, "/distil/:multiband-combinations/:dataset", routes.MultiBandCombinationsHandler(esMetadataStorageCtor))
 
 	// POST
 	registerRoutePost(mux, "/distil/grouping/:dataset", routes.GroupingHandler(pgDataStorageCtor, esMetadataStorageCtor))


### PR DESCRIPTION
fixes #1604 #1603 

1. Adds a new route to support fetching the valid multi-band combinations for a dataset.
1. A new `MultiBandImage` type to the set of valid types on the server side.
1. Updates server-side task computation to include `remote_sensing` as a task keyword when classification or regression involving a `MultiBandImage` takes place.