### PR TITLE
Adds check to stop queueing if a pipeline is running

### DIFF
--- a/api/compute/pipeline.go
+++ b/api/compute/pipeline.go
@@ -122,6 +122,7 @@ type Queue struct {
 	mu            sync.RWMutex
 	tasks         chan *QueueItem
 	alreadyQueued map[string]*QueueItem
+	inProgress    *QueueItem
 }
 
 // Enqueue adds one entry to the queue, providing the response channel as result.
@@ -138,6 +139,14 @@ func (q *Queue) Enqueue(key string, data interface{}) chan *QueueResponse {
 		log.Infof("'%s' already in queue so adding one more channel to output", key)
 		queuedItem.output = append(queuedItem.output, output)
 		queuedItem.data = data
+		q.mu.Unlock()
+
+		return output
+	}
+	if q.inProgress != nil && q.inProgress.key == key {
+		log.Infof("'%s' already in progress so adding one more channel to output", key)
+		q.inProgress.output = append(q.inProgress.output, output)
+		q.inProgress.data = data
 		q.mu.Unlock()
 
 		return output
@@ -167,9 +176,16 @@ func (q *Queue) Dequeue() (*QueueItem, bool) {
 
 	q.mu.Lock()
 	q.alreadyQueued[item.key] = nil
+	q.inProgress = item
 	q.mu.Unlock()
 
 	return item, true
+}
+
+func (q *Queue) Done() {
+	q.mu.Lock()
+	q.inProgress = nil
+	q.mu.Unlock()
 }
 
 // InitializeCache sets up an empty cache or if a source file provided, reads
@@ -253,6 +269,7 @@ func SubmitPipeline(client *compute.Client, datasets []string, datasetsProduce [
 
 	datasetURI := result.Output.(string)
 	cache.cache.Set(hashedPipelineUniqueKey, datasetURI, gc.DefaultExpiration)
+	queue.Done()
 	err = cache.PersistCache()
 	if err != nil {
 		log.Warnf("error persisting cache: %v", err)

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -333,7 +333,7 @@ func (s *Storage) AddVariable(dataset string, varName string, varDisplayName str
 		if v.Name == varName {
 			// check if it has been deleted
 			if !v.Deleted {
-				return fmt.Errorf("variable already exists under this key")
+				return errors.Errorf("variable already exists under this key")
 			}
 
 			// deleted, add the new var in its place


### PR DESCRIPTION
Fixes #1549 

Checks were in place to ensure that a pipeline submission request wasn't added to the queue if it was already present.  A similar check had to be added to ensure that a running pipeline couldn't be added to the queue.