### PR TITLE
Model save/load fixes

### DIFF
--- a/api/compute/pipeline.go
+++ b/api/compute/pipeline.go
@@ -182,6 +182,7 @@ func (q *Queue) Dequeue() (*QueueItem, bool) {
 	return item, true
 }
 
+// Done flags a task queue as being completed, which removes it from the in progress slot.
 func (q *Queue) Done() {
 	q.mu.Lock()
 	q.inProgress = nil

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -140,6 +140,7 @@ type ExportedModelStorageCtor func() (ExportedModelStorage, error)
 type ExportedModelStorage interface {
 	PersistExportedModel(exportedModel *ExportedModel) error
 	FetchModel(model string) (*ExportedModel, error)
+	FetchModelByID(fittedSolutionID string) (*ExportedModel, error)
 	FetchModels() ([]*ExportedModel, error)
 	SearchModels(terms string) ([]*ExportedModel, error)
 }

--- a/api/model/storage/elastic/model.go
+++ b/api/model/storage/elastic/model.go
@@ -142,7 +142,10 @@ func (s *Storage) FetchModel(modelName string) (*api.ExportedModel, error) {
 	if err != nil {
 		return nil, err
 	}
-	return models[0], nil
+	if len(models) > 0 {
+		return models[0], nil
+	}
+	return nil, nil
 }
 
 // FetchModelByID returns a model in the provided index using the model's fitted solution ID.
@@ -162,7 +165,10 @@ func (s *Storage) FetchModelByID(fittedSolutionID string) (*api.ExportedModel, e
 	if err != nil {
 		return nil, err
 	}
-	return models[0], nil
+	if len(models) > 0 {
+		return models[0], nil
+	}
+	return nil, nil
 }
 
 // SearchModels returns the models that match the search criteria in the

--- a/api/model/storage/elastic/model.go
+++ b/api/model/storage/elastic/model.go
@@ -124,9 +124,30 @@ func (s *Storage) FetchModels() ([]*api.ExportedModel, error) {
 	return s.parseModels(res)
 }
 
-// FetchModel returns a model in the provided index.
+// FetchModel returns a model in the provided index.  Model name is the named assigend
+// to the model by the user.
 func (s *Storage) FetchModel(modelName string) (*api.ExportedModel, error) {
-	query := elastic.NewMatchQuery("modelName", modelName)
+	query := elastic.NewMatchQuery("id", modelName)
+	// execute the ES query
+	res, err := s.client.Search().
+		Query(query).
+		Index(s.modelIndex).
+		FetchSource(true).
+		Size(modelsListSize).
+		Do(context.Background())
+	if err != nil {
+		return nil, errors.Wrap(err, "elasticsearch model fetch query failed")
+	}
+	models, err := s.parseModels(res)
+	if err != nil {
+		return nil, err
+	}
+	return models[0], nil
+}
+
+// FetchModelByID returns a model in the provided index using the model's fitted solution ID.
+func (s *Storage) FetchModelByID(fittedSolutionID string) (*api.ExportedModel, error) {
+	query := elastic.NewMatchQuery("_id", fittedSolutionID)
 	// execute the ES query
 	res, err := s.client.Search().
 		Query(query).

--- a/api/routes/load.go
+++ b/api/routes/load.go
@@ -1,0 +1,85 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"net/http"
+
+	"goji.io/v3/pat"
+
+	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/task"
+	log "github.com/unchartedsoftware/plog"
+)
+
+// LoadHandler requests that the downstream auto ml system load a model for further use.
+func LoadHandler(modelStorageCtor api.ExportedModelStorageCtor, solutionStorageCtor api.SolutionStorageCtor,
+	metadataStorageCtor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// extract route parameters
+		solutionID := pat.Param(r, "solution-id")
+		fitted := pat.Param(r, "fitted")
+		fittedBool := parseBoolParam(fitted)
+
+		modelStorage, err := modelStorageCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		metadataStorage, err := metadataStorageCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		solutionStorage, err := solutionStorageCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		if fittedBool {
+			// Fetch the path to saved solution
+			fittedSolution, err := modelStorage.FetchModelByID(solutionID)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+			// Request that the ta2 load the solution
+			loadedModel, err := task.LoadFittedSolution(fittedSolution.FilePath, solutionStorage, metadataStorage)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+			log.Infof("loaded model - %s", loadedModel)
+		} else {
+			_, err = task.LoadSolution(solutionID)
+		}
+
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		log.Infof("Completed export request for %s", solutionID)
+
+		err = handleJSON(w, map[string]interface{}{"solution-id": solutionID, "result": "loaded"})
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+	}
+}

--- a/api/routes/models.go
+++ b/api/routes/models.go
@@ -25,16 +25,6 @@ import (
 	"github.com/uncharted-distil/distil/api/model"
 )
 
-// ModelResult represents the result of a model response.
-type ModelResult struct {
-	Model *model.ExportedModel `json:"model"`
-}
-
-// ModelsResult represents the result of a models response.
-type ModelsResult struct {
-	Models []*model.ExportedModel `json:"models"`
-}
-
 // ModelHandler generates a route handler that returns a specified model summary.
 func ModelHandler(ctor model.ExportedModelStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -57,9 +47,7 @@ func ModelHandler(ctor model.ExportedModelStorageCtor) func(http.ResponseWriter,
 		}
 
 		// marshal data
-		err = handleJSON(w, ModelResult{
-			Model: res,
-		})
+		err = handleJSON(w, res)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable to marshal model result into JSON"))
 			return
@@ -87,16 +75,19 @@ func ModelsHandler(modelCtor model.ExportedModelStorageCtor) func(http.ResponseW
 			return
 		}
 
-		models, err := storage.SearchModels(terms)
+		var models []*model.ExportedModel
+		if terms != "" {
+			models, err = storage.SearchModels(terms)
+		} else {
+			models, err = storage.FetchModels()
+		}
 		if err != nil {
 			handleError(w, err)
 			return
 		}
 
 		// marshal data
-		err = handleJSON(w, ModelsResult{
-			Models: models,
-		})
+		err = handleJSON(w, models)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable to marshal model results into JSON"))
 			return

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -83,6 +83,7 @@ type PredictParams struct {
 	MetaStorage        api.MetadataStorage
 	DataStorage        api.DataStorage
 	SolutionStorage    api.SolutionStorage
+	ModelStorage       api.ExportedModelStorage
 	DatasetIngested    bool
 	DatasetImported    bool
 	IngestConfig       *IngestTaskConfig
@@ -192,6 +193,16 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 
 	// get the explained solution id
 	solution, err := params.SolutionStorage.FetchSolution(params.SolutionID)
+	if err != nil {
+		return nil, err
+	}
+
+	// ensure the ta2 has fitted solution loaded
+	exportedModel, err := params.ModelStorage.FetchModelByID(params.FittedSolutionID)
+	if err != nil {
+		return nil, err
+	}
+	_, err = LoadFittedSolution(exportedModel.FilePath, params.SolutionStorage, params.MetaStorage)
 	if err != nil {
 		return nil, err
 	}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -197,14 +197,17 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 		return nil, err
 	}
 
-	// ensure the ta2 has fitted solution loaded
+	// Ensure the ta2 has fitted solution loaded.  If the model wasn't saved, it should be available
+	// as part of the session.
 	exportedModel, err := params.ModelStorage.FetchModelByID(params.FittedSolutionID)
 	if err != nil {
 		return nil, err
 	}
-	_, err = LoadFittedSolution(exportedModel.FilePath, params.SolutionStorage, params.MetaStorage)
-	if err != nil {
-		return nil, err
+	if exportedModel != nil {
+		_, err = LoadFittedSolution(exportedModel.FilePath, params.SolutionStorage, params.MetaStorage)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// submit the new dataset for predictions

--- a/api/task/solution.go
+++ b/api/task/solution.go
@@ -67,3 +67,21 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 func SaveSolution(solutionID string) (string, error) {
 	return client.SaveSolution(context.Background(), solutionID)
 }
+
+// LoadFittedSolution loads a fitted solution via TA2TA3 API.
+func LoadFittedSolution(fittedSolutionURI string, solutionStorage api.SolutionStorage, metadataStorage api.MetadataStorage) (string, error) {
+	fittedSolutionID, err := client.LoadFittedSolution(context.Background(), fittedSolutionURI)
+	if err != nil {
+		return "", err
+	}
+	return fittedSolutionID, nil
+}
+
+// LoadSolution loads an unfitted solution via TA2TA3 API.
+func LoadSolution(solutionURI string) (string, error) {
+	fittedSolutionID, err := client.LoadFittedSolution(context.Background(), solutionURI)
+	if err != nil {
+		return "", err
+	}
+	return fittedSolutionID, nil
+}

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -53,11 +53,12 @@ func SetProblemFile(file string) {
 
 // SolutionHandler represents a solution websocket handler.
 func SolutionHandler(client *compute.Client, metadataCtor apiModel.MetadataStorageCtor,
-	dataCtor apiModel.DataStorageCtor, solutionCtor apiModel.SolutionStorageCtor) func(http.ResponseWriter, *http.Request) {
+	dataCtor apiModel.DataStorageCtor, solutionCtor apiModel.SolutionStorageCtor,
+	modelCtor apiModel.ExportedModelStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 
 		// create conn
-		conn, err := NewConnection(w, r, handleSolutionMessage(client, metadataCtor, dataCtor, solutionCtor))
+		conn, err := NewConnection(w, r, handleSolutionMessage(client, metadataCtor, dataCtor, solutionCtor, modelCtor))
 		if err != nil {
 			log.Warn(err)
 			return
@@ -73,7 +74,8 @@ func SolutionHandler(client *compute.Client, metadataCtor apiModel.MetadataStora
 }
 
 func handleSolutionMessage(client *compute.Client, metadataCtor apiModel.MetadataStorageCtor,
-	dataCtor apiModel.DataStorageCtor, solutionCtor apiModel.SolutionStorageCtor) func(conn *Connection, bytes []byte) {
+	dataCtor apiModel.DataStorageCtor, solutionCtor apiModel.SolutionStorageCtor,
+	modelCtor apiModel.ExportedModelStorageCtor) func(conn *Connection, bytes []byte) {
 	return func(conn *Connection, bytes []byte) {
 		// parse the message
 		msg, err := NewMessage(bytes)
@@ -83,12 +85,13 @@ func handleSolutionMessage(client *compute.Client, metadataCtor apiModel.Metadat
 			return
 		}
 		// handle message
-		go handleMessage(conn, client, metadataCtor, dataCtor, solutionCtor, msg)
+		go handleMessage(conn, client, metadataCtor, dataCtor, solutionCtor, modelCtor, msg)
 	}
 }
 
 func handleMessage(conn *Connection, client *compute.Client, metadataCtor apiModel.MetadataStorageCtor,
-	dataCtor apiModel.DataStorageCtor, solutionCtor apiModel.SolutionStorageCtor, msg *Message) {
+	dataCtor apiModel.DataStorageCtor, solutionCtor apiModel.SolutionStorageCtor, modelCtor apiModel.ExportedModelStorageCtor,
+	msg *Message) {
 	switch msg.Type {
 	case createSolutions:
 		handleCreateSolutions(conn, client, metadataCtor, dataCtor, solutionCtor, msg)
@@ -97,7 +100,7 @@ func handleMessage(conn *Connection, client *compute.Client, metadataCtor apiMod
 		handleStopSolutions(conn, client, msg)
 		return
 	case predict:
-		handlePredict(conn, client, metadataCtor, dataCtor, solutionCtor, msg)
+		handlePredict(conn, client, metadataCtor, dataCtor, solutionCtor, modelCtor, msg)
 	default:
 		// unrecognized type
 		handleErr(conn, msg, errors.New("unrecognized message type"))
@@ -231,7 +234,8 @@ func handleStopSolutions(conn *Connection, client *compute.Client, msg *Message)
 }
 
 func handlePredict(conn *Connection, client *compute.Client, metadataCtor apiModel.MetadataStorageCtor,
-	dataCtor apiModel.DataStorageCtor, solutionCtor apiModel.SolutionStorageCtor, msg *Message) {
+	dataCtor apiModel.DataStorageCtor, solutionCtor apiModel.SolutionStorageCtor,
+	modelCtor apiModel.ExportedModelStorageCtor, msg *Message) {
 
 	// initialize the storage
 	dataStorage, err := dataCtor()
@@ -249,6 +253,13 @@ func handlePredict(conn *Connection, client *compute.Client, metadataCtor apiMod
 
 	// initialize solution storage
 	solutionStorage, err := solutionCtor()
+	if err != nil {
+		handleErr(conn, msg, errors.Wrap(err, "unable to initialize solution storage"))
+		return
+	}
+
+	// initialize save model storage
+	modelStorage, err := modelCtor()
 	if err != nil {
 		handleErr(conn, msg, errors.Wrap(err, "unable to initialize solution storage"))
 		return
@@ -357,6 +368,7 @@ func handlePredict(conn *Connection, client *compute.Client, metadataCtor apiMod
 		MetaStorage:        metaStorage,
 		DataStorage:        dataStorage,
 		SolutionStorage:    solutionStorage,
+		ModelStorage:       modelStorage,
 		DatasetIngested:    false,
 		DatasetImported:    false,
 		Config:             &config,

--- a/clean_db.sh
+++ b/clean_db.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo rm -rf $D3MOUTPUTDIR
+docker system prune --force && docker volume prune --force

--- a/main.go
+++ b/main.go
@@ -251,7 +251,7 @@ func main() {
 	registerRoute(mux, "/distil/multiband-image/:dataset/:image-id/:band-combination", routes.MultiBandImageHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/distil/multiband-combinations/:dataset", routes.MultiBandCombinationsHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/distil/load/:solution-id/:fitted", routes.LoadHandler(esExportedModelStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor))
-	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor))
+	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor, esExportedModelStorageCtor))
 
 	// POST
 	registerRoutePost(mux, "/distil/grouping/:dataset", routes.GroupingHandler(pgDataStorageCtor, esMetadataStorageCtor))

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"syscall"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/pkg/errors"
 	log "github.com/unchartedsoftware/plog"
 	"github.com/zenazn/goji/graceful"
 	goji "goji.io/v3"
@@ -247,9 +248,10 @@ func main() {
 	registerRoute(mux, "/distil/export/:solution-id", routes.ExportHandler(solutionClient, config.D3MOutputDir, discoveryLogger))
 	registerRoute(mux, "/distil/config", routes.ConfigHandler(config, version, timestamp, problemPath, datasetDocPath))
 	registerRoute(mux, "/distil/task/:dataset/:target/:variables", routes.TaskHandler(pgDataStorageCtor, esMetadataStorageCtor))
-	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor))
 	registerRoute(mux, "/distil/multiband-image/:dataset/:image-id/:band-combination", routes.MultiBandImageHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/distil/multiband-combinations/:dataset", routes.MultiBandCombinationsHandler(esMetadataStorageCtor))
+	registerRoute(mux, "/distil/load/:solution-id/:fitted", routes.LoadHandler(esExportedModelStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor))
+	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor))
 
 	// POST
 	registerRoutePost(mux, "/distil/grouping/:dataset", routes.GroupingHandler(pgDataStorageCtor, esMetadataStorageCtor))
@@ -322,5 +324,7 @@ func updateExtremas(metaStorage model.MetadataStorage, dataStorage model.DataSto
 func createOutputFolders(config *env.Config) {
 	// create the augmented data folder
 	augmentPath := env.GetAugmentedPath()
-	os.MkdirAll(augmentPath, os.ModePerm)
+	if err := os.MkdirAll(augmentPath, os.ModePerm); err != nil {
+		log.Error(errors.Wrap(err, "failed to created output folder"))
+	}
 }

--- a/public/components/PredictionSummaries.vue
+++ b/public/components/PredictionSummaries.vue
@@ -72,7 +72,6 @@ import Vue from "vue";
 import { Solution } from "../store/requests/index";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 import { createRouteEntry, overlayRouteEntry } from "../util/routes";
-import { PREDICTION_UPLOAD } from "../util/uploads";
 import { getPredictionResultSummary, getIDFromKey } from "../util/summaries";
 import { sum } from "d3";
 import { getPredictionsById } from "../util/predictions";

--- a/public/components/PredictionsDataUploader.vue
+++ b/public/components/PredictionsDataUploader.vue
@@ -1,0 +1,100 @@
+<template>
+  <div>
+    <b-button block variant="primary" v-b-modal.predictions-data-upload-modal
+      >Apply Model
+    </b-button>
+
+    <!-- Modal Component -->
+    <b-modal
+      id="predictions-data-upload-modal"
+      title="Select input data"
+      @ok="handleOk()"
+      @show="clearForm()"
+    >
+      <p>Select a csv or zip file to import</p>
+      <b-form-file
+        ref="fileinput"
+        v-model="file"
+        :state="Boolean(file)"
+        accept=".csv, .zip"
+        plain
+      />
+      <div class="mt-3">Selected file: {{ file ? file.name : "" }}</div>
+    </b-modal>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { actions as datasetActions } from "../store/dataset/module";
+import { actions as requestActions } from "../store/requests/module";
+import { filterSummariesByDataset } from "../util/data";
+import {
+  getBase64,
+  generateUniqueDatasetName,
+  removeExtension
+} from "../util/uploads";
+import moment from "moment";
+
+export default Vue.extend({
+  name: "predictions-uploader",
+
+  data() {
+    return {
+      file: null as File,
+      importDataName: ""
+    };
+  },
+
+  props: {
+    fittedSolutionId: String as () => string,
+    target: String as () => string,
+    targetType: String as () => string
+  },
+
+  methods: {
+    clearForm() {
+      this.file = null;
+      const $refs = this.$refs as any;
+      if ($refs && $refs.fileinput) $refs.fileinput.reset();
+    },
+    async handleOk() {
+      if (!this.file) {
+        return;
+      }
+
+      const deconflictedName = generateUniqueDatasetName(
+        removeExtension(this.file.name)
+      );
+
+      this.$emit("uploadstart", {
+        file: this.file,
+        filename: this.file.name,
+        datasetID: deconflictedName
+      });
+
+      // Apply model to a new prediction set.  The selected file's contents will be uploaded and
+      // fed into a fitted solution.  The prediction request goes through a websocket similar to
+      try {
+        const dataset = await getBase64(this.file);
+        const requestMsg = {
+          datasetId: deconflictedName,
+          dataset: dataset,
+          fittedSolutionId: this.fittedSolutionId,
+          target: this.target,
+          targetType: this.targetType
+        };
+        const response = await requestActions.createPredictRequest(
+          this.$store,
+          requestMsg
+        );
+        this.$emit("uploadfinish", null, response);
+      } catch (err) {
+        this.$emit("uploadfinish", err, null);
+      }
+    }
+  }
+});
+</script>
+
+<style></style>

--- a/public/components/RecentSolutions.vue
+++ b/public/components/RecentSolutions.vue
@@ -15,8 +15,11 @@
 <script lang="ts">
 import SolutionPreview from "../components/SolutionPreview";
 import { getters as requestGetters } from "../store/requests/module";
+import { getters as modelGetters } from "../store/model/module";
 import { Solution } from "../store/requests/index";
 import Vue from "vue";
+import _ from "lodash";
+import moment from "moment";
 
 export default Vue.extend({
   name: "recent-solutions",
@@ -33,9 +36,19 @@ export default Vue.extend({
   },
 
   computed: {
+    // Return recent solutions, filtering down to only those that have
+    // been saved.  This is to ensure that the TA2 can re-load the fitted solution
+    // for additional produce calls.
     recentSolutions(): Solution[] {
+      // find solutions associated with exported models
+      const savedModelsMap = _.mapKeys(
+        modelGetters.getModels(this.$store),
+        m => m.fittedSolutionId
+      );
       return requestGetters
         .getSolutions(this.$store)
+        .filter(s => savedModelsMap[s.fittedSolutionId])
+        .sort((a, b) => moment(b.timestamp).unix() - moment(a.timestamp).unix())
         .slice(0, this.maxSolutions);
     }
   }

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -11,15 +11,14 @@
     <result-facets :showResiduals="showResiduals" />
 
     <template v-if="isActiveSolutionCompleted">
-      <file-uploader
+      <predictions-data-uploader
         class="result-button-alignment"
         @uploadstart="onUploadStart"
         @uploadfinish="onUploadFinish"
-        :upload-type="uploadType"
         :fitted-solution-id="fittedSolutionId"
         :target="target"
         :target-type="targetType"
-      ></file-uploader>
+      ></predictions-data-uploader>
       <b-button
         block
         variant="primary"
@@ -68,7 +67,7 @@
 
 <script lang="ts">
 import ResultFacets from "../components/ResultFacets";
-import FileUploader from "../components/FileUploader";
+import PredictionsDataUploader from "../components/PredictionsDataUploader";
 import ErrorThresholdSlider from "../components/ErrorThresholdSlider";
 import { getSolutionById } from "../util/solutions";
 import { getters as datasetGetters } from "../store/dataset/module";
@@ -91,7 +90,6 @@ import Vue from "vue";
 import { Solution, SOLUTION_COMPLETED } from "../store/requests/index";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 import { createRouteEntry, varModesToString } from "../util/routes";
-import { PREDICTION_UPLOAD } from "../util/uploads";
 import { getPredictionsById } from "../util/predictions";
 
 export default Vue.extend({
@@ -99,7 +97,7 @@ export default Vue.extend({
 
   components: {
     ResultFacets,
-    FileUploader,
+    PredictionsDataUploader,
     ErrorThresholdSlider,
     vueSlider
   },
@@ -113,7 +111,6 @@ export default Vue.extend({
       file: null,
       uploadData: {},
       uploadStatus: "",
-      uploadType: PREDICTION_UPLOAD,
       saveName: "",
       saveNameState: null,
       saveDescription: "",

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -309,9 +309,7 @@ export const actions = {
     args: {
       datasetID: string;
       file: File;
-      type: string;
       targetType: string;
-      fittedSolutionId: string;
     }
   ): Promise<void> {
     if (!validateArgs(args, ["datasetID", "file", "type"])) {

--- a/public/store/model/actions.ts
+++ b/public/store/model/actions.ts
@@ -1,19 +1,31 @@
 import _ from "lodash";
 import axios from "axios";
 import { ActionContext } from "vuex";
-import { ModelState } from "./index";
+import { ModelState, Model } from "./index";
 import { mutations } from "./module";
 import { DistilState } from "../store";
 
 export type ModelContext = ActionContext<ModelState, DistilState>;
 
 export const actions = {
-  // searches model descriptions and column names for supplied terms
+  // searches model descriptions and column names for supplied terms and writes
+  // the results into the store
   async searchModels(context: ModelContext, terms: string): Promise<void> {
     const params = !_.isEmpty(terms) ? `?search=${terms}` : "";
     try {
-      const response = await axios.get(`/distil/models${params}`);
-      mutations.setModels(context, response.data.models);
+      const response = await axios.get<Model[]>(`/distil/models${params}`);
+      mutations.setFilteredModels(context, response.data);
+    } catch (error) {
+      console.error(error);
+      mutations.setFilteredModels(context, []);
+    }
+  },
+
+  // fetches the list of saved models and writes the results into the store
+  async fetchModels(context: ModelContext): Promise<void> {
+    try {
+      const response = await axios.get<Model[]>("/distil/models");
+      mutations.setModels(context, response.data);
     } catch (error) {
       console.error(error);
       mutations.setModels(context, []);

--- a/public/store/model/getters.ts
+++ b/public/store/model/getters.ts
@@ -1,7 +1,12 @@
 import { Model, ModelState } from "./index";
+import _ from "lodash";
 
 export const getters = {
+  getFilteredModels(state: ModelState): Model[] {
+    return state.filteredModelIds.map(m => state.models[m]);
+  },
+
   getModels(state: ModelState): Model[] {
-    return state.models;
+    return _.values(state.models);
   }
 };

--- a/public/store/model/index.ts
+++ b/public/store/model/index.ts
@@ -1,3 +1,5 @@
+import { Dictionary } from "vue-router/types/router";
+
 export interface Model {
   modelName: string;
   modelDescription: string;
@@ -10,9 +12,13 @@ export interface Model {
 }
 
 export interface ModelState {
-  models: Model[];
+  // list of of all saved models, keyed by fitted solution id
+  models: Dictionary<Model>;
+  // fitted solution id of models that are currently being filtered
+  filteredModelIds: string[];
 }
 
 export const state: ModelState = {
-  models: []
+  models: {},
+  filteredModelIds: []
 };

--- a/public/store/model/module.ts
+++ b/public/store/model/module.ts
@@ -19,13 +19,16 @@ const { commit, read, dispatch } = getStoreAccessors<ModelState, DistilState>(
 );
 
 export const getters = {
+  getFilteredModels: read(moduleGetters.getFilteredModels),
   getModels: read(moduleGetters.getModels)
 };
 
 export const actions = {
-  searchModels: dispatch(moduleActions.searchModels)
+  searchModels: dispatch(moduleActions.searchModels),
+  fetchModels: dispatch(moduleActions.fetchModels)
 };
 
 export const mutations = {
-  setModels: commit(moduleMutations.setModels)
+  setModels: commit(moduleMutations.setModels),
+  setFilteredModels: commit(moduleMutations.setFilteredModels)
 };

--- a/public/store/model/mutations.ts
+++ b/public/store/model/mutations.ts
@@ -9,6 +9,7 @@ export const mutations = {
 
   // replace the list of filtered models (a subset of the full saved model list)
   setFilteredModels(state: ModelState, models: Model[]) {
+    if (!models) return;
     state.filteredModelIds = models.map(m => m.fittedSolutionId);
   }
 };

--- a/public/store/model/mutations.ts
+++ b/public/store/model/mutations.ts
@@ -1,25 +1,14 @@
-import Vue from "vue";
 import { Model, ModelState } from "./index";
+import _ from "lodash";
 
 export const mutations = {
+  // replace the map of saved models
   setModels(state: ModelState, models: Model[]) {
-    // individually add models if they do not exist
-    if (models) {
-      const lookup = {};
-      state.models.forEach((m, index) => {
-        lookup[m.fittedSolutionId] = index;
-      });
-      models.forEach(m => {
-        const index = lookup[m.fittedSolutionId];
-        if (index !== undefined) {
-          // update if it already exists
-          Vue.set(state.models, index, m);
-        } else {
-          state.models.push(m);
-        }
-      });
-    } else {
-      Vue.set(state, "models", []);
-    }
+    state.models = _.keyBy(models, m => m.fittedSolutionId);
+  },
+
+  // replace the list of filtered models (a subset of the full saved model list)
+  setFilteredModels(state: ModelState, models: Model[]) {
+    state.filteredModelIds = models.map(m => m.fittedSolutionId);
   }
 };

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -26,6 +26,7 @@ import { actions as resultsActions } from "../results/module";
 import { actions as predictActions } from "../predictions/module";
 import { getters as routeGetters } from "../route/module";
 import { TaskTypes, SummaryMode } from "../dataset";
+import { validateArgs } from "../../util/data";
 
 const CREATE_SOLUTIONS = "CREATE_SOLUTIONS";
 const STOP_SOLUTIONS = "STOP_SOLUTIONS";
@@ -563,7 +564,10 @@ export const actions = {
 
   // fetches a specific prediction by request ID
   async fetchPrediction(context: RequestContext, args: { requestId: string }) {
-    args.requestId = args.requestId || "";
+    if (!validateArgs(args, ["requestId"])) {
+      return;
+    }
+
     try {
       // fetch and uddate the search data
       const requestResponse = await axios.get<Predictions>(

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -20,7 +20,10 @@ import {
   actions as predictionActions,
   mutations as predictionMutations
 } from "../predictions/module";
-import { actions as modelActions } from "../model/module";
+import {
+  actions as modelActions,
+  mutations as modelMutations
+} from "../model/module";
 import { getters as routeGetters } from "../route/module";
 import { TaskTypes, SummaryMode, Variable, Highlight } from "../dataset";
 import { getPredictionsById } from "../../util/predictions";
@@ -181,15 +184,21 @@ export const actions = {
     // clear any previous state
     requestMutations.clearSolutionRequests(store);
     requestMutations.clearSolutions(store);
+    modelMutations.setModels(store, []);
+    modelMutations.setFilteredModels(store, []);
 
     // fetch new state
+    await modelActions.fetchModels(store);
     await requestActions.fetchSolutions(store, {});
     requestActions.fetchSolutionRequests(store, {});
   },
 
-  fetchSearchData(context: ViewContext) {
+  async fetchSearchData(context: ViewContext) {
     const terms = context.getters.getRouteTerms;
     const datasetIDs = context.getters.getRouteJoinDatasets;
+
+    // fetch saved models - subsequent calls to
+    await modelActions.fetchModels(store);
 
     const promises = datasetIDs.map((id: string) => {
       return datasetActions.fetchDataset(store, {

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -381,7 +381,8 @@ export const actions = {
       fetchSolutions(context, {
         dataset: dataset,
         target: target
-      })
+      }),
+      datasetActions.searchDatasets(store, "")
     ]);
     return actions.updateResultsSolution(context);
   },

--- a/public/util/uploads.ts
+++ b/public/util/uploads.ts
@@ -1,5 +1,6 @@
-export const PREDICTION_UPLOAD = "prediction";
-export const DATASET_UPLOAD = "dataset";
+import store from "../store/store";
+import { getters as datasetGetters } from "../store/dataset/module";
+import _ from "lodash";
 
 // Converts a file into a Base64 string.
 export function getBase64(file: File): Promise<string> {
@@ -15,4 +16,30 @@ export function getBase64(file: File): Promise<string> {
     };
     reader.onerror = error => reject(error);
   });
+}
+
+// Removes the extension from a filename
+export function removeExtension(filename: string): string {
+  return filename
+    .split(".")
+    .slice(0, -1)
+    .join(".");
+}
+
+// Given a potential dataset name, will compare against those already stored
+// in system and return one that is unique by appending `_n` if necessary.
+// We make the comparison case insensitive.
+export function generateUniqueDatasetName(datasetName: string): string {
+  const datasetNames = new Set(
+    datasetGetters.getDatasets(store).map(d => _.toLower(d.id))
+  );
+  let newName = datasetName;
+  let count = 1;
+  while (true) {
+    if (!datasetNames.has(_.toLower(newName))) {
+      return newName;
+    }
+    newName = `${datasetName}_${count}`;
+    count++;
+  }
 }

--- a/public/views/Home.vue
+++ b/public/views/Home.vue
@@ -22,7 +22,6 @@
             class="file-uploader"
             @uploadstart="onUploadStart"
             @uploadfinish="onUploadFinish"
-            :upload-type="uploadType"
           ></file-uploader>
         </div>
       </div>
@@ -51,7 +50,6 @@ import RunningSolutions from "../components/RunningSolutions";
 import SearchBar from "../components/SearchBar";
 import { getters as appGetters } from "../store/app/module";
 import { actions as viewActions } from "../store/view/module";
-import { DATASET_UPLOAD } from "../util/uploads";
 import Vue from "vue";
 
 export default Vue.extend({
@@ -68,8 +66,7 @@ export default Vue.extend({
   data() {
     return {
       uploadData: {},
-      uploadStatus: "",
-      uploadType: DATASET_UPLOAD
+      uploadStatus: ""
     };
   },
 

--- a/public/views/Search.vue
+++ b/public/views/Search.vue
@@ -23,7 +23,6 @@
             class="file-uploader"
             @uploadstart="onUploadStart"
             @uploadfinish="onUploadFinish"
-            :upload-type="uploadType"
           ></file-uploader>
         </div>
       </div>
@@ -69,7 +68,6 @@ import {
 } from "../store/dataset/module";
 import { getters as modelGetters } from "../store/model/module";
 import { SEARCH_ROUTE, JOIN_DATASETS_ROUTE } from "../store/route/index";
-import { DATASET_UPLOAD } from "../util/uploads";
 
 export default Vue.extend({
   name: "search-view",
@@ -87,8 +85,7 @@ export default Vue.extend({
     return {
       isPending: false,
       uploadData: {},
-      uploadStatus: "",
-      uploadType: DATASET_UPLOAD
+      uploadStatus: ""
     };
   },
 


### PR DESCRIPTION
fixes #1543 #1573

* Split data upload dialog into a version for datasets, a version for prediction data since the two shared little actual code
* Updated dataset name deconfliction to examine to use list of datasets when generating unique name
* Added support for fetching full set of saved models from server
* Limited recent  models display in home screen to display only saved models
* Updated predicted task (server side) to ensure that TA2 loads a model before running predictions