### PR TITLE
Added the name of a fitted solution above the variable name

### DIFF
--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -4,10 +4,12 @@
     v-bind:class="{ 'result-group-selected': isSelected }"
     @click="onClick()"
   >
-    <div class="result-group-title">
+    <header class="result-group-title">
+      <h5 v-if="modelName">{{ modelName }}</h5>
       <b
         >{{ name }} <sup>{{ solutionIndex }}</sup></b
       >
+
       <template v-if="!isErrored && !isSelected">
         <div
           class="pull-right pl-2 solution-button"
@@ -51,7 +53,8 @@
           ERROR
         </b-badge>
       </template>
-    </div>
+    </header>
+
     <div class="result-group-body" v-if="isMaximized">
       <template v-if="isCompleted">
         <div v-for="summary in predictedSummaries" :key="summary.key">
@@ -128,6 +131,7 @@ import {
   SOLUTION_PROGRESS,
   SOLUTION_LABELS
 } from "../util/solutions";
+import { getModelNameByFittedSolutionId } from "../util/models";
 import { overlayRouteEntry } from "../util/routes";
 import { updateHighlight, clearHighlight } from "../util/highlights";
 import { actions as appActions } from "../store/app/module";
@@ -169,6 +173,25 @@ export default Vue.extend({
 
     target(): string {
       return routeGetters.getRouteTargetVariable(this.$store);
+    },
+
+    /**
+     * Name of the model if it exist.
+     * @return {String}
+     */
+    modelName(): string {
+      // Find the fitted solution ID.
+      const fittedSolutionId = getSolutionById(
+        store.state.requestsModule.solutions,
+        this.solutionId
+      )?.fittedSolutionId;
+      if (_.isEmpty(fittedSolutionId)) { return; }
+
+      // Retreive the model name from the fitted solution.
+      const name = getModelNameByFittedSolutionId(fittedSolutionId);
+
+      // Return the name if it exist, null otherwise.
+      return _.isNil(name) ? null : name;
     },
 
     predictedInstanceName(): string {

--- a/public/util/models.ts
+++ b/public/util/models.ts
@@ -1,0 +1,17 @@
+import { isNil } from "lodash";
+import store from "../store/store";
+import { getters as modelGetters } from "../store/model/module";
+
+/**
+ * Name of the model of a fitted solution.
+ * @param  {String} fittedSolutionId
+ * @return {String}
+ */
+export function getModelNameByFittedSolutionId(fittedSolutionId: string) {
+  const model = modelGetters
+    .getModels(store)
+    .find(model => model.fittedSolutionId === fittedSolutionId);
+
+  // Return the name if it exist, null otherwise.
+  return isNil(model.modelName) ? null : model.modelName;
+}


### PR DESCRIPTION
closes #1617 

![Screen Shot 2020-05-25 at 12 12 34](https://user-images.githubusercontent.com/636801/82829862-4774de80-9e82-11ea-81b9-fedba9162dd1.png)

I wasn't sure which variable name to add the model name above, so I choose the result list which seemed appropriate.

I used the `fittedSolutionId` to find the name, as it was the most reliable way to get a model.

Also, I don't know if it's a bug, but if I refresh the browser on the result page of a saved model, the model reloadd, but the store `modelModule` is emptied.

