### PR TITLE
Added a check to make sure that `Remove All` button only applies to non timeseries.

### DIFF
--- a/public/components/TrainingVariables.vue
+++ b/public/components/TrainingVariables.vue
@@ -24,7 +24,7 @@
         <div>
           {{ subtitle }}
         </div>
-        <div v-if="trainingVariableSummaries.length > 0">
+        <div v-if="isAllTrainingVariablesRemovable">
           <b-button size="sm" variant="outline-secondary" @click="removeAll"
             >Remove All</b-button
           >
@@ -86,6 +86,26 @@ export default Vue.extend({
     trainingVariableSummaries(): VariableSummary[] {
       return routeGetters.getTrainingVariableSummaries(this.$store);
     },
+
+    /**
+     * Check if all the training variables are removable.
+     * @return {Boolean}
+     */
+    isAllTrainingVariablesRemovable(): boolean {
+      // Fetch the variables in the timeseries grouping.
+      const timeseriesGrouping = datasetGetters.getTimeseriesGroupingVariables(
+        this.$store
+      );
+
+      // Filter them out of the available training variables.
+      const trainingVariables = Array.from(
+        this.trainingVariableSummaries
+      ).filter(variable => !timeseriesGrouping.includes(variable.key));
+
+      // The variables can be removed.
+      return trainingVariables.length > 0;
+    },
+
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);
     },
@@ -95,6 +115,7 @@ export default Vue.extend({
     instanceName(): string {
       return TRAINING_VARS_INSTANCE;
     },
+
     html(): (Group) => HTMLDivElement {
       return (group: Group) => {
         // exclude remove button if the var is an id / sub-id of the

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -29,6 +29,24 @@ export const getters = {
     return state.variables.filter(v => v.grouping);
   },
 
+  /**
+   * Return the varibles used on the timeseries grouping.
+   * @return {Array<String>}
+   */
+  getTimeseriesGroupingVariables(state: DatasetState): string[] {
+    // Get only the timeseries grouping.
+    const timeseriesGrouping = state.variables.find(
+      v => v.grouping && v.grouping.type === "timeseries"
+    );
+
+    // Return an empty array if none have been found.
+    if (!timeseriesGrouping) {
+      return [];
+    }
+
+    return timeseriesGrouping.grouping.subIds;
+  },
+
   getPendingRequests(state: DatasetState) {
     return state.pendingRequests;
   },

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -27,6 +27,9 @@ export const getters = {
   // variables
   getVariables: read(moduleGetters.getVariables),
   getGroupings: read(moduleGetters.getGroupings),
+  getTimeseriesGroupingVariables: read(
+    moduleGetters.getTimeseriesGroupingVariables
+  ),
   getVariablesMap: read(moduleGetters.getVariablesMap),
   getVariableTypesMap: read(moduleGetters.getVariableTypesMap),
   getVariableSummaries: read(moduleGetters.getVariableSummaries),


### PR DESCRIPTION
closes #1611 

I'm not sure this solves the problem. I keep looking into the source code to understand how time-series are flagged, but I do not seem to find a ~proper~ way to detect when the predicted feature is a time-series.