### PR TITLE
Fixes for stratified splitting with groups

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -360,7 +360,7 @@ func shuffleAndWrite(rowData [][]string, targetCol int, groupCol int, maxTrainin
 
 		// write out training data until we we reach the max training count, then write out the
 		// test data
-		tracker := shuffleTrain
+		tracker := shuffleTest
 		for _, data := range rowData {
 			err := tracker.writer.Write(data)
 			if err != nil {
@@ -368,8 +368,8 @@ func shuffleAndWrite(rowData [][]string, targetCol int, groupCol int, maxTrainin
 			}
 			tracker.count++
 			if !tracker.lessThanMax() {
-				if tracker == shuffleTrain {
-					tracker = shuffleTest
+				if tracker == shuffleTest {
+					tracker = shuffleTrain
 				} else {
 					break
 				}
@@ -394,7 +394,7 @@ func shuffleAndWrite(rowData [][]string, targetCol int, groupCol int, maxTrainin
 
 		// Iterate over the randomized list of group keys, looking up the associated rows for each.  Write out
 		// the train rows, then the test rows.
-		tracker := shuffleTrain
+		tracker := shuffleTest
 		for _, groupKey := range groupKeys {
 			for _, row := range groupData[groupKey] {
 				err := tracker.writer.Write(row)
@@ -404,8 +404,8 @@ func shuffleAndWrite(rowData [][]string, targetCol int, groupCol int, maxTrainin
 				tracker.count++
 			}
 			if !tracker.lessThanMax() {
-				if tracker == shuffleTrain {
-					tracker = shuffleTest
+				if tracker == shuffleTest {
+					tracker = shuffleTrain
 				} else {
 					break
 				}


### PR DESCRIPTION
Stratified splitting with groups wasn't quite working.  There's now a separate code path for grouped vs. non-grouped, which is admittedly a bit ugly.  We should probably take another pass over the code given all the organic additions to split types we've had to make.