### PR TITLE
Cleanup Ingest

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -18,6 +18,7 @@ package model
 import (
 	"time"
 
+	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
 )
 
@@ -138,6 +139,7 @@ type MetadataStorage interface {
 	AddGroupedVariable(dataset string, varName string, varDisplayName string, varType string, varRole string, grouping model.BaseGrouping) error
 	RemoveGroupedVariable(datasetName string, grouping model.BaseGrouping) error
 	DeleteDataset(dataset string) error
+	IngestDataset(datasetSource metadata.DatasetSource, meta *model.Metadata) error
 }
 
 // ExportedModelStorageCtor represents a client constructor to instantiate a

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -137,6 +137,7 @@ type MetadataStorage interface {
 	DeleteVariable(dataset string, varName string) error
 	AddGroupedVariable(dataset string, varName string, varDisplayName string, varType string, varRole string, grouping model.BaseGrouping) error
 	RemoveGroupedVariable(datasetName string, grouping model.BaseGrouping) error
+	DeleteDataset(dataset string) error
 }
 
 // ExportedModelStorageCtor represents a client constructor to instantiate a

--- a/api/model/storage/datamart/dataset.go
+++ b/api/model/storage/datamart/dataset.go
@@ -59,6 +59,11 @@ func (s *Storage) FetchDatasets(includeIndex bool, includeMeta bool) ([]*api.Dat
 	return s.SearchDatasets("", nil, includeIndex, includeMeta)
 }
 
+// DeleteDataset deletes a dataset from the datamart.
+func (s *Storage) DeleteDataset(dataset string) error {
+	return errors.Errorf("Not implemented")
+}
+
 // FetchDataset returns a dataset in the provided index.
 func (s *Storage) FetchDataset(datasetName string, includeIndex bool, includeMeta bool) (*api.Dataset, error) {
 	return nil, errors.Errorf("Not implemented")

--- a/api/model/storage/datamart/dataset.go
+++ b/api/model/storage/datamart/dataset.go
@@ -53,6 +53,11 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 	return s.download(s, id, uri)
 }
 
+// IngestDataset adds a document consisting of the metadata to the datamart.
+func (s *Storage) IngestDataset(datasetSource metadata.DatasetSource, meta *model.Metadata) error {
+	return errors.Errorf("Not implemented")
+}
+
 // FetchDatasets returns all datasets in the provided index.
 func (s *Storage) FetchDatasets(includeIndex bool, includeMeta bool) ([]*api.Dataset, error) {
 	// use default string in search to get complete list

--- a/api/model/storage/datamart/nyu.go
+++ b/api/model/storage/datamart/nyu.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	api "github.com/uncharted-distil/distil/api/model"
@@ -239,7 +238,7 @@ func materializeNYUDataset(datamart *Storage, id string, uri string) (string, er
 
 	// format the dataset
 	extractedSchema := path.Join(extractedArchivePath, compute.D3MDataSchema)
-	formattedPath, err := task.Format(metadata.Contrib, extractedSchema, name, datamart.ingestConfig)
+	formattedPath, err := task.Format(extractedSchema, name, datamart.ingestConfig)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to format datamart dataset")
 	}

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -38,6 +38,66 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 	return "", errors.Errorf("Not Supported")
 }
 
+// IngestDataset adds a document consisting of the metadata to ES.
+func (s *Storage) IngestDataset(datasetSource metadata.DatasetSource, meta *model.Metadata) error {
+
+	if len(meta.DataResources) > 1 && meta.SchemaSource != model.SchemaSourceOriginal {
+		return errors.New("metadata variables not merged into a single dataset")
+	}
+
+	mainDR := meta.GetMainDataResource()
+
+	// clear refers to
+	for _, v := range mainDR.Variables {
+		v.RefersTo = nil
+	}
+	var origins []map[string]interface{}
+	if meta.DatasetOrigins != nil {
+		origins = make([]map[string]interface{}, len(meta.DatasetOrigins))
+		for i, ds := range meta.DatasetOrigins {
+			origins[i] = map[string]interface{}{
+				"searchResult":  ds.SearchResult,
+				"provenance":    ds.Provenance,
+				"sourceDataset": ds.SourceDataset,
+			}
+		}
+	}
+
+	source := map[string]interface{}{
+		"datasetName":      meta.Name,
+		"datasetID":        meta.ID,
+		"parentDatasetIDs": meta.ParentDatasetIDs,
+		"storageName":      meta.StorageName,
+		"description":      meta.Description,
+		"summary":          meta.Summary,
+		"summaryMachine":   meta.SummaryMachine,
+		"numRows":          meta.NumRows,
+		"numBytes":         meta.NumBytes,
+		"variables":        mainDR.Variables,
+		"datasetFolder":    meta.DatasetFolder,
+		"source":           datasetSource,
+		"datasetOrigins":   origins,
+		"type":             meta.Type,
+	}
+
+	bytes, err := json.Marshal(source)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal document source")
+	}
+
+	// push the document into the metadata index
+	_, err = s.client.Index().
+		Index(s.datasetIndex).
+		Id(meta.ID).
+		BodyString(string(bytes)).
+		Refresh("true").
+		Do(context.Background())
+	if err != nil {
+		return errors.Wrapf(err, "failed to add document to index `%s`", s.datasetIndex)
+	}
+	return nil
+}
+
 // DeleteDataset deletes a dataset from ES.
 func (s *Storage) DeleteDataset(dataset string) error {
 	_, err := s.client.Delete().Index(s.datasetIndex).Id(dataset).Do(context.Background())

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -38,6 +38,13 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 	return "", errors.Errorf("Not Supported")
 }
 
+// DeleteDataset deletes a dataset from ES.
+func (s *Storage) DeleteDataset(dataset string) error {
+	_, err := s.client.Delete().Index(s.datasetIndex).Id(dataset).Do(context.Background())
+
+	return err
+}
+
 func (s *Storage) parseDatasets(res *elastic.SearchResult, includeIndex bool, includeMeta bool) ([]*api.Dataset, error) {
 	var datasets []*api.Dataset
 	for _, hit := range res.Hits.Hits {

--- a/api/model/storage/file/dataset.go
+++ b/api/model/storage/file/dataset.go
@@ -39,6 +39,11 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 	return uri, nil
 }
 
+// IngestDataset adds a document consisting of the metadata to the file system.
+func (s *Storage) IngestDataset(datasetSource metadata.DatasetSource, meta *model.Metadata) error {
+	return errors.Errorf("Not implemented")
+}
+
 // DeleteDataset deletes a dataset from the file system.
 func (s *Storage) DeleteDataset(dataset string) error {
 	return errors.Errorf("Not implemented")

--- a/api/model/storage/file/dataset.go
+++ b/api/model/storage/file/dataset.go
@@ -39,6 +39,11 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 	return uri, nil
 }
 
+// DeleteDataset deletes a dataset from the file system.
+func (s *Storage) DeleteDataset(dataset string) error {
+	return errors.Errorf("Not implemented")
+}
+
 // FetchDatasets returns all datasets in the provided index.
 func (s *Storage) FetchDatasets(includeIndex bool, includeMeta bool) ([]*api.Dataset, error) {
 	// use default string in search to get complete list

--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -73,12 +73,6 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 				}
 			}
 		}
-		// update ingest config to use ingest URI.
-		cfg, err := env.LoadConfig()
-		if err != nil {
-			handleError(w, err)
-			return
-		}
 
 		meta, err := createMetadataStorageForSource(source, provenance, datamartCtors, fileMetaCtor, esMetaCtor)
 		if err != nil {
@@ -98,7 +92,7 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 		}
 
 		// ingest the imported dataset
-		datasetID, err = task.IngestDataset(source, dataCtor, esMetaCtor, cfg.ESDatasetsIndex, datasetID, origins, api.DatasetTypeModelling, &ingestConfig)
+		datasetID, err = task.IngestDataset(source, dataCtor, esMetaCtor, datasetID, origins, api.DatasetTypeModelling, &ingestConfig)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/inference.go
+++ b/api/routes/inference.go
@@ -181,7 +181,6 @@ func InferenceHandler(outputPath string, dataStorageCtor api.DataStorageCtor, so
 			FittedSolutionID:   fittedSolutionID,
 			DatasetConstructor: ds,
 			OutputPath:         outputPath,
-			Index:              config.ESDatasetsIndex,
 			Target:             targetVar,
 			MetaStorage:        metaStorage,
 			DataStorage:        dataStorage,

--- a/api/task/classify.go
+++ b/api/task/classify.go
@@ -79,7 +79,7 @@ func castProbabilityArray(in []interface{}) ([]float64, error) {
 }
 
 // Classify will classify the dataset using a primitive.
-func Classify(schemaPath string, index string, dataset string, config *IngestTaskConfig) (string, error) {
+func Classify(schemaPath string, dataset string, config *IngestTaskConfig) (string, error) {
 	schemaDoc := path.Dir(schemaPath)
 
 	// create & submit the solution request

--- a/api/task/cleaning.go
+++ b/api/task/cleaning.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Clean will clean bad data for further processing.
-func Clean(datasetSource metadata.DatasetSource, schemaFile string, index string, dataset string, config *IngestTaskConfig) (string, error) {
+func Clean(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
 	// copy the data to a new directory
 	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.CleanOutputSchemaRelative, config.CleanOutputDataRelative)
 	if err != nil {

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -134,20 +134,14 @@ func Cluster(datasetInputDir string, dataset string, variable string, features [
 
 	var step *description.FullySpecifiedPipeline
 	var err error
-	addMeta := false
 	if model.IsImage(clusteringVar.Type) {
 		step, err = description.CreateImageClusteringPipeline("business", "basic image clustering", []*model.Variable{clusteringVar})
-		if err != nil {
-			return false, nil, err
-		}
-		addMeta = true
 	} else {
 		step, err = description.CreateSlothPipeline("time series clustering",
 			"k-means time series clustering", "", "", features)
-		if err != nil {
-			return false, nil, err
-		}
-		addMeta = true
+	}
+	if err != nil {
+		return false, nil, err
 	}
 
 	datasetURI, err := submitPipeline([]string{datasetInputDir}, step)
@@ -182,5 +176,5 @@ func Cluster(datasetInputDir string, dataset string, variable string, features [
 		}
 	}
 
-	return addMeta, clusteredData, nil
+	return true, clusteredData, nil
 }

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -43,7 +43,7 @@ type ClusterPoint struct {
 }
 
 // ClusterDataset will cluster the dataset fields using a primitive.
-func ClusterDataset(datasetSource metadata.DatasetSource, schemaFile string, index string, dataset string, config *IngestTaskConfig) (string, error) {
+func ClusterDataset(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
 	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.ClusteringOutputSchemaRelative, config.ClusteringOutputDataRelative)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to copy source data folder")

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -95,7 +95,7 @@ func CreateDataset(dataset string, datasetCtor DatasetConstructor, outputPath st
 	}
 
 	// format the dataset into a D3M format
-	formattedPath, err := Format(metadata.Contrib, schemaPath, dataset, ingestConfig)
+	formattedPath, err := Format(schemaPath, dataset, ingestConfig)
 	if err != nil {
 		return "", "", err
 	}
@@ -133,7 +133,7 @@ func writeDataset(meta *model.Metadata, csvData []byte, outputPath string, confi
 	}
 
 	// format the dataset into a D3M format
-	formattedPath, err := Format(metadata.Contrib, schemaPath, meta.Name, config)
+	formattedPath, err := Format(schemaPath, meta.Name, config)
 	if err != nil {
 		return "", err
 	}

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Format will format a dataset to have the required structures for D3M.
-func Format(datasetSource metadata.DatasetSource, schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
+func Format(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
 	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to load original schema file")

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -43,7 +43,7 @@ type GeocodedPoint struct {
 
 // GeocodeForwardDataset geocodes fields that are types of locations.
 // The results are append to the dataset and the whole is output to disk.
-func GeocodeForwardDataset(datasetSource metadata.DatasetSource, schemaFile string, index string, dataset string, config *IngestTaskConfig) (string, error) {
+func GeocodeForwardDataset(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
 	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.GeocodingOutputSchemaRelative, config.GeocodingOutputDataRelative)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to copy source data folder")

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -235,7 +235,7 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 // Ingest the metadata to ES and the data to Postgres.
 func Ingest(originalSchemaFile string, schemaFile string, storage api.MetadataStorage, dataset string, source metadata.DatasetSource,
 	origins []*model.DatasetOrigin, datasetType api.DatasetType, config *IngestTaskConfig, checkMatch bool, fallbackMerged bool) (string, error) {
-	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, dataset, source, nil, config, true, fallbackMerged)
+	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, source, nil, config, true, fallbackMerged)
 	if err != nil {
 		return "", err
 	}
@@ -292,13 +292,13 @@ func Ingest(originalSchemaFile string, schemaFile string, storage api.MetadataSt
 	}
 
 	// ingest the metadata
-	_, err = IngestMetadata(originalSchemaFile, schemaFile, storage, dataset, source, origins, datasetType, config, true, fallbackMerged)
+	_, err = IngestMetadata(originalSchemaFile, schemaFile, storage, source, origins, datasetType, config, true, fallbackMerged)
 	if err != nil {
 		return "", err
 	}
 
 	// ingest the data
-	err = IngestPostgres(originalSchemaFile, schemaFile, dataset, source, config, true, false, fallbackMerged)
+	err = IngestPostgres(originalSchemaFile, schemaFile, source, config, true, false, fallbackMerged)
 	if err != nil {
 		return "", err
 	}
@@ -307,9 +307,9 @@ func Ingest(originalSchemaFile string, schemaFile string, storage api.MetadataSt
 }
 
 // IngestMetadata ingests the data to ES.
-func IngestMetadata(originalSchemaFile string, schemaFile string, storage api.MetadataStorage, dataset string, source metadata.DatasetSource,
+func IngestMetadata(originalSchemaFile string, schemaFile string, storage api.MetadataStorage, source metadata.DatasetSource,
 	origins []*model.DatasetOrigin, datasetType api.DatasetType, config *IngestTaskConfig, verifyMetadata bool, fallbackMerged bool) (string, error) {
-	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, dataset, source, origins, config, verifyMetadata, fallbackMerged)
+	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, source, origins, config, verifyMetadata, fallbackMerged)
 	if err != nil {
 		return "", err
 	}
@@ -327,9 +327,9 @@ func IngestMetadata(originalSchemaFile string, schemaFile string, storage api.Me
 }
 
 // IngestPostgres ingests a dataset to PG storage.
-func IngestPostgres(originalSchemaFile string, schemaFile string, dataset string, source metadata.DatasetSource,
+func IngestPostgres(originalSchemaFile string, schemaFile string, source metadata.DatasetSource,
 	config *IngestTaskConfig, verifyMetadata bool, createMetadataTables bool, fallbackMerged bool) error {
-	datasetDir, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, dataset, source, nil, config, verifyMetadata, fallbackMerged)
+	datasetDir, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, source, nil, config, verifyMetadata, fallbackMerged)
 	if err != nil {
 		return err
 	}
@@ -432,7 +432,7 @@ func IngestPostgres(originalSchemaFile string, schemaFile string, dataset string
 	return nil
 }
 
-func loadMetadataForIngest(originalSchemaFile string, schemaFile string, dataset string, source metadata.DatasetSource,
+func loadMetadataForIngest(originalSchemaFile string, schemaFile string, source metadata.DatasetSource,
 	origins []*model.DatasetOrigin, config *IngestTaskConfig, verifyMetadata bool, mergedFallback bool) (string, *model.Metadata, error) {
 	datasetDir := path.Dir(schemaFile)
 	meta, err := metadata.LoadMetadataFromClassification(schemaFile, path.Join(datasetDir, config.ClassificationOutputPathRelative), true, mergedFallback)

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Merge will merge data resources into a single data resource.
-func Merge(datasetSource metadata.DatasetSource, schemaFile string, index string, dataset string, config *IngestTaskConfig) (string, error) {
+func Merge(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
 	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.MergedOutputSchemaPathRelative, config.MergedOutputPathRelative)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to copy source data folder")

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -78,7 +78,6 @@ type PredictParams struct {
 	FittedSolutionID   string
 	DatasetConstructor DatasetConstructor
 	OutputPath         string
-	Index              string
 	Target             *model.Variable
 	MetaStorage        api.MetadataStorage
 	DataStorage        api.DataStorage
@@ -146,7 +145,7 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 
 	if !params.DatasetIngested {
 		// ingest the dataset but without running simon, duke, etc.
-		_, err = Ingest(schemaPath, schemaPath, params.MetaStorage, params.Index, params.Dataset,
+		_, err = Ingest(schemaPath, schemaPath, params.MetaStorage, params.Dataset,
 			metadata.Augmented, nil, api.DatasetTypeInference, params.IngestConfig, false, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to ingest ranked data")

--- a/api/task/rank.go
+++ b/api/task/rank.go
@@ -36,7 +36,7 @@ type ImportanceResult struct {
 }
 
 // Rank will rank the dataset using a primitive.
-func Rank(schemaPath string, index string, dataset string, config *IngestTaskConfig) (string, error) {
+func Rank(schemaPath string, dataset string, config *IngestTaskConfig) (string, error) {
 	schemaDoc := path.Dir(schemaPath)
 
 	// create & submit the solution request

--- a/api/task/summarize.go
+++ b/api/task/summarize.go
@@ -35,7 +35,7 @@ type SummaryResult struct {
 }
 
 // Summarize will summarize the dataset using a primitive.
-func Summarize(schemaPath string, index string, dataset string, config *IngestTaskConfig) (string, error) {
+func Summarize(schemaPath string, dataset string, config *IngestTaskConfig) (string, error) {
 	schemaDoc := path.Dir(schemaPath)
 
 	// create & submit the solution request

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -363,7 +363,6 @@ func handlePredict(conn *Connection, client *compute.Client, metadataCtor apiMod
 		FittedSolutionID:   request.FittedSolutionID,
 		DatasetConstructor: ds,
 		OutputPath:         path.Join(config.D3MOutputDir, config.AugmentedSubFolder),
-		Index:              config.ESDatasetsIndex,
 		Target:             targetVar,
 		MetaStorage:        metaStorage,
 		DataStorage:        dataStorage,

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/shopspring/decimal v0.0.0-20191009025716-f1972eb1d1f5 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20200611020108-e988c28c0db5
+	github.com/uncharted-distil/distil-compute v0.0.0-20200611145508-f6e29ea87c58
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/shopspring/decimal v0.0.0-20191009025716-f1972eb1d1f5 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20200608184046-adfa6130b324
+	github.com/uncharted-distil/distil-compute v0.0.0-20200611020108-e988c28c0db5
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/uncharted-distil/distil-compute v0.0.0-20200611020108-e988c28c0db5 h1:HFMksBBzCb/RB1OvPKGJXIFEH0lSPDOzoAU/vq4lIHc=
 github.com/uncharted-distil/distil-compute v0.0.0-20200611020108-e988c28c0db5/go.mod h1:+2yftisLjKetRuMlUsAuJS7Rtom/VI5CP5nd+57Vtl0=
+github.com/uncharted-distil/distil-compute v0.0.0-20200611145508-f6e29ea87c58 h1:L2l9GPIuCpaiel1dI0S5ZXP9C/KQCUvoD+eW+qCHkyw=
+github.com/uncharted-distil/distil-compute v0.0.0-20200611145508-f6e29ea87c58/go.mod h1:+2yftisLjKetRuMlUsAuJS7Rtom/VI5CP5nd+57Vtl0=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/uncharted-distil/distil-compute v0.0.0-20200603163657-b306977deba2 h1
 github.com/uncharted-distil/distil-compute v0.0.0-20200603163657-b306977deba2/go.mod h1:QVZkHnsUQRxeMf5qhSEFDNdh+Nh+GvgcZPNHQKR5CNE=
 github.com/uncharted-distil/distil-compute v0.0.0-20200608184046-adfa6130b324 h1:d8MirxwzaS8stQf2JxxmYUXEHC1c1J2qyPFCbt808N0=
 github.com/uncharted-distil/distil-compute v0.0.0-20200608184046-adfa6130b324/go.mod h1:QVZkHnsUQRxeMf5qhSEFDNdh+Nh+GvgcZPNHQKR5CNE=
+github.com/uncharted-distil/distil-compute v0.0.0-20200611020108-e988c28c0db5 h1:HFMksBBzCb/RB1OvPKGJXIFEH0lSPDOzoAU/vq4lIHc=
+github.com/uncharted-distil/distil-compute v0.0.0-20200611020108-e988c28c0db5/go.mod h1:+2yftisLjKetRuMlUsAuJS7Rtom/VI5CP5nd+57Vtl0=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/go.sum
+++ b/go.sum
@@ -112,12 +112,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20200529151237-7cc113a345d2 h1:whb8sMtNeRsZc+yRcAueE6W5PuEQtZKz3cSzd433bMI=
-github.com/uncharted-distil/distil-compute v0.0.0-20200529151237-7cc113a345d2/go.mod h1:QVZkHnsUQRxeMf5qhSEFDNdh+Nh+GvgcZPNHQKR5CNE=
-github.com/uncharted-distil/distil-compute v0.0.0-20200603163657-b306977deba2 h1:cx2iHTkUDPPpHsfYJ3/jkU/slSJXbxJDibOhUvX3rXQ=
-github.com/uncharted-distil/distil-compute v0.0.0-20200603163657-b306977deba2/go.mod h1:QVZkHnsUQRxeMf5qhSEFDNdh+Nh+GvgcZPNHQKR5CNE=
-github.com/uncharted-distil/distil-compute v0.0.0-20200608184046-adfa6130b324 h1:d8MirxwzaS8stQf2JxxmYUXEHC1c1J2qyPFCbt808N0=
-github.com/uncharted-distil/distil-compute v0.0.0-20200608184046-adfa6130b324/go.mod h1:QVZkHnsUQRxeMf5qhSEFDNdh+Nh+GvgcZPNHQKR5CNE=
 github.com/uncharted-distil/distil-compute v0.0.0-20200611020108-e988c28c0db5 h1:HFMksBBzCb/RB1OvPKGJXIFEH0lSPDOzoAU/vq4lIHc=
 github.com/uncharted-distil/distil-compute v0.0.0-20200611020108-e988c28c0db5/go.mod h1:+2yftisLjKetRuMlUsAuJS7Rtom/VI5CP5nd+57Vtl0=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=

--- a/main.go
+++ b/main.go
@@ -118,10 +118,10 @@ func main() {
 		config.PostgresDatabase, config.PostgresLogLevel)
 
 	// instantiate the metadata storage (using ES).
-	esMetadataStorageCtor := es.NewMetadataStorage(config.ESDatasetsIndex, esClientCtor)
+	esMetadataStorageCtor := es.NewMetadataStorage(config.ESDatasetsIndex, false, esClientCtor)
 
 	// instantiate the exported model storage (using ES).
-	esExportedModelStorageCtor := es.NewExportedModelStorage(config.ESModelsIndex, esClientCtor)
+	esExportedModelStorageCtor := es.NewExportedModelStorage(config.ESModelsIndex, false, esClientCtor)
 
 	// instantiate the metadata storage (using filesystem).
 	fileMetadataStorageCtor := file.NewMetadataStorage(config.D3MOutputDir)
@@ -218,7 +218,7 @@ func main() {
 			os.Exit(1)
 		}
 		_, err = task.IngestDataset(metadata.Contrib, pgDataStorageCtor, esMetadataStorageCtor,
-			config.ESDatasetsIndex, "initial", nil, model.DatasetTypeModelling, ingestConfig)
+			"initial", nil, model.DatasetTypeModelling, ingestConfig)
 		if err != nil {
 			log.Errorf("%+v", err)
 			os.Exit(1)


### PR DESCRIPTION
All ES code in compute has been moved to distil. Some cleanup of the ingest process has taken place, along with the removal of no longer used parameters.