### PR TITLE
Ingest eurosat dataset

### DIFF
--- a/api/util/file.go
+++ b/api/util/file.go
@@ -260,3 +260,21 @@ func FileExists(filename string) bool {
 	}
 	return true
 }
+
+// GetFolderFileType returns the extension of the first file in the media folder.
+func GetFolderFileType(folder string) (string, error) {
+	files, err := ioutil.ReadDir(folder)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to read folder")
+	}
+	if len(files) == 0 {
+		return "", nil
+	}
+
+	extension := path.Ext(files[0].Name())
+	if len(extension) > 0 {
+		extension = extension[1:]
+	}
+
+	return extension, nil
+}

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -102,10 +102,15 @@ var (
 // ImageFromCombination takes a base datsaet directory, fileID and a band combination label and
 // returns a composed image.  NOTE: Currently a bit hardcoded for BigEarthNet data.
 func ImageFromCombination(datasetDir string, fileID string, bandCombination BandCombinationID) (*image.RGBA, error) {
+	fileType, err := GetFolderFileType(datasetDir)
+	if err != nil {
+		return nil, err
+	}
+
 	filePaths := []string{}
 	if bandCombo, ok := SentinelBandCombinations[strings.ToLower(string(bandCombination))]; ok {
 		for _, bandLabel := range bandCombo.Mapping {
-			filePath := getFilePath(datasetDir, fileID, bandLabel)
+			filePath := getFilePath(datasetDir, fileID, bandLabel, fileType)
 			filePaths = append(filePaths, filePath)
 		}
 	}
@@ -296,7 +301,7 @@ func SplitMultiBandImage(dataset gdal.Dataset, outputFolder string, bandMapping 
 
 // getFilePath takes a top level dataset directory, a file ID and a band label and composes them
 // into a coherent path for a BigEarthNet file.
-func getFilePath(datasetDir string, fileID string, bandLabel string) string {
-	fileName := fmt.Sprintf("%s_%s.tif", fileID, strings.ToUpper(bandLabel))
+func getFilePath(datasetDir string, fileID string, bandLabel string, fileType string) string {
+	fileName := fmt.Sprintf("%s_%s.%s", fileID, strings.ToUpper(bandLabel), fileType)
 	return path.Join(datasetDir, fileName)
 }


### PR DESCRIPTION
Eurosat dataset has multiband images that are all stored inside a single tiff file. Code was added to the remote sensing ingest so that multiband images will be splits when copying files to the media folder on ingest. Changes were also made to no longer assume the `.tif` extension for multiband images. It now uses the first extension found in the media folder.

Made timestamp parsing optional on remote sensing ingest. Log parsing errors up to a maximum.