### PR TITLE
Rs count fix

### DIFF
--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -212,7 +212,7 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 
 		// if timeseries mode, get the grouping field and use that for counts
 		countCol := ""
-		if mode == api.TimeseriesMode {
+		if mode == api.TimeseriesMode || mode == api.RemoteSensingMode {
 			vars, err := s.metadata.FetchVariables(dataset, false, true)
 			if err != nil {
 				return nil, err

--- a/api/model/variable_summary.go
+++ b/api/model/variable_summary.go
@@ -74,6 +74,8 @@ const (
 	ClusterMode
 	// TimeseriesMode use the timeseries grouping to return timeseries counts rather than observation counts.
 	TimeseriesMode
+	// RemoteSensingMode use the remote sensing grouping to return tile counts rather than image counts.
+	RemoteSensingMode
 )
 
 // SummaryModeFromString creates a SummaryMode from the supplied string
@@ -83,6 +85,8 @@ func SummaryModeFromString(s string) (SummaryMode, error) {
 		return ClusterMode, nil
 	case "timeseries":
 		return TimeseriesMode, nil
+	case "remoteSensing":
+		return RemoteSensingMode, nil
 	case "default":
 		return DefaultMode, nil
 	default:

--- a/public/components/AvailableTargetVariables.vue
+++ b/public/components/AvailableTargetVariables.vue
@@ -163,12 +163,6 @@ export default Vue.extend({
                       varModesMap.set(v, SummaryMode.Timeseries);
                     }
                   });
-                } else if (task.includes("remoteSensing")) {
-                  training.forEach(v => {
-                    if (v !== group.colName) {
-                      varModesMap.set(v, SummaryMode.RemoteSensing);
-                    }
-                  });
                 }
                 const varModesStr = varModesToString(varModesMap);
 

--- a/public/components/AvailableTargetVariables.vue
+++ b/public/components/AvailableTargetVariables.vue
@@ -163,6 +163,12 @@ export default Vue.extend({
                       varModesMap.set(v, SummaryMode.Timeseries);
                     }
                   });
+                } else if (task.includes("remoteSensing")) {
+                  training.forEach(v => {
+                    if (v !== group.colName) {
+                      varModesMap.set(v, SummaryMode.RemoteSensing);
+                    }
+                  });
                 }
                 const varModesStr = varModesToString(varModesMap);
 

--- a/public/components/GeocoordinateFacet.vue
+++ b/public/components/GeocoordinateFacet.vue
@@ -83,7 +83,8 @@ import {
   Extrema,
   Highlight,
   NUMERICAL_SUMMARY,
-  RowSelection
+  RowSelection,
+  SummaryMode
 } from "../store/dataset/index";
 import TypeChangeMenu from "../components/TypeChangeMenu";
 import FacetEntry from "../components/FacetEntry";
@@ -96,7 +97,7 @@ import {
   EXPAND_ACTION_TYPE,
   COLLAPSE_ACTION_TYPE
 } from "../util/types";
-import { overlayRouteEntry } from "../util/routes";
+import { overlayRouteEntry, varModesToString } from "../util/routes";
 import { Filter, removeFiltersByName } from "../util/filters";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 
@@ -634,9 +635,31 @@ export default Vue.extend({
         variableNames: training
       });
 
+      const task = taskResponse.data.task.join(",");
+      const varModesMap = routeGetters.getDecodedVarModes(this.$store);
+
+      if (task.includes("remoteSensing")) {
+        const available = routeGetters.getAvailableVariables(this.$store);
+
+        training.forEach(v => {
+          varModesMap.set(v, SummaryMode.RemoteSensing);
+        });
+
+        available.forEach(v => {
+          varModesMap.set(v.colName, SummaryMode.RemoteSensing);
+        });
+
+        varModesMap.set(
+          routeGetters.getRouteTargetVariable(this.$store),
+          SummaryMode.RemoteSensing
+        );
+      }
+      const varModesStr = varModesToString(varModesMap);
+
       const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
         training: training.join(","),
-        task: taskResponse.data.task.join(",")
+        task: task,
+        varModes: varModesStr
       });
 
       this.$router.push(entry);

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -165,7 +165,8 @@ export interface VariableSummary {
 export enum SummaryMode {
   Default = "default",
   Cluster = "cluster",
-  Timeseries = "timeseries"
+  Timeseries = "timeseries",
+  RemoteSensing = "remoteSensing"
 }
 
 export interface TableValue {


### PR DESCRIPTION
Fixes #1666

Partial fix: once a remote sensing feature is added to a model, the counts on the model screen will reflect tile counts rather than band counts. Conceptually, this seems like the desired behaviour for now. But this means that until the remote sensing feature is added to the model, the counts will reflect band counts.