### PR TITLE
Complete integration of tile visualizations into map + geofacet

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -274,7 +274,7 @@ export default Vue.extend({
         */
         const coordinates = [
           [fullCoordinates[1].Float, fullCoordinates[0].Float], // Corner A as [Lat, Lng]
-          [fullCoordinates[5].Float, fullCoordinates[4].Float] // Corner B as [Lat, Lng]
+          [fullCoordinates[5].Float, fullCoordinates[4].Float] // Corner C as [Lat, Lng]
         ] as LatLngBoundsLiteral;
 
         return { imageUrl, coordinates } as Area;

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -1,21 +1,28 @@
 <template>
   <div
     class="geo-plot-container"
-    v-bind:class="{ 'selection-mode': isSelectionMode }"
+    :class="{ 'selection-mode': isSelectionMode }"
   >
     <div
       class="geo-plot"
-      v-bind:id="mapID"
-      v-on:mousedown="onMouseDown"
-      v-on:mouseup="onMouseUp"
-      v-on:mousemove="onMouseMove"
-      v-on:keydown.esc="onEsc"
+      :id="mapID"
+      @mousedown="onMouseDown"
+      @mouseup="onMouseUp"
+      @mousemove="onMouseMove"
+      @keydown.esc="onEsc"
     ></div>
+
+    <image-drilldown
+      v-if="isRemoteSensing"
+      @hide="hideImageDrilldown"
+      :imageUrl="imageUrl"
+      :visible="isImageDrilldown"
+    ></image-drilldown>
 
     <div
       class="selection-toggle"
-      v-bind:class="{ active: isSelectionMode }"
-      v-on:click="isSelectionMode = !isSelectionMode"
+      :class="{ active: isSelectionMode }"
+      @click="isSelectionMode = !isSelectionMode"
     >
       <a
         class="selection-toggle-control"
@@ -35,6 +42,7 @@ import leaflet, { MarkerOptions } from "leaflet";
 import Vue from "vue";
 import IconBase from "./icons/IconBase";
 import IconCropFree from "./icons/IconCropFree";
+import ImageDrilldown from "./ImageDrilldown.vue";
 import { getters as appGetters } from "../store/app/module";
 import { SatelliteBand } from "../store/app/index";
 import { getters as datasetGetters } from "../store/dataset/module";
@@ -93,40 +101,17 @@ type TileLayer = import("leaflet").TileLayer;
 type LatLngBoundsLiteral = import("leaflet").LatLngBoundsLiteral;
 
 interface Area {
-  id: number;
   coordinates: LatLngBoundsLiteral;
+  imageUrl: String;
 }
-
-const FAKEDATA = [
-  {
-    id: 1,
-    coordinates: [
-      [35, 36],
-      [45, 46]
-    ]
-  },
-  {
-    id: 2,
-    coordinates: [
-      [24, 25],
-      [34, 35]
-    ]
-  },
-  {
-    id: 3,
-    coordinates: [
-      [13, 14],
-      [23, 24]
-    ]
-  }
-] as Area[];
 
 export default Vue.extend({
   name: "geo-plot",
 
   components: {
     IconBase,
-    IconCropFree
+    IconCropFree,
+    ImageDrilldown
   },
 
   props: {
@@ -143,7 +128,9 @@ export default Vue.extend({
       startingLatLng: null,
       currentRect: null,
       selectedRect: null,
-      isSelectionMode: false
+      isSelectionMode: false,
+      isImageDrilldown: false,
+      imageUrl: null
     };
   },
 
@@ -271,7 +258,27 @@ export default Vue.extend({
         return [];
       }
 
-      return FAKEDATA;
+      return this.dataItems.map(item => {
+        const imageUrl = item.group_id.value;
+        const fullCoordinates = item.coordinates.value.Elements;
+        /* 
+          Item store the coordinates as a list of 8 values being four pairs of [Lng, Lat], 
+          one for each corner of the remote-sensing image.
+
+          [0,1]     [2,3]
+            A-------B
+            |       |
+            |       |
+            D-------C
+          [6,7]     [4,5]
+        */
+        const coordinates = [
+          [fullCoordinates[1].Float, fullCoordinates[0].Float], // Corner A as [Lat, Lng]
+          [fullCoordinates[5].Float, fullCoordinates[4].Float] // Corner B as [Lat, Lng]
+        ] as LatLngBoundsLiteral;
+
+        return { imageUrl, coordinates } as Area;
+      });
     },
 
     highlight(): Highlight {
@@ -303,13 +310,7 @@ export default Vue.extend({
      * @returns {TileLayer}
      */
     baseLayer(): TileLayer {
-      let URL = "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
-
-      if (this.isRemoteSensing) {
-        const { r, g, b } = this.currentSatelliteBand;
-        URL = `distil/dataset/tile/${r}/${g}/${b}/{z}/{x}/{y}.png`;
-      }
-
+      const URL = "http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
       return leaflet.tileLayer(URL);
     }
   },
@@ -580,6 +581,14 @@ export default Vue.extend({
       });
     },
 
+    showImageDrilldown(imageUrl: String) {
+      this.imageUrl = imageUrl;
+      this.isImageDrilldown = true;
+    },
+    hideImageDrilldown() {
+      this.isImageDrilldown = false;
+    },
+
     /**
      * Create a Leaflet map, if it doesn't exist already, with basic defaults.
      */
@@ -629,7 +638,7 @@ export default Vue.extend({
 
       // Add each area to the layer group.
       this.areas.forEach(area => {
-        const { coordinates, id } = area;
+        const { coordinates, imageUrl } = area;
 
         // Make sure the new area fit on the map.
         coordinates.forEach(coordinate => bounds.extend(coordinate));
@@ -637,8 +646,8 @@ export default Vue.extend({
         // Create a rectangle to display the area on the map.
         const rectangle = leaflet
           .rectangle(coordinates, displayOptions)
-          .on("click", () => console.debug(`Open image modal for ${id}.`))
-          .bindTooltip(`Satellite Image ${id}`);
+          .on("click", () => this.showImageDrilldown(imageUrl))
+          .bindTooltip(`Satellite Image ${imageUrl}`);
 
         // Add the rectangle to the layer group.
         layerGroup.addLayer(rectangle);

--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -31,15 +31,15 @@ const imageId = (imageUrl: String) => imageUrl.split(/_B[0-9][0-9a-zA-Z][.]/)[0]
  * Display a modal with drilldowned information about an image.
  *
  * @param visible  {Boolean} Display or hide the modal.
- * @param imageUrl {String=} URL of the image to be drilldown.
+ * @param imageUrl {String}  URL of the image to be drilldown.
  * @param title    {String=} Title of the modal.
  */
 export default Vue.extend({
   name: "image-drilldown",
 
   props: {
-    visible: { type: Boolean as () => boolean, required: true },
-    imageUrl: String,
+    visible: { type: Boolean, required: true },
+    imageUrl: { type: String, required: true },
     title: String,
   },
 

--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -1,0 +1,141 @@
+<template>
+  <b-modal @hide="hide" hide-footer :title="visibleTitle" :visible="visible">
+    <div v-if="isRemoteSensing && availableBands.length > 0">
+      <b-dropdown :text="band" size="sm">
+        <b-dropdown-item
+          v-for="bandInfo in availableBands"
+          :key="bandInfo.id"
+          @click="setBandCombination(bandInfo.id)"
+          >{{ bandInfo.displayName }}
+        </b-dropdown-item>
+      </b-dropdown>
+    </div>
+    <div class="image-container" ref="imageContainer"></div>
+  </b-modal>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { BandID, BandCombination } from "../store/dataset/index";
+import {
+  getters as datasetGetters,
+  actions as datasetActions
+} from "../store/dataset/module";
+import { getters as routeGetters } from "../store/route/module";
+import { Dictionary } from "../util/dict";
+import { overlayRouteEntry } from "../util/routes";
+
+const imageId = (imageUrl: String) => imageUrl.split(/_B[0-9][0-9a-zA-Z][.]/)[0];
+
+/**
+ * Display a modal with drilldowned information about an image.
+ *
+ * @param visible  {Boolean} Display or hide the modal.
+ * @param imageUrl {String=} URL of the image to be drilldown.
+ * @param title    {String=} Title of the modal.
+ */
+export default Vue.extend({
+  name: "image-drilldown",
+
+  props: {
+    visible: { type: Boolean as () => boolean, required: true },
+    imageUrl: String,
+    title: String,
+  },
+
+  mounted() {
+    this.injectImage();
+  },
+
+  updated() {
+    this.$nextTick(this.injectImage);
+  },
+
+  computed: {
+    availableBands(): BandCombination[] {
+      return datasetGetters.getMultiBandCombinations(this.$store);
+    },
+
+    band(): string {
+      const bandID = routeGetters.getBandCombinationId(this.$store);
+      return this.availableBands.find(b => b.id === bandID)?.displayName;
+    },
+
+    dataset(): string {
+      return routeGetters.getRouteDataset(this.$store);
+    },
+
+    files(): Dictionary<any> {
+      return datasetGetters.getFiles(this.$store);
+    },
+
+    image(): HTMLImageElement {
+      return this.files[this.imageUrl] ?? this.files[imageId(this.imageUrl)] ?? null;
+    },
+
+    isRemoteSensing(): boolean {
+      return routeGetters.isRemoteSensing(this.$store);
+    },
+
+    visibleTitle(): string {
+      return this.title ?? this.imageUrl ?? "Image Drilldown";
+    },
+  },
+
+  methods: {
+    hide() {
+      this.$emit('hide');
+    },
+
+    injectImage() {
+      const container = this.$refs.imageContainer as any;
+
+      if (this.image && container) {
+        container.innerHTML = "";
+        container.appendChild(
+          this.image.cloneNode() as HTMLImageElement
+        );
+      }
+    },
+
+    async requestMultiBandImage() {
+      await datasetActions.fetchMultiBandImage(this.$store, {
+        dataset: this.dataset,
+        imageId: imageId(this.imageUrl),
+        bandCombination: routeGetters.getBandCombinationId(this.$store)
+      });
+
+      // Display the image for that band.
+      this.injectImage();
+    },
+
+    setBandCombination(bandID: BandID) {
+      // Writes a new band combination into the route
+      const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
+        bandCombinationId: bandID
+      });
+      this.$router.push(entry);
+
+      // Request the new band of the image.
+      this.requestMultiBandImage();
+    },
+  }
+});
+</script>
+
+<style>
+.image-container {
+  /* Keep the image under 25% of screen width. */
+  max-height: 25vw;
+  max-width: 25vw;
+
+  text-align: center;
+}
+
+/* Keep the image in its container. */
+.image-container img {
+  max-height: 100%;
+  max-width: 100%;
+  position: relative;
+}
+</style>

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -146,17 +146,8 @@ export default Vue.extend({
       }
     },
     band(): string {
-      const bandID = routeGetters.getBandCombinationId(this.$store);
-      return this.availableBands.find(b => b.id === bandID)?.displayName;
+      return routeGetters.getBandCombinationId(this.$store);
     },
-
-    availableBands(): BandCombination[] {
-      // Show available bands for remote sensing only
-      if (this.type === REMOTE_SENSING_TYPE) {
-        return datasetGetters.getMultiBandCombinations(this.$store);
-      }
-      return [];
-    }
   },
 
   methods: {

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -1,42 +1,32 @@
 <template>
   <div
     v-observe-visibility="visibilityChanged"
-    v-bind:class="{ 'is-hidden': !isVisible && !preventHiding }"
-    v-bind:style="{ width: `${width}px`, height: `${height}px` }"
+    :class="{ 'is-hidden': !isVisible && !preventHiding }"
+    :style="{ width: `${width}px`, height: `${height}px` }"
   >
-    <div
-      class="image-container"
-      v-bind:class="{ selected: isSelected && isLoaded }"
-    >
-      <div
-        class="image-elem"
-        v-bind:class="{ clickable: hasClick }"
-        ref="imageElem"
-        @click.stop="handleClick"
-        v-bind:style="{ 'max-width': `${width}px` }"
-      >
-        <div v-if="!isLoaded" v-html="spinnerHTML"></div>
-      </div>
+    <div class="image-container" :class="{ selected: isSelected && isLoaded }">
+      <template v-if="!isLoaded">
+        <div v-html="spinnerHTML"></div>
+      </template>
+      <template v-else>
+        <div
+          class="image-elem"
+          :class="{ clickable: hasClick }"
+          @click.stop="handleClick"
+          ref="imageElem"
+        ></div>
+        <i
+          class="fa fa-search-plus zoom-icon"
+          @click.stop="showZoomedImage"
+        ></i>
+      </template>
     </div>
-    <b-modal
-      id="image-zoom-modal"
+    <image-drilldown
+      @hide="hideZoomImage"
+      :imageUrl="imageUrl"
       :title="imageUrl"
-      @hide="hideModal"
       :visible="!!zoomImage"
-      hide-footer
-    >
-      <div v-if="availableBands.length > 0">
-        <b-dropdown :text="band" size="sm">
-          <b-dropdown-item
-            v-for="bandInfo in availableBands"
-            :key="bandInfo.id"
-            @click="setBandCombination(bandInfo.id)"
-            >{{ bandInfo.displayName }}</b-dropdown-item
-          >
-        </b-dropdown>
-      </div>
-      <div class="image-elem-zoom" ref="imageElemZoom"></div>
-    </b-modal>
+    ></image-drilldown>
   </div>
 </template>
 
@@ -44,6 +34,7 @@
 import $ from "jquery";
 import _ from "lodash";
 import Vue from "vue";
+import ImageDrilldown from "./ImageDrilldown.vue";
 import {
   getters as datasetGetters,
   actions as datasetActions
@@ -61,10 +52,14 @@ import {
 import { isRowSelected } from "../util/row";
 import { Dictionary } from "../util/dict";
 import { REMOTE_SENSING_TYPE, IMAGE_TYPE } from "../util/types";
-import { createRouteEntry, overlayRouteEntry } from "../util/routes";
+import { createRouteEntry } from "../util/routes";
 
 export default Vue.extend({
   name: "image-preview",
+
+  components: {
+    ImageDrilldown
+  },
 
   props: {
     row: Object as () => TableRow,
@@ -98,6 +93,7 @@ export default Vue.extend({
         }
       }
     },
+
     // Refresh image on band change
     band(newBand: string, oldBand: string) {
       if (newBand !== oldBand) {
@@ -119,10 +115,6 @@ export default Vue.extend({
     };
   },
 
-  updated() {
-    this.$nextTick(this.injectZoomedImage);
-  },
-
   computed: {
     imageId(): string {
       return this.imageUrl.split(/_B[0-9][0-9a-zA-Z][.]/)[0];
@@ -134,11 +126,7 @@ export default Vue.extend({
       return !!this.files[this.imageUrl] && !!this.files[this.imageId];
     },
     image(): HTMLImageElement {
-      return this.files[this.imageUrl]
-        ? this.files[this.imageUrl]
-        : this.files[this.imageId]
-        ? this.files[this.imageId]
-        : null;
+      return this.files[this.imageUrl] ?? this.files[this.imageId] ?? null;
     },
     spinnerHTML(): string {
       return circleSpinnerHTML();
@@ -161,6 +149,7 @@ export default Vue.extend({
       const bandID = routeGetters.getBandCombinationId(this.$store);
       return this.availableBands.find(b => b.id === bandID)?.displayName;
     },
+
     availableBands(): BandCombination[] {
       // Show available bands for remote sensing only
       if (this.type === REMOTE_SENSING_TYPE) {
@@ -192,37 +181,11 @@ export default Vue.extend({
       }
     },
 
-    // Writes a new band combination into the route
-    setBandCombination(bandID: BandID) {
-      const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
-        bandCombinationId: bandID
-      });
-      this.$router.push(entry);
-    },
-
-    injectZoomedImage() {
-      const $elem = this.$refs.imageElemZoom as any;
-      if (this.image && $elem) {
-        $elem.innerHTML = "";
-        $elem.appendChild(
-          this.clonedImageElement(this.zoomedWidth, this.zoomedHeight)
-        );
-      }
-    },
-
     showZoomedImage() {
       this.zoomImage = true;
     },
-
-    hideModal() {
+    hideZoomImage() {
       this.zoomImage = false;
-    },
-
-    clonedImageElement(width: number, height: number): HTMLImageElement {
-      const img = this.image.cloneNode();
-      $(img).css("max-width", `${width}px`);
-      $(img).css("max-height", `${height}px`);
-      return img as HTMLImageElement;
     },
 
     clearImage(elem?: any) {
@@ -236,17 +199,12 @@ export default Vue.extend({
       if (!this.image) {
         return;
       }
+
       const elem = this.$refs.imageElem as any;
       if (elem) {
         this.clearImage(elem);
-        elem.appendChild(this.clonedImageElement(this.width, this.height));
-        const icon = document.createElement("i");
-        icon.className += "fa fa-search-plus zoom-icon";
-        $(icon).click(event => {
-          this.showZoomedImage();
-          event.stopPropagation();
-        });
-        elem.appendChild(icon);
+        const image = this.image.cloneNode() as HTMLImageElement;
+        elem.appendChild(image);
         this.hasRendered = true;
       }
     },
@@ -275,6 +233,7 @@ export default Vue.extend({
       }
     }
   },
+
   async beforeMount() {
     // lazy fetch available band types
     if (
@@ -290,61 +249,59 @@ export default Vue.extend({
 </script>
 
 <style>
+.is-hidden {
+  visibility: hidden;
+}
+
 .image-container {
   border: 2px solid rgba(0, 0, 0, 0);
+  position: relative;
 }
+
 .image-container.selected {
   border: 2px solid #ff0067;
 }
 
-.image-elem {
-  position: relative;
-}
 .image-elem:hover {
   background-color: #000;
 }
-.image-elem img {
-  position: relative;
-}
+
 .image-elem.clickable {
   cursor: pointer;
 }
+
 .image-elem.clickable img:hover {
   opacity: 0.7;
 }
 
-.image-elem.clickable zoom-icon:hover {
-  opacity: 0.7;
+/* Keep the image in its container. */
+.image-elem img {
+  max-height: 100%;
+  max-width: 100%;
+  position: relative;
 }
 
-.image-elem-zoom {
-  position: relative;
-  text-align: center;
-}
-.image-elem-zoom img {
-  position: relative;
-  padding: 8px 16px;
-  max-width: 100%;
-  border-radius: 4px;
-}
-.image-elem .zoom-icon {
+/* Zoom icon */
+
+.image-container .zoom-icon {
+  background-color: #424242;
+  color: #fff;
+  cursor: pointer;
+  opacity: 0.7;
+  padding: 4px;
   position: absolute;
   right: 0;
   top: 0;
-  padding: 4px;
-  color: #fff;
   visibility: hidden;
 }
-.image-elem:hover .zoom-icon {
+
+/* Make the icon visible on image hover. */
+.image-container:hover .zoom-icon {
   visibility: visible;
 }
 
-.zoom-icon {
-  cursor: pointer;
-  background-color: #424242;
-}
-
-.is-hidden {
-  visibility: hidden;
+/* Make the icon dimmer on hover. */
+.image-container .zoom-icon:hover {
+  opacity: 1;
 }
 </style>

--- a/public/components/ViewTypeToggle.vue
+++ b/public/components/ViewTypeToggle.vue
@@ -113,7 +113,9 @@ export default Vue.extend({
     hasGeoVariables(): boolean {
       const hasGeocoord =
         this.variables.filter(
-          v => v.grouping && v.grouping.type === GEOCOORDINATE_TYPE
+          v =>
+            v.grouping &&
+            [GEOCOORDINATE_TYPE, REMOTE_SENSING_TYPE].includes(v.grouping.type)
         ).length > 0;
       const hasLat =
         this.variables.filter(v => v.colType === LONGITUDE_TYPE).length > 0;


### PR DESCRIPTION
closes #1636

- Separate the `image-drilldown` modal to its component.
- Move the band selection dropdown to the `image-drilldown` component. It might be better to create its component.
- Added the `GeoPlot` view for Remote sensing images, displaying their areas, and added the drilldown on click.