### PR TITLE
Image label scaling

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -261,8 +261,8 @@ export default Vue.extend({
       return this.dataItems.map(item => {
         const imageUrl = item.group_id.value;
         const fullCoordinates = item.coordinates.value.Elements;
-        /* 
-          Item store the coordinates as a list of 8 values being four pairs of [Lng, Lat], 
+        /*
+          Item store the coordinates as a list of 8 values being four pairs of [Lng, Lat],
           one for each corner of the remote-sensing image.
 
           [0,1]     [2,3]
@@ -627,7 +627,7 @@ export default Vue.extend({
      */
     addAreas() {
       const displayOptions = {
-        color: "chartreuse"
+        color: "rgb(42, 198, 223)"
       };
 
       // Create a layer group to contain all the areas to be displayed.

--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -1,0 +1,188 @@
+<template>
+  <ol class="labels">
+    <li
+      v-for="(label, index) in labels"
+      :key="index"
+      class="label"
+      :class="label.status"
+    >
+      {{ label.value }}
+    </li>
+  </ol>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Dictionary } from "../util/dict";
+import { TableRow, TableColumn, VariableSummary } from "../store/dataset/index";
+import { getters as datasetGetters } from "../store/dataset/module";
+import { getters as requestGetters } from "../store/requests/module";
+import { getters as routeGetters } from "../store/route/module";
+import { getters as resultGetters } from "../store/results/module";
+import _ from "lodash";
+
+interface Label {
+  status: string;
+  value: string;
+}
+
+/**
+ * Display the prediction result as a label.
+ */
+export default Vue.extend({
+  name: "image-label",
+
+  components: {},
+
+  data() {
+    return {};
+  },
+
+  props: {
+    dataFields: Object as () => Dictionary<TableColumn>,
+    includedActive: Boolean as () => boolean,
+    item: Object as () => TableRow,
+    shortenLabels: Boolean as () => boolean
+  },
+
+  computed: {
+    fields(): Dictionary<TableColumn> {
+      return this.dataFields
+        ? this.dataFields
+        : this.includedActive
+        ? datasetGetters.getIncludedTableDataFields(this.$store)
+        : datasetGetters.getExcludedTableDataFields(this.$store);
+    },
+
+    labels(): Label[] {
+      const labels = [];
+      let status;
+
+      for (const key in this.fields) {
+        status = null;
+
+        // Define status of label (correct or incorrect) if we want to show the predicted error.
+        if (key === this.predictedField && this.showError) {
+          status = this.correct() ? "correct" : "incorrect";
+        }
+
+        // Display the label
+        if (key === this.targetField || key === this.predictedField) {
+          const label = this.shortenLabels
+            ? this.shortenLabel(this.item[key].value)
+            : this.item[key].value;
+          labels.push({ status, value: label } as Label);
+        }
+      }
+
+      return labels;
+    },
+
+    predictedField(): string {
+      const predictions = requestGetters.getActivePredictions(this.$store);
+      if (predictions) {
+        return predictions.predictedKey;
+      }
+
+      const solution = requestGetters.getActiveSolution(this.$store);
+      return solution ? `${solution.predictedKey}` : "";
+    },
+
+    showError(): boolean {
+      return (
+        this.predictedField && !requestGetters.getActivePredictions(this.$store)
+      );
+    },
+
+    targetField(): string {
+      return routeGetters.getRouteTargetVariable(this.$store);
+    },
+
+    // Creates a dictionary of label lengths keyed by a label's first character.  This supports
+    // the generation of a minimum ambiguous label by starting letter.  For the set [Airport, Agriculture, Forest],
+    // we will end up with [A=4, F=1], which at runtime will generate display lables of [Ai, Ag, F].  This is a computed
+    // property so it should only end up being updated when the underlying data changes.
+    labelLengths(): Dictionary<number> {
+      let summary: VariableSummary = null;
+      // find the target variable and get the prediction labels
+      if (this.showError) {
+        summary = resultGetters.getTargetSummary(this.$store);
+      } else {
+        summary = datasetGetters
+          .getVariableSummaries(this.$store)
+          .find(v => v.key === this.targetField);
+      }
+      const bucketNames = summary.baseline.buckets.map(b => b.key);
+      // If this isn't categorical, don't generate the table.
+      if (!bucketNames) {
+        return {};
+      }
+
+      // initailize label lengths with zeroes
+      const imageLabelLengths: Dictionary<number> = {};
+      bucketNames.forEach(b => (imageLabelLengths[b[0]] = 0));
+
+      // Compare each label to the others
+      for (let i = 0; i < bucketNames.length; i++) {
+        const currLabel = bucketNames[i];
+        for (let j = i + 1; j < bucketNames.length; j++) {
+          const compareLabel = bucketNames[j];
+          // Update the min number of characters required to disambiguate the labels
+          // with the same starting character.
+          if (currLabel[0] === compareLabel[0]) {
+            for (
+              let k = imageLabelLengths[currLabel[0]];
+              k < Math.min(currLabel.length, compareLabel.length);
+              k++
+            ) {
+              if (currLabel[k] !== compareLabel[k]) {
+                break;
+              }
+              imageLabelLengths[currLabel[0]] += 1;
+            }
+          }
+        }
+      }
+      return imageLabelLengths;
+    }
+  },
+
+  methods: {
+    correct(): boolean {
+      return (
+        this.item[this.targetField].value ===
+        this.item[this.predictedField].value
+      );
+    },
+
+    // Given a raw label value, returns shortened label that is unique amongst the set of target labels.
+    shortenLabel(rawLabel: string): string {
+      const labelLength = this.labelLengths[rawLabel[0]];
+      return _.isNil(labelLength)
+        ? rawLabel
+        : rawLabel.substring(0, labelLength + 1);
+    }
+  }
+});
+</script>
+
+<style scoped>
+.labels {
+  color: white;
+  list-style: none;
+  list-style-position: outside;
+  max-width: 100%;
+}
+
+.label {
+  background-color: #424242;
+  overflow: hidden;
+  padding: 0 2px;
+}
+.label.correct {
+  background-color: #03c003;
+}
+.label.incorrect {
+  background-color: #be0000;
+}
+</style>

--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -3,6 +3,7 @@
     <li
       v-for="(label, index) in labels"
       :key="index"
+      :title="label.title"
       class="label"
       :class="label.status"
     >
@@ -24,6 +25,7 @@ import _ from "lodash";
 interface Label {
   status: string;
   value: string;
+  title: string;
 }
 
 /**
@@ -62,8 +64,8 @@ export default Vue.extend({
     },
 
     labels(): Label[] {
-      const labels = [];
-      let status;
+      const labels: Label[] = [];
+      let status: string;
 
       for (const key in this.fields) {
         status = null;
@@ -81,10 +83,20 @@ export default Vue.extend({
 
         // Display the label
         if (key === this.targetField || key === this.predictedField) {
-          const label = this.shortenLabels
-            ? this.shortenLabel(this.item[key].value)
-            : this.item[key].value;
-          labels.push({ status, value: label } as Label);
+          const fullLabel = <string>this.item[key].value;
+          if (this.shortenLabels) {
+            labels.push({
+              status,
+              value: this.shortenLabel(fullLabel),
+              title: fullLabel
+            });
+          } else {
+            labels.push({
+              status,
+              value: fullLabel,
+              title: ""
+            });
+          }
         }
       }
 

--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -1,5 +1,5 @@
 <template>
-  <ol class="labels">
+  <ol class="labels" :class="alignment">
     <li
       v-for="(label, index) in labels"
       :key="index"
@@ -42,7 +42,14 @@ export default Vue.extend({
     dataFields: Object as () => Dictionary<TableColumn>,
     includedActive: Boolean as () => boolean,
     item: Object as () => TableRow,
-    shortenLabels: Boolean as () => boolean
+    shortenLabels: {
+      type: Boolean as () => boolean,
+      default: false
+    },
+    alignHorizontal: {
+      type: Boolean as () => boolean,
+      default: false
+    }
   },
 
   computed: {
@@ -61,9 +68,15 @@ export default Vue.extend({
       for (const key in this.fields) {
         status = null;
 
-        // Define status of label (correct or incorrect) if we want to show the predicted error.
-        if (key === this.predictedField && this.showError) {
-          status = this.correct() ? "correct" : "incorrect";
+        // If we're showing error, we want to show
+        // a) *just* the correct label or
+        // b) the incorrect label *and* the ground truth label for comparison.
+        if (this.showError) {
+          if (key === this.predictedField) {
+            status = this.correct() ? "correct" : "incorrect";
+          } else if (key === this.targetField && this.correct()) {
+            continue;
+          }
         }
 
         // Display the label
@@ -92,6 +105,10 @@ export default Vue.extend({
       return (
         this.predictedField && !requestGetters.getActivePredictions(this.$store)
       );
+    },
+
+    alignment(): string {
+      return this.alignHorizontal ? "horizontal" : "vertical";
     },
 
     targetField(): string {
@@ -172,8 +189,11 @@ export default Vue.extend({
   list-style: none;
   list-style-position: outside;
   max-width: 100%;
+  padding-inline-start: 0px;
 }
-
+.labels.horizontal {
+  display: inline-flex;
+}
 .label {
   background-color: #424242;
   overflow: hidden;

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -21,6 +21,7 @@
             :dataFields="dataFields"
             includedActive
             shortenLabels
+            alignHorizontal
             :item="item"
           />
         </div>
@@ -180,6 +181,7 @@ export default Vue.extend({
   left: 2px;
   top: 2px;
   padding: 0 2px;
+  margin: 0 2px;
   z-index: 1;
 }
 </style>

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -13,40 +13,16 @@
               :height="imageHeight"
               :on-click="onImageClick"
               :type="imageField.type"
+              :key="fieldKey"
             ></image-preview>
           </template>
-          <div v-if="showError" class="image-label-container">
-            <template v-for="(fieldInfo, fieldKey) in fields">
-              <div
-                v-if="fieldKey == predictedField && correct(item)"
-                class="image-label-correct"
-              >
-                {{ shortenLabel(item[fieldKey].value) }}
-              </div>
-              <div
-                v-if="fieldKey == targetField && !correct(item)"
-                class="image-label"
-              >
-                {{ shortenLabel(item[fieldKey].value) }}
-              </div>
-              <div
-                v-if="fieldKey == predictedField && !correct(item)"
-                class="image-label-incorrect"
-              >
-                {{ shortenLabel(item[fieldKey].value) }}
-              </div>
-            </template>
-          </div>
-          <div v-if="!showError" class="image-label-container">
-            <template v-for="(fieldInfo, fieldKey) in fields">
-              <div
-                v-if="fieldKey == targetField || fieldKey == predictedField"
-                class="image-label"
-              >
-                {{ shortenLabel(item[fieldKey].value) }}
-              </div>
-            </template>
-          </div>
+          <image-label
+            class="image-label"
+            :dataFields="dataFields"
+            includedActive
+            shortenLabels
+            :item="item"
+          />
         </div>
       </template>
     </template>
@@ -54,11 +30,9 @@
 </template>
 
 <script lang="ts">
-import _ from "lodash";
 import Vue from "vue";
+import ImageLabel from "./ImageLabel";
 import ImagePreview from "./ImagePreview";
-import { getters as datasetGetters } from "../store/dataset/module";
-import { getters as requestGetters } from "../store/requests/module";
 import {
   RowSelection,
   TableColumn,
@@ -68,8 +42,10 @@ import {
   Variable,
   VariableSummary
 } from "../store/dataset/index";
+import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
 import { getters as resultGetters } from "../store/results/module";
+import { getters as requestGetters } from "../store/requests/module";
 import { Dictionary } from "../util/dict";
 import {
   addRowSelection,
@@ -86,6 +62,7 @@ export default Vue.extend({
   name: "image-mosaic",
 
   components: {
+    ImageLabel,
     ImagePreview
   },
 
@@ -153,54 +130,6 @@ export default Vue.extend({
       return (
         this.predictedField && !requestGetters.getActivePredictions(this.$store)
       );
-    },
-
-    // Creates a dictionary of label lengths keyed by a label's first character.  This supports
-    // the generation of a minimum ambiguous label by starting letter.  For the set [Airport, Agriculture, Forest],
-    // we will end up with [A=4, F=1], which at runtime will generate display lables of [Ai, Ag, F].  This is a computed
-    // property so it should only end up being updated when the underlying data changes.
-    labelLengths(): Dictionary<number> {
-      let summary: VariableSummary = null;
-      // find the target variable and get the prediction labels
-      if (this.showError) {
-        summary = resultGetters.getTargetSummary(this.$store);
-      } else {
-        summary = datasetGetters
-          .getVariableSummaries(this.$store)
-          .find(v => v.key === this.targetField);
-      }
-      const bucketNames = summary.baseline.buckets.map(b => b.key);
-      // If this isn't categorical, don't generate the table.
-      if (!bucketNames) {
-        return {};
-      }
-
-      // initailize label lengths with zeroes
-      const imageLabelLengths: Dictionary<number> = {};
-      bucketNames.forEach(b => (imageLabelLengths[b[0]] = 0));
-
-      // Compare each label to the others
-      for (let i = 0; i < bucketNames.length; i++) {
-        const currLabel = bucketNames[i];
-        for (let j = i + 1; j < bucketNames.length; j++) {
-          const compareLabel = bucketNames[j];
-          // Update the min number of characters required to disambiguate the labels
-          // with the same starting character.
-          if (currLabel[0] === compareLabel[0]) {
-            for (
-              let k = imageLabelLengths[currLabel[0]];
-              k < Math.min(currLabel.length, compareLabel.length);
-              k++
-            ) {
-              if (currLabel[k] !== compareLabel[k]) {
-                break;
-              }
-              imageLabelLengths[currLabel[0]] += 1;
-            }
-          }
-        }
-      }
-      return imageLabelLengths;
     }
   },
 
@@ -221,18 +150,6 @@ export default Vue.extend({
           event.row[D3M_INDEX_FIELD]
         );
       }
-    },
-
-    correct(item: any): boolean {
-      return item[this.targetField].value === item[this.predictedField].value;
-    },
-
-    // Given a raw label value, returns shortened label that is unique amongst the set of target labels.
-    shortenLabel(rawLabel: string): string {
-      const labelLength = this.labelLengths[rawLabel[0]];
-      return _.isNil(labelLength)
-        ? rawLabel
-        : rawLabel.substring(0, labelLength + 1);
     }
   }
 });
@@ -258,34 +175,11 @@ export default Vue.extend({
   position: relative;
 }
 
-.image-label-container {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  z-index: 1;
-}
-
 .image-label {
-  float: right;
-  background-color: #424242;
-  color: #fff;
-  padding: 0 4px;
-  margin: 0, 2px;
-}
-
-.image-label-correct {
-  float: right;
-  background-color: #03c003;
-  color: #fff;
-  padding: 0 4px;
-  margin: 0, 2px;
-}
-
-.image-label-incorrect {
-  float: right;
-  background-color: #be0000;
-  color: #fff;
-  padding: 0 4px;
-  margin: 0, 2px;
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  padding: 0 2px;
+  z-index: 1;
 }
 </style>

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -36,7 +36,7 @@
         ></results-geo-plot>
         <image-mosaic
           v-if="viewType === IMAGE_VIEW"
-          :included-active="includedActive"
+          included-active
           :instance-name="instanceName"
           :data-fields="dataFields"
           :data-items="dataItems"
@@ -93,7 +93,6 @@ export default Vue.extend({
 
   data() {
     return {
-      includedActive: true,
       TABLE_VIEW: TABLE_VIEW,
       IMAGE_VIEW: IMAGE_VIEW,
       GRAPH_VIEW: GRAPH_VIEW,


### PR DESCRIPTION
fixes #1671 

Based on design feedback, we're now showing shortened image mosaic labels based on the first character of the label.  In the case where there are more than 1 label with a given first letter, we will determine the minimum sequence of subsequent letters to display to disambiguate all labels within that starting letter group.