### PR TITLE
Remote Sensing Filter & Counts

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -51,7 +51,7 @@ type DataStorage interface {
 	FetchResults(dataset string, storageName string, resultURI string, solutionID string, filterParams *FilterParams, removeTargetColumn bool) (*FilteredData, error)
 	FetchPredictedSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, extrema *Extrema, mode SummaryMode) (*VariableSummary, error)
 	FetchResultsExtremaByURI(dataset string, storageName string, resultURI string) (*Extrema, error)
-	FetchCorrectnessSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams) (*VariableSummary, error)
+	FetchCorrectnessSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, mode SummaryMode) (*VariableSummary, error)
 	FetchResidualsSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, extrema *Extrema, mode SummaryMode) (*VariableSummary, error)
 	FetchResidualsExtremaByURI(dataset string, storageName string, resultURI string) (*Extrema, error)
 	FetchExtrema(storageName string, variable *model.Variable) (*Extrema, error)

--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -125,7 +125,7 @@ func (f *CategoricalField) getTopCategories(filterParams *api.FilterParams, inve
 	// create the filter for the query
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -165,7 +165,7 @@ func (f *CategoricalField) fetchHistogram(filterParams *api.FilterParams, invert
 	// create the filter for the query
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -192,7 +192,7 @@ func (f *CategoricalField) fetchHistogramByResult(resultURI string, filterParams
 	fromClause := f.getFromClause(false)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (f *CategoricalField) fetchPredictedSummaryData(resultURI string, datasetRe
 	targetName := f.Key
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -124,7 +124,7 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -179,7 +179,7 @@ func (f *CoordinateField) fetchHistogram(filterParams *api.FilterParams, invert 
 func (f *CoordinateField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams, numBuckets int) (*api.Histogram, error) {
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/correctness.go
+++ b/api/model/storage/postgres/correctness.go
@@ -75,6 +75,11 @@ func (s *Storage) fetchHistogram(dataset string, storageName string, variable *m
 	if err != nil {
 		return nil, err
 	}
+	if countCol == "" {
+		countCol = "*"
+	} else {
+		countCol = fmt.Sprintf("DISTINCT \"%s\"", countCol)
+	}
 
 	wheres = append(wheres, fmt.Sprintf("result.result_id = $%d AND result.target = $%d ", len(params)+1, len(params)+2))
 	params = append(params, resultURI, targetName)
@@ -98,7 +103,7 @@ func (s *Storage) fetchHistogram(dataset string, storageName string, variable *m
 }
 
 func (s *Storage) getCountCol(dataset string, mode api.SummaryMode) (string, error) {
-	countCol := "*"
+	countCol := ""
 	if mode == api.RemoteSensingMode {
 		// remote sensing group should be distinct by group id
 		vars, err := s.metadata.FetchVariables(dataset, false, true)
@@ -108,7 +113,7 @@ func (s *Storage) getCountCol(dataset string, mode api.SummaryMode) (string, err
 
 		for _, v := range vars {
 			if v.IsGrouping() {
-				countCol = fmt.Sprintf("DISTINCT \"%s\"", v.Grouping.GetIDCol())
+				countCol = v.Grouping.GetIDCol()
 			}
 		}
 

--- a/api/model/storage/postgres/correctness.go
+++ b/api/model/storage/postgres/correctness.go
@@ -66,7 +66,7 @@ func (s *Storage) fetchHistogram(dataset string, storageName string, variable *m
 	storageNameResult := s.getResultTable(storageName)
 
 	// get filter where / params
-	wheres, params, err := s.buildResultQueryFilters(storageName, resultURI, filterParams)
+	wheres, params, err := s.buildResultQueryFilters(dataset, storageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -125,7 +125,7 @@ func (f *DateTimeField) fetchHistogram(filterParams *api.FilterParams, invert bo
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	// need the extrema to calculate the histogram interval
 	extrema, err := f.fetchExtrema()
@@ -162,7 +162,7 @@ func (f *DateTimeField) fetchHistogramByResult(resultURI string, filterParams *a
 	fromClause := f.getFromClause(false)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ func (f *DateTimeField) fetchPredictedSummaryData(resultURI string, datasetResul
 	histogramName, bucketQuery, histogramQuery := f.getResultHistogramAggQuery(extrema, resultVariable, numBuckets)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -18,6 +18,7 @@ package postgres
 import (
 	"fmt"
 
+	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
 )
 
@@ -98,7 +99,7 @@ func updateClusterHighlight(metadataStorage api.MetadataStorage, dataset string,
 			return err
 		}
 
-		if variable.IsGrouping() {
+		if variable.IsGrouping() && model.IsTimeSeries(variable.Grouping.GetType()) {
 			clusterCol, ok := api.GetClusterColFromGrouping(variable.Grouping)
 			if ok && api.HasClusterData(dataset, clusterCol, metadataStorage) {
 				filterParams.Highlight.Key = clusterCol

--- a/api/model/storage/postgres/image.go
+++ b/api/model/storage/postgres/image.go
@@ -139,7 +139,7 @@ func (f *ImageField) fetchHistogram(filterParams *api.FilterParams, invert bool,
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	prefixedVarName := f.featureVarName(mode)
 
@@ -183,7 +183,7 @@ func (f *ImageField) fetchHistogram(filterParams *api.FilterParams, invert bool,
 func (f *ImageField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (*api.Histogram, error) {
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (f *ImageField) fetchPredictedSummaryData(resultURI string, datasetResult s
 	targetName := f.featureVarName(mode)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/multibandimage.go
+++ b/api/model/storage/postgres/multibandimage.go
@@ -139,7 +139,7 @@ func (f *MultiBandImageField) fetchHistogram(filterParams *api.FilterParams, inv
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	prefixedVarName := f.featureVarName(mode)
 
@@ -184,7 +184,7 @@ func (f *MultiBandImageField) fetchHistogram(filterParams *api.FilterParams, inv
 func (f *MultiBandImageField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (*api.Histogram, error) {
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (f *MultiBandImageField) fetchPredictedSummaryData(resultURI string, datase
 	targetName := f.featureVarName(mode)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -130,7 +130,7 @@ func (f *NumericalField) fetchHistogram(filterParams *api.FilterParams, invert b
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 	wheres = append(wheres, f.getNaNFilter())
 
 	// need the extrema to calculate the histogram interval
@@ -180,7 +180,7 @@ func (f *NumericalField) fetchHistogramByResult(resultURI string, filterParams *
 	fromClause := f.getFromClause(false)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -457,7 +457,7 @@ func (f *NumericalField) fetchPredictedSummaryData(resultURI string, datasetResu
 	histogramName, bucketQuery, histogramQuery := f.getResultHistogramAggQuery(extrema, resultVariable, numBuckets)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +548,7 @@ func (f *NumericalField) FetchNumericalStats(filterParams *api.FilterParams, inv
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 	wheres = append(wheres, f.getNaNFilter())
 
 	where := ""
@@ -576,7 +576,7 @@ func (f *NumericalField) FetchNumericalStatsByResult(resultURI string, filterPar
 	fromClause := f.getFromClause(false)
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/remote_sensing.go
+++ b/api/model/storage/postgres/remote_sensing.go
@@ -101,7 +101,7 @@ func (f *RemoteSensingField) fetchHistogram(filterParams *api.FilterParams, inve
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -248,7 +248,7 @@ func (f *RemoteSensingField) parseExtrema(rows *pgx.Rows) (*api.Extrema, *api.Ex
 
 func (f *RemoteSensingField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams, numBuckets int) (*api.Histogram, error) {
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -195,7 +195,7 @@ func (s *Storage) fetchResidualsHistogram(resultURI string, datasetName, storage
 	params = append(params, variable.Name)
 
 	wheres := make([]string, 0)
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
+	wheres, params = s.buildFilteredQueryWhere(datasetName, wheres, params, "", filterParams, false)
 
 	where := ""
 	if len(wheres) > 0 {

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -584,7 +584,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 	// Create the filter portion of the where clause.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, dataTableAlias, genericFilterParams, false)
+	wheres, params = s.buildFilteredQueryWhere(dataset, wheres, params, dataTableAlias, genericFilterParams, false)
 
 	// Add the predicted filter into the where clause if it was included in the filter set
 	if filters.predictedFilter != nil {

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -763,12 +763,17 @@ func (s *Storage) FetchPredictedSummary(dataset string, storageName string, resu
 		return nil, err
 	}
 
+	countCol, err := s.getCountCol(dataset, mode)
+	if err != nil {
+		return nil, err
+	}
+
 	// use the variable type to guide the summary creation
 	var field Field
 	if model.IsNumerical(variable.Type) {
-		field = NewNumericalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type, "")
+		field = NewNumericalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type, countCol)
 	} else if model.IsCategorical(variable.Type) {
-		field = NewCategoricalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type, "")
+		field = NewCategoricalField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type, countCol)
 	} else if model.IsVector(variable.Type) {
 		field = NewVectorField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type)
 	} else {

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -277,7 +277,7 @@ func (f *TextField) getTopCategories(filterParams *api.FilterParams, invert bool
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -324,7 +324,7 @@ func (f *TextField) fetchHistogram(filterParams *api.FilterParams, invert bool) 
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -358,7 +358,7 @@ func (f *TextField) fetchHistogram(filterParams *api.FilterParams, invert bool) 
 func (f *TextField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams) (*api.Histogram, error) {
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +471,7 @@ func (f *TextField) fetchPredictedSummaryData(resultURI string, datasetResult st
 	targetName := f.Key
 
 	// get filter where / params
-	wheres, params, err := f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -222,7 +222,7 @@ func (s *Storage) FetchTimeseries(dataset string, storageName string, timeseries
 	wheres = append(wheres, fmt.Sprintf("\"%s\" = $1", timeseriesColName))
 	params = append(params, timeseriesURI)
 
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", filterParams, invert)
+	wheres, params = s.buildFilteredQueryWhere(dataset, wheres, params, "", filterParams, invert)
 	where := fmt.Sprintf("WHERE %s", strings.Join(wheres, " AND "))
 
 	// Get count by category.
@@ -283,7 +283,7 @@ func (s *Storage) FetchTimeseriesForecast(dataset string, storageName string, ti
 	wheres = append(wheres, fmt.Sprintf("\"%s\" = $1", timeseriesColName))
 	params = append(params, timeseriesURI)
 
-	wheres, params = s.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
+	wheres, params = s.buildFilteredQueryWhere(dataset, wheres, params, "", filterParams, false)
 
 	params = append(params, resultURI)
 	wheres = append(wheres, fmt.Sprintf("result.result_id = $%d", len(params)))
@@ -413,7 +413,7 @@ func (f *TimeSeriesField) fetchHistogram(filterParams *api.FilterParams, invert 
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
-	wheres, params = f.Storage.buildFilteredQueryWhere(wheres, params, "", filterParams, false)
+	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, false)
 
 	where := ""
 	if len(wheres) > 0 {
@@ -454,7 +454,7 @@ func (f *TimeSeriesField) fetchHistogramByResult(resultURI string, filterParams 
 	var err error
 	if f.Type != "timeseries" {
 		// get filter where / params
-		wheres, params, err = f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+		wheres, params, err = f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 		if err != nil {
 			return nil, err
 		}
@@ -583,7 +583,7 @@ func (f *TimeSeriesField) fetchPredictedSummaryData(resultURI string, datasetRes
 	var err error
 	if f.Type != "timeseries" {
 		// get filter where / params
-		wheres, params, err = f.Storage.buildResultQueryFilters(f.DatasetStorageName, resultURI, filterParams)
+		wheres, params, err = f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
 		if err != nil {
 			return nil, err
 		}

--- a/api/routes/correctness_summary.go
+++ b/api/routes/correctness_summary.go
@@ -38,6 +38,13 @@ func CorrectnessSummaryHandler(solutionCtor api.SolutionStorageCtor, dataCtor ap
 		dataset := pat.Param(r, "dataset")
 		storageName := model.NormalizeDatasetID(dataset)
 
+		// get variable summary mode
+		mode, err := api.SummaryModeFromString(pat.Param(r, "mode"))
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
 		resultUUID, err := url.PathUnescape(pat.Param(r, "results-uuid"))
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable to unescape results uuid"))
@@ -78,7 +85,7 @@ func CorrectnessSummaryHandler(solutionCtor api.SolutionStorageCtor, dataCtor ap
 		}
 
 		// fetch summary histogram
-		summary, err := data.FetchCorrectnessSummary(dataset, storageName, res.ResultURI, filterParams)
+		summary, err := data.FetchCorrectnessSummary(dataset, storageName, res.ResultURI, filterParams, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/public/components/GeocoordinateFacet.vue
+++ b/public/components/GeocoordinateFacet.vue
@@ -827,7 +827,7 @@ export default Vue.extend({
       updateHighlight(this.$router, {
         context: this.instanceName,
         dataset: this.dataset,
-        key: LON_LAT_KEY,
+        key: this.summary.key,
         value: value
       });
     },

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -91,7 +91,7 @@ function updateCurrentSolutionResults(
     .getRouteTask(store)
     .includes(TaskTypes.FORECASTING);
 
-  const varModes = context.getters.getDecodedVarModes;
+  const varModes: Map<string, SummaryMode> = context.getters.getDecodedVarModes;
 
   resultsActions.fetchResultTableData(store, {
     dataset: req.dataset,
@@ -142,9 +142,11 @@ function updateCurrentSolutionResults(
   } else if (isClassification) {
     resultsActions.fetchCorrectnessSummary(store, {
       dataset: req.dataset,
-      target: req.target,
       solutionId: res.solutionId,
-      highlight: context.getters.getDecodedHighlight
+      highlight: context.getters.getDecodedHighlight,
+      varMode: varModes.has(req.target)
+        ? varModes.get(req.target)
+        : SummaryMode.Default
     });
   }
 }
@@ -222,9 +224,11 @@ function updateSolutionResults(
   } else if (isClassification) {
     resultsActions.fetchCorrectnessSummary(store, {
       dataset: req.dataset,
-      target: req.target,
       solutionId: res.solutionId,
-      highlight: context.getters.getDecodedHighlight
+      highlight: context.getters.getDecodedHighlight,
+      varMode: varModes.has(req.target)
+        ? varModes.get(req.target)
+        : SummaryMode.Default
     });
   }
 }

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -16,7 +16,8 @@ import {
   createPendingSummary,
   createErrorSummary,
   createEmptyTableData,
-  fetchSummaryExemplars
+  fetchSummaryExemplars,
+  validateArgs
 } from "../../util/data";
 import { getters as resultGetters } from "../results/module";
 import { getters as dataGetters } from "../dataset/module";
@@ -549,17 +550,14 @@ export const actions = {
     context: ResultsContext,
     args: {
       dataset: string;
-      target: string;
       solutionId: string;
       highlight: Highlight;
+      varMode: SummaryMode;
     }
   ) {
-    if (!args.dataset) {
-      console.warn("`dataset` argument is missing");
-      return null;
-    }
-    if (!args.solutionId) {
-      console.warn("`pipelineId` argument is missing");
+    if (
+      !validateArgs(args, ["dataset", "solutionId", "highlight", "varMode"])
+    ) {
       return null;
     }
 
@@ -591,7 +589,7 @@ export const actions = {
       resultGetters.getCorrectnessSummaries(context),
       mutations.updateCorrectnessSummaries,
       filterParams,
-      SummaryMode.Default
+      args.varMode
     );
   },
 
@@ -600,15 +598,17 @@ export const actions = {
     context: ResultsContext,
     args: {
       dataset: string;
-      target: string;
       requestIds: string[];
       highlight: Highlight;
+      varMode: SummaryMode;
     }
   ) {
-    if (!args.requestIds) {
-      console.warn("`requestIds` argument is missing");
+    if (
+      !validateArgs(args, ["dataset", "requestIds", "highlight", "varMode"])
+    ) {
       return null;
     }
+
     const solutions = getSolutionsBySolutionRequestIds(
       context.rootState.requestsModule.solutions,
       args.requestIds
@@ -617,9 +617,9 @@ export const actions = {
       solutions.map(solution => {
         return actions.fetchCorrectnessSummary(context, {
           dataset: args.dataset,
-          target: args.target,
           solutionId: solution.solutionId,
-          highlight: args.highlight
+          highlight: args.highlight,
+          varMode: args.varMode
         });
       })
     );

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -410,7 +410,8 @@ export const actions = {
     const trainingVariables =
       context.getters.getActiveSolutionTrainingVariables;
     const highlight = context.getters.getDecodedHighlight;
-    const varModes = context.getters.getDecodedVarModes;
+    const varModes: Map<string, SummaryMode> =
+      context.getters.getDecodedVarModes;
 
     resultActions.fetchResultTableData(store, {
       dataset: dataset,
@@ -462,9 +463,11 @@ export const actions = {
     } else if (task.includes(TaskTypes.CLASSIFICATION)) {
       resultActions.fetchCorrectnessSummaries(store, {
         dataset: dataset,
-        target: target,
         requestIds: requestIds,
-        highlight: highlight
+        highlight: highlight,
+        varMode: varModes.has(target)
+          ? varModes.get(target)
+          : SummaryMode.Default
       });
     } else {
       console.error(`unhandled task type ${task}`);


### PR DESCRIPTION
Fixed routes and queries to properly apply the remote sensing (and in general summary modes) when getting counts. Also fixed the filter building for bivariate filtering to assume a remote sensing group if the key isnt a concatenation of fields.