### PR TITLE
Timeseries Result Queries

### DIFF
--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -212,7 +212,7 @@ func (f *CategoricalField) fetchHistogramByResult(resultURI string, filterParams
 	query := fmt.Sprintf(
 		`SELECT data."%s", COUNT(%s) AS count
 		 FROM %s data INNER JOIN %s result ON data."%s" = result.index
-		 WHERE result.result_id = $%d %s
+		 WHERE result.result_id = $%d AND result.value != '' %s
 		 GROUP BY "%s"
 		 ORDER BY count desc, "%s" LIMIT %d;`,
 		f.Key, f.Count, fromClause, f.Storage.getResultTable(f.DatasetStorageName),

--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -155,6 +155,10 @@ func (f *CategoricalField) getTopCategories(filterParams *api.FilterParams, inve
 			}
 			categories = append(categories, category)
 		}
+		err = rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
 	}
 	return categories, nil
 }
@@ -257,6 +261,10 @@ func (f *CategoricalField) parseHistogram(rows pgx.Rows) (*api.Histogram, error)
 			if bucketCount > max {
 				max = bucketCount
 			}
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -301,6 +301,10 @@ func (f *CoordinateField) parseHistogram(rows pgx.Rows, xExtrema *api.Extrema, y
 		}
 		xBuckets[xBucket].Buckets[yBucket].Count += yRowBucketCount
 	}
+	err := rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	// assign histogram attributes
 	return &api.Histogram{

--- a/api/model/storage/postgres/correctness.go
+++ b/api/model/storage/postgres/correctness.go
@@ -142,6 +142,10 @@ func (s *Storage) parseHistogram(rows pgx.Rows, variable *model.Variable) (*api.
 			}
 			countMap[predictedTerm][targetTerm] = bucketCount
 		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
 	}
 
 	correctBucket := &api.Bucket{

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -315,8 +315,13 @@ func (s *Storage) insertBatchData(db *pg.DB, storageName string, varNames []stri
 	count := 0
 	for i := 0; i < len(inserts); i++ {
 		insertSQL = fmt.Sprintf("%s %s", insertSQL, basicInsert)
-		for j := 0; j < fieldCount; j++ {
+		for j := 0; j < len(inserts[i]); j++ {
 			params = append(params, inserts[i][j])
+		}
+
+		// append nil for remaining fields
+		for j := len(inserts[i]); j < fieldCount; j++ {
+			params = append(params, nil)
 		}
 
 		count = count + 1

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -120,15 +120,13 @@ func (f *DateTimeField) FetchSummaryData(resultURI string, filterParams *api.Fil
 }
 
 func (f *DateTimeField) fetchHistogram(filterParams *api.FilterParams, invert bool, numBuckets int) (*api.Histogram, error) {
-	return f.fetchHistogramWithJoins(filterParams, invert, numBuckets, nil)
+	return f.fetchHistogramWithJoins(filterParams, invert, numBuckets, nil, []string{}, []interface{}{})
 }
 
-func (f *DateTimeField) fetchHistogramWithJoins(filterParams *api.FilterParams, invert bool, numBuckets int, joins []*joinDefinition) (*api.Histogram, error) {
+func (f *DateTimeField) fetchHistogramWithJoins(filterParams *api.FilterParams, invert bool, numBuckets int, joins []*joinDefinition, wheres []string, params []interface{}) (*api.Histogram, error) {
 	fromClause := f.getFromClause(true)
 
 	// create the filter for the query.
-	wheres := make([]string, 0)
-	params := make([]interface{}, 0)
 	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 
 	// need the extrema to calculate the histogram interval

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -308,6 +308,10 @@ func (f *DateTimeField) parseHistogram(rows pgx.Rows, extrema *api.Extrema, numB
 
 		}
 	}
+	err := rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	// assign histogram attributes
 	return &api.Histogram{

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -38,7 +38,7 @@ type Field interface {
 type TimelineField interface {
 	Field
 	fetchHistogram(filterParams *api.FilterParams, invert bool, numBuckets int) (*api.Histogram, error)
-	fetchHistogramWithJoins(filterParams *api.FilterParams, invert bool, numBuckets int, joins []*joinDefinition) (*api.Histogram, error)
+	fetchHistogramWithJoins(filterParams *api.FilterParams, invert bool, numBuckets int, joins []*joinDefinition, wheres []string, params []interface{}) (*api.Histogram, error)
 }
 
 // BasicField provides access to baseline field data

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -38,6 +38,7 @@ type Field interface {
 type TimelineField interface {
 	Field
 	fetchHistogram(filterParams *api.FilterParams, invert bool, numBuckets int) (*api.Histogram, error)
+	fetchHistogramWithJoins(filterParams *api.FilterParams, invert bool, numBuckets int, joins []*joinDefinition) (*api.Histogram, error)
 }
 
 // BasicField provides access to baseline field data
@@ -79,6 +80,19 @@ func (b *BasicField) GetLabel() string {
 // GetType returns the internal Distil type of the field.
 func (b *BasicField) GetType() string {
 	return b.Type
+}
+
+func createJoinStatements(joins []*joinDefinition) string {
+	joinSQL := ""
+	for _, j := range joins {
+		joinSQL = fmt.Sprintf("%s INNER JOIN %s AS %s ON %s.\"%s\" = %s.\"%s\"",
+			joinSQL, j.joinTableName, j.joinAlias, j.baseAlias, j.baseColumn, j.joinAlias, j.joinColumn)
+	}
+	if len(joinSQL) > 0 {
+		joinSQL = fmt.Sprintf("INNER JOIN %s", joinSQL)
+	}
+
+	return joinSQL
 }
 
 // Checks to see if the highlighted variable has cluster data.  If so, the highlight key will be switched to the

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -88,9 +88,6 @@ func createJoinStatements(joins []*joinDefinition) string {
 		joinSQL = fmt.Sprintf("%s INNER JOIN %s AS %s ON %s.\"%s\" = %s.\"%s\"",
 			joinSQL, j.joinTableName, j.joinAlias, j.baseAlias, j.baseColumn, j.joinAlias, j.joinColumn)
 	}
-	if len(joinSQL) > 0 {
-		joinSQL = fmt.Sprintf("INNER JOIN %s", joinSQL)
-	}
 
 	return joinSQL
 }

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -77,6 +77,10 @@ func (s *Storage) parseFilteredData(dataset string, variables []*model.Variable,
 
 			result.Values = append(result.Values, weightedValues)
 		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
 
 		fields := rows.FieldDescriptions()
 		columns := make([]api.Column, len(fields))

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -124,7 +124,7 @@ func (s *Storage) buildIncludeFilter(dataset string, wheres []string, params []i
 	case model.DatetimeFilter:
 		// datetime
 		// extract epoch for comparison
-		where := fmt.Sprintf("cast(extract(epoch from %s) as double precision) >= $%d AND cast(extract(epoch from %s) as double precision) <= $%d", name, len(params)+1, name, len(params)+2)
+		where := fmt.Sprintf("cast(extract(epoch from %s) as double precision) >= $%d AND cast(extract(epoch from %s) as double precision) < $%d", name, len(params)+1, name, len(params)+2)
 		wheres = append(wheres, where)
 		params = append(params, *filter.Min)
 		params = append(params, *filter.Max)
@@ -132,7 +132,7 @@ func (s *Storage) buildIncludeFilter(dataset string, wheres []string, params []i
 	case model.NumericalFilter:
 		// numerical
 		// cast to double precision in case of string based representation
-		where := fmt.Sprintf("cast(%s as double precision) >= $%d AND cast(%s as double precision) <= $%d", name, len(params)+1, name, len(params)+2)
+		where := fmt.Sprintf("cast(%s as double precision) >= $%d AND cast(%s as double precision) < $%d", name, len(params)+1, name, len(params)+2)
 		wheres = append(wheres, where)
 		params = append(params, *filter.Min)
 		params = append(params, *filter.Max)
@@ -156,7 +156,7 @@ func (s *Storage) buildIncludeFilter(dataset string, wheres []string, params []i
 		if err != nil {
 			log.Warnf("%+v", err)
 		} else {
-			where := fmt.Sprintf("cast(%s as double precision) >= $%d AND cast(%s as double precision) <= $%d AND cast(%s as double precision) >= $%d AND cast(%s as double precision) <= $%d",
+			where := fmt.Sprintf("cast(%s as double precision) >= $%d AND cast(%s as double precision) < $%d AND cast(%s as double precision) >= $%d AND cast(%s as double precision) < $%d",
 				fields[0], len(params)+1, fields[0], len(params)+2, fields[1], len(params)+3, fields[1], len(params)+4)
 			wheres = append(wheres, where)
 			params = append(params, filter.Bounds.MinX)
@@ -247,7 +247,7 @@ func (s *Storage) buildExcludeFilter(dataset string, wheres []string, params []i
 	case model.DatetimeFilter:
 		// datetime
 		// extract epoch for comparison
-		where := fmt.Sprintf("cast(extract(epoch from %s) as double precision) < $%d OR cast(extract(epoch from %s) as double precision) > $%d", name, len(params)+1, name, len(params)+2)
+		where := fmt.Sprintf("cast(extract(epoch from %s) as double precision) < $%d OR cast(extract(epoch from %s) as double precision) >= $%d", name, len(params)+1, name, len(params)+2)
 		wheres = append(wheres, where)
 		params = append(params, *filter.Min)
 		params = append(params, *filter.Max)
@@ -255,7 +255,7 @@ func (s *Storage) buildExcludeFilter(dataset string, wheres []string, params []i
 	case model.NumericalFilter:
 		// numerical
 		//TODO: WHY DOES THIS QUERY NOT CAST TO DOUBLE LIKE THE INCLUDE???
-		where := fmt.Sprintf("(%s < $%d OR %s > $%d)", name, len(params)+1, name, len(params)+2)
+		where := fmt.Sprintf("(%s < $%d OR %s >= $%d)", name, len(params)+1, name, len(params)+2)
 		wheres = append(wheres, where)
 		params = append(params, *filter.Min)
 		params = append(params, *filter.Max)
@@ -279,7 +279,7 @@ func (s *Storage) buildExcludeFilter(dataset string, wheres []string, params []i
 		if err != nil {
 			log.Warnf("%+v", err)
 		} else {
-			where := fmt.Sprintf("(cast(%s as double precision) < $%d OR cast(%s as double precision) > $%d) OR (cast(%s as double precision) < $%d OR cast(%s as double precision) > $%d)",
+			where := fmt.Sprintf("(cast(%s as double precision) < $%d OR cast(%s as double precision) >= $%d) OR (cast(%s as double precision) < $%d OR cast(%s as double precision) >= $%d)",
 				fields[0], len(params)+1, fields[0], len(params)+2, fields[1], len(params)+3, fields[1], len(params)+4)
 			wheres = append(wheres, where)
 			params = append(params, filter.Bounds.MinX)

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -480,7 +480,7 @@ func (s *Storage) buildPredictedResultWhere(dataset string, wheres []string, par
 
 func (s *Storage) buildResultQueryFilters(dataset string, storageName string, resultURI string, filterParams *api.FilterParams) ([]string, []interface{}, error) {
 	// pull filters generated against the result facet out for special handling
-	filters := s.splitFilters(filterParams)
+	filters := splitFilters(filterParams)
 
 	genericFilterParams := &api.FilterParams{
 		Filters: filters.genericFilters,
@@ -519,7 +519,7 @@ type filters struct {
 	correctnessFilter *model.Filter
 }
 
-func (s *Storage) splitFilters(filterParams *api.FilterParams) *filters {
+func splitFilters(filterParams *api.FilterParams) *filters {
 	// Groups filters for handling downstream
 	var predictedFilter *model.Filter
 	var residualFilter *model.Filter

--- a/api/model/storage/postgres/image.go
+++ b/api/model/storage/postgres/image.go
@@ -131,6 +131,10 @@ func (f *ImageField) fetchRepresentationImages(categoryBuckets []*api.Bucket, mo
 			imageFiles = append(imageFiles, imageFile)
 		}
 		rows.Close()
+		err = rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
 	}
 	return imageFiles, nil
 }
@@ -258,6 +262,10 @@ func (f *ImageField) parseHistogram(rows pgx.Rows, mode api.SummaryMode) (*api.H
 			if bucketCount > max {
 				max = bucketCount
 			}
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 

--- a/api/model/storage/postgres/multibandimage.go
+++ b/api/model/storage/postgres/multibandimage.go
@@ -131,6 +131,10 @@ func (f *MultiBandImageField) fetchRepresentationGroups(categoryBuckets []*api.B
 			imageFiles = append(imageFiles, imageFile)
 		}
 		rows.Close()
+		err = rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
 	}
 	return imageFiles, nil
 }
@@ -259,6 +263,10 @@ func (f *MultiBandImageField) parseHistogram(rows pgx.Rows, mode api.SummaryMode
 			if bucketCount > max {
 				max = bucketCount
 			}
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -153,7 +153,7 @@ func (f *NumericalField) fetchHistogramWithJoins(filterParams *api.FilterParams,
 	joinSQL := createJoinStatements(joins)
 
 	// Create the complete query string.
-	query := fmt.Sprintf("SELECT %s as bucket, CAST(%s as double precision) AS %s, COUNT(%s) AS count FROM %s %s %s GROUP BY %s ORDER BY %s;",
+	query := fmt.Sprintf("SELECT %s as bucket, CAST(%s as double precision) AS %s, COUNT(%s) AS count FROM %s AS bb %s %s GROUP BY %s ORDER BY %s;",
 		bucketQuery, histogramQuery, histogramName, f.Count, fromClause, joinSQL, where, bucketQuery, histogramName)
 
 	// execute the postgres query

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -125,15 +125,13 @@ func (f *NumericalField) FetchSummaryData(resultURI string, filterParams *api.Fi
 }
 
 func (f *NumericalField) fetchHistogram(filterParams *api.FilterParams, invert bool, numBuckets int) (*api.Histogram, error) {
-	return f.fetchHistogramWithJoins(filterParams, invert, numBuckets, nil)
+	return f.fetchHistogramWithJoins(filterParams, invert, numBuckets, nil, []string{}, []interface{}{})
 }
 
-func (f *NumericalField) fetchHistogramWithJoins(filterParams *api.FilterParams, invert bool, numBuckets int, joins []*joinDefinition) (*api.Histogram, error) {
+func (f *NumericalField) fetchHistogramWithJoins(filterParams *api.FilterParams, invert bool, numBuckets int, joins []*joinDefinition, wheres []string, params []interface{}) (*api.Histogram, error) {
 	fromClause := f.getFromClause(true)
 
 	// create the filter for the query.
-	wheres := make([]string, 0)
-	params := make([]interface{}, 0)
 	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams, invert)
 	wheres = append(wheres, f.getNaNFilter())
 

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -125,6 +125,10 @@ func (f *NumericalField) FetchSummaryData(resultURI string, filterParams *api.Fi
 }
 
 func (f *NumericalField) fetchHistogram(filterParams *api.FilterParams, invert bool, numBuckets int) (*api.Histogram, error) {
+	return f.fetchHistogramWithJoins(filterParams, invert, numBuckets, nil)
+}
+
+func (f *NumericalField) fetchHistogramWithJoins(filterParams *api.FilterParams, invert bool, numBuckets int, joins []*joinDefinition) (*api.Histogram, error) {
 	fromClause := f.getFromClause(true)
 
 	// create the filter for the query.
@@ -148,9 +152,11 @@ func (f *NumericalField) fetchHistogram(filterParams *api.FilterParams, invert b
 		where = fmt.Sprintf("WHERE %s", strings.Join(wheres, " AND "))
 	}
 
+	joinSQL := createJoinStatements(joins)
+
 	// Create the complete query string.
-	query := fmt.Sprintf("SELECT %s as bucket, CAST(%s as double precision) AS %s, COUNT(%s) AS count FROM %s %s GROUP BY %s ORDER BY %s;",
-		bucketQuery, histogramQuery, histogramName, f.Count, fromClause, where, bucketQuery, histogramName)
+	query := fmt.Sprintf("SELECT %s as bucket, CAST(%s as double precision) AS %s, COUNT(%s) AS count FROM %s %s %s GROUP BY %s ORDER BY %s;",
+		bucketQuery, histogramQuery, histogramName, f.Count, fromClause, joinSQL, where, bucketQuery, histogramName)
 
 	// execute the postgres query
 	res, err := f.Storage.client.Query(query, params...)

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -469,6 +469,7 @@ func (f *NumericalField) fetchPredictedSummaryData(resultURI string, datasetResu
 
 	wheres = append(wheres, fmt.Sprintf("result.result_id = $%d AND result.target = $%d ", len(params)+1, len(params)+2))
 	params = append(params, resultURI, f.Key)
+	wheres = append(wheres, fmt.Sprintf("%s != ''", resultVariable.Name))
 
 	// Create the complete query string.
 	query := fmt.Sprintf(`

--- a/api/model/storage/postgres/pipeline.go
+++ b/api/model/storage/postgres/pipeline.go
@@ -147,6 +147,10 @@ func (s *Storage) FetchSolution(solutionID string) (*api.Solution, error) {
 		defer rows.Close()
 	}
 	rows.Next()
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	solution, err := s.parseSolution(rows)
 	if err != nil {
@@ -219,6 +223,10 @@ func (s *Storage) parseSolutionWeight(rows pgx.Rows) ([]*api.SolutionWeight, err
 			Weight:       weight,
 		})
 	}
+	err := rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return results, nil
 }
@@ -261,6 +269,10 @@ func (s *Storage) parseSolutionState(rows pgx.Rows) ([]*api.SolutionState, error
 			CreatedTime: createdTime,
 		})
 	}
+	err := rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return results, nil
 }
@@ -295,6 +307,10 @@ func (s *Storage) parseSolutionResult(rows pgx.Rows) ([]*api.SolutionResult, err
 			Dataset:          dataset,
 		})
 	}
+	err := rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return results, nil
 }
@@ -328,6 +344,10 @@ func (s *Storage) parseSolutionFeatureWeight(resultURI string, rows pgx.Rows) (*
 			}
 
 			result.Weights = output
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 
@@ -523,6 +543,10 @@ func (s *Storage) FetchSolutionScores(solutionID string) ([]*api.SolutionScore, 
 			SortMultiplier: compute.GetMetricScoreMultiplier(metric),
 		})
 	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return results, nil
 }
@@ -570,6 +594,10 @@ func (s *Storage) FetchSolutionsByDatasetTarget(dataset string, target string) (
 		}
 		solutions = append(solutions, solution)
 	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return solutions, nil
 }
@@ -607,6 +635,10 @@ func (s *Storage) FetchSolutionsByRequestID(requestID string) ([]*api.Solution, 
 			return nil, err
 		}
 		solutions = append(solutions, solution)
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
 	}
 
 	return solutions, nil

--- a/api/model/storage/postgres/prediction.go
+++ b/api/model/storage/postgres/prediction.go
@@ -50,6 +50,10 @@ func (s *Storage) FetchPrediction(requestID string) (*api.Prediction, error) {
 		defer rows.Close()
 	}
 	rows.Next()
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return s.loadPrediction(rows)
 }
@@ -75,6 +79,10 @@ func (s *Storage) FetchPredictionsByFittedSolutionID(fittedSolutionID string) ([
 			return nil, err
 		}
 		predictions = append(predictions, prediction)
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
 	}
 
 	return predictions, nil

--- a/api/model/storage/postgres/remote_sensing.go
+++ b/api/model/storage/postgres/remote_sensing.go
@@ -373,6 +373,10 @@ func (f *RemoteSensingField) parseHistogram(rows pgx.Rows, xExtrema *api.Extrema
 		}
 		xBuckets[xBucket].Buckets[yBucket].Count += yRowBucketCount
 	}
+	err := rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	// assign histogram attributes
 	return &api.Histogram{

--- a/api/model/storage/postgres/request.go
+++ b/api/model/storage/postgres/request.go
@@ -99,6 +99,10 @@ func (s *Storage) FetchRequest(requestID string) (*api.Request, error) {
 		defer rows.Close()
 	}
 	rows.Next()
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return s.loadRequest(rows)
 }
@@ -118,6 +122,10 @@ func (s *Storage) FetchRequestBySolutionID(solutionID string) (*api.Request, err
 		defer rows.Close()
 	}
 	rows.Next()
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return s.loadRequest(rows)
 }
@@ -137,6 +145,10 @@ func (s *Storage) FetchRequestByFittedSolutionID(fittedSolutionID string) (*api.
 		defer rows.Close()
 	}
 	rows.Next()
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return s.loadRequest(rows)
 }
@@ -202,6 +214,10 @@ func (s *Storage) FetchRequestFeatures(requestID string) ([]*api.Feature, error)
 			FeatureName: featureName,
 			FeatureType: featureType,
 		})
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
 	}
 
 	return results, nil
@@ -278,6 +294,10 @@ func (s *Storage) FetchRequestFilters(requestID string, features []*api.Feature)
 			))
 		}
 	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	for _, feature := range features {
 		filters.Variables = append(filters.Variables, feature.FeatureName)
@@ -334,6 +354,10 @@ func (s *Storage) FetchRequestByDatasetTarget(dataset string, target string) ([]
 			return nil, err
 		}
 		requests = append(requests, request)
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
 	}
 	return requests, nil
 }

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -153,7 +153,7 @@ func (s *Storage) fetchResidualsExtrema(resultURI string, storageName string, va
 	fromClause := getResultJoin("res", storageName)
 
 	// create a query that does min and max aggregations for each variable
-	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE result_id = $1 AND target = $2;", aggQuery, fromClause)
+	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE result_id = $1 AND target = $2 AND value != '';", aggQuery, fromClause)
 
 	// execute the postgres query
 	res, err := s.client.Query(queryString, resultURI, targetName)

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -206,8 +206,9 @@ func (s *Storage) fetchResidualsHistogram(resultURI string, datasetName, storage
 	query := fmt.Sprintf(`
 		SELECT %s as bucket, CAST(%s as double precision) AS %s, COUNT(*) AS count
 		FROM %s
-		WHERE result_id = $1 AND target = $2 %s
-		GROUP BY %s ORDER BY %s;`, bucketQuery, histogramQuery, histogramName, fromClause, where, bucketQuery, histogramName)
+		WHERE result_id = $1 AND target = $2 AND %s != '' %s
+		GROUP BY %s ORDER BY %s;`, bucketQuery, histogramQuery, histogramName,
+		fromClause, resultVariable.Name, where, bucketQuery, histogramName)
 
 	// execute the postgres query
 	res, err := s.client.Query(query, params...)

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -680,7 +680,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 		"SELECT %s"+
 			"FROM %s as predicted inner join %s as data on data.\"%s\" = predicted.index "+
 			"LEFT OUTER JOIN %s as weights on weights.\"%s\" = predicted.index AND weights.result_id = predicted.result_id "+
-			"WHERE predicted.result_id = $%d AND target = $%d",
+			"WHERE predicted.result_id = $%d AND target = $%d AND predicted.value != ''",
 		selectedVars, storageNameResult, storageName, model.D3MIndexFieldName,
 		s.getSolutionFeatureWeightTable(storageName), model.D3MIndexFieldName,
 		len(params)+1, len(params)+2)

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -595,7 +595,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 	fieldsExplain := addTableAlias("weights", fields, true)
 
 	// break filters out groups for specific handling
-	filters := s.splitFilters(filterParams)
+	filters := splitFilters(filterParams)
 
 	genericFilterParams := &api.FilterParams{
 		Filters: filters.genericFilters,

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -65,6 +65,10 @@ func (s *Storage) getResultTargetName(storageName string, resultURI string) (str
 
 		return targetName, nil
 	}
+	err = rows.Err()
+	if err != nil {
+		return "", errors.Wrapf(err, "error reading data from postgres")
+	}
 
 	return "", errors.Errorf("Target feature for result URI `%s` not found", resultURI)
 }
@@ -345,6 +349,10 @@ func (s *Storage) parseFilteredResults(variables []*model.Variable, numRows int,
 				}
 			}
 			result.Values = append(result.Values, weightedValues)
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 		result.Columns = columns
 	} else {

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -162,7 +162,12 @@ func (f *TextField) parseTimeExtrema(timeVar *model.Variable, rows pgx.Rows) (*a
 		if !exists {
 			return nil, fmt.Errorf("no rows in extrema query result")
 		}
-		err := rows.Scan(&minValue, &maxValue)
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
+
+		err = rows.Scan(&minValue, &maxValue)
 		if err != nil {
 			return nil, errors.Wrap(err, "no min / max aggregation found")
 		}
@@ -265,6 +270,10 @@ func (f *TextField) parseTimeHistogram(rows pgx.Rows, extrema *api.Extrema, inte
 			buckets[len(buckets)-1].Count += bucketCount
 		}
 	}
+	err := rows.Err()
+	if err != nil {
+		return nil, errors.Wrapf(err, "error reading data from postgres")
+	}
 	// assign histogram attributes
 	return &api.Histogram{
 		Extrema:         binning.Rounded,
@@ -315,6 +324,10 @@ func (f *TextField) getTopCategories(filterParams *api.FilterParams, invert bool
 				return nil, err
 			}
 			categories = append(categories, category)
+		}
+		err = rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 	return categories, nil
@@ -422,6 +435,10 @@ func (f *TextField) parseHistogram(rows pgx.Rows) (*api.Histogram, error) {
 			if bucketCount > max {
 				max = bucketCount
 			}
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -78,6 +78,10 @@ func (s *Storage) parseTimeseries(rows pgx.Rows) ([]*api.TimeseriesObservation, 
 				Time:  x,
 			})
 		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
 	}
 
 	return points, nil
@@ -99,6 +103,10 @@ func (s *Storage) parseDateTimeTimeseries(rows pgx.Rows) ([]*api.TimeseriesObser
 				Value: api.NullableFloat64(value),
 				Time:  float64(time.Unix() * 1000),
 			})
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 
@@ -123,6 +131,10 @@ func (s *Storage) parseTimeseriesForecast(rows pgx.Rows) ([]*api.TimeseriesObser
 				ConfidenceLow:  api.NullableFloat64(confidenceLow),
 				ConfidenceHigh: api.NullableFloat64(confidenceHigh),
 			})
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 
@@ -149,6 +161,10 @@ func (s *Storage) parseDateTimeTimeseriesForecast(rows pgx.Rows) ([]*api.Timeser
 				ConfidenceLow:  api.NullableFloat64(confidenceLow),
 				ConfidenceHigh: api.NullableFloat64(confidenceHigh),
 			})
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 
@@ -201,6 +217,10 @@ func (f *TimeSeriesField) fetchRepresentationTimeSeries(categoryBuckets []*api.B
 
 			rows.Close()
 			return nil, errors.Wrap(fmt.Errorf("timeseries id type not recognized %v", values[0]), "unable to parse timeseries id")
+		}
+		err = rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 
@@ -535,6 +555,10 @@ func (f *TimeSeriesField) parseHistogram(rows pgx.Rows, mode api.SummaryMode) (*
 			if bucketCount > max {
 				max = bucketCount
 			}
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	}
 

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -393,6 +393,8 @@ func (f *TimeSeriesField) FetchSummaryData(resultURI string, filterParams *api.F
 		}
 	}
 
+	// split the filters to make sure the result based filters can be applied properly
+
 	// Handle timeseries that use a timestamp/int as their time value, or those that use a date time.
 	var timelineField TimelineField
 	if f.XColType == model.DateTimeType {
@@ -472,16 +474,10 @@ func (f *TimeSeriesField) fetchHistogram(filterParams *api.FilterParams, invert 
 }
 
 func (f *TimeSeriesField) fetchHistogramByResult(resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (*api.Histogram, error) {
-
-	wheres := []string{}
-	params := []interface{}{}
-	var err error
-	if f.Type != "timeseries" {
-		// get filter where / params
-		wheres, params, err = f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
-		if err != nil {
-			return nil, err
-		}
+	// get filter where / params
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
+	if err != nil {
+		return nil, err
 	}
 
 	params = append(params, resultURI)
@@ -497,7 +493,7 @@ func (f *TimeSeriesField) fetchHistogramByResult(resultURI string, filterParams 
 	query := fmt.Sprintf(
 		`SELECT data."%s", COUNT(DISTINCT "%s") AS __count__
 		 FROM %s data INNER JOIN %s result ON data."%s" = result.index
-		 WHERE result.result_id = $%d %s
+		 WHERE result.result_id = $%d AND result.value != '' %s
 		 GROUP BY "%s"
 		 ORDER BY __count__ desc, "%s" LIMIT %d;`,
 		keyColName, f.IDCol, f.DatasetStorageName, f.Storage.getResultTable(f.DatasetStorageName),
@@ -605,16 +601,10 @@ func (f *TimeSeriesField) FetchPredictedSummaryData(resultURI string, datasetRes
 }
 
 func (f *TimeSeriesField) fetchPredictedSummaryData(resultURI string, datasetResult string, filterParams *api.FilterParams, extrema *api.Extrema, mode api.SummaryMode) (*api.Histogram, error) {
-
-	wheres := []string{}
-	params := []interface{}{}
-	var err error
-	if f.Type != "timeseries" {
-		// get filter where / params
-		wheres, params, err = f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
-		if err != nil {
-			return nil, err
-		}
+	// get filter where / params
+	wheres, params, err := f.Storage.buildResultQueryFilters(f.GetDatasetName(), f.DatasetStorageName, resultURI, filterParams)
+	if err != nil {
+		return nil, err
 	}
 
 	params = append(params, resultURI)

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -302,6 +302,10 @@ func (s *Storage) FetchCategoryCounts(storageName string, variable *model.Variab
 			}
 			counts[label] = count
 		}
+		err = rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
 	}
 	return counts, nil
 }
@@ -327,6 +331,10 @@ func (s *Storage) FetchRawDistinctValues(dataset string, storageName string, var
 			}
 			values = append(values, val)
 		}
+		err = rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
 	}
 	return values, nil
 }
@@ -340,5 +348,11 @@ func (s *Storage) DoesVariableExist(dataset string, storageName string, varName 
 	}
 	defer rows.Close()
 
-	return rows.Next(), nil
+	exists := rows.Next()
+	err = rows.Err()
+	if err != nil {
+		return false, errors.Wrapf(err, "error reading data from postgres")
+	}
+
+	return exists, nil
 }


### PR DESCRIPTION
Updated timeseries result handling to not crash when empty values are returned. Confidence values can also be excluded for a subset of the results without problem when ingesting results.

Added proper filtering for residuals in timeseries. Updated numerical filters to be upper bound exclusive.

Updated postgres querying to properly propagate errors. The new version of the postgres library changed how errors were to be detected.