### PR TITLE
SHAP Parsing Display Name

### DIFF
--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -127,7 +127,7 @@ func (s *Storage) PersistSolutionFeatureWeight(dataset string, storageName strin
 	fields := []string{"result_id"}
 	for dbFieldIndex, dbField := range fieldsDatabase {
 		for i := 0; i < len(fieldsWeight); i++ {
-			if fieldsMetadataMap[dbField] != nil && fieldsMetadataMap[dbField].DisplayName == fieldsWeight[i] {
+			if fieldsMetadataMap[dbField] != nil && fieldsMetadataMap[dbField].Name == fieldsWeight[i] {
 				fieldsMap[dbFieldIndex] = i + 1
 				fields = append(fields, dbField)
 			}


### PR DESCRIPTION
Switched from variable display name to name when parsing SHAP output since variable name is what TA2 expects I think. We may need to add an explicit database name field. We would then have Name, Display Name & Database Name. TA2 would work off Name, and then we could do anything else we want with the other 2.