### PR TITLE
#1699 Grid Image Facet, Drilldown & More/Less Fix

### DIFF
--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -1,5 +1,11 @@
 <template>
-  <b-modal @hide="hide" hide-footer :title="visibleTitle" :visible="visible">
+  <b-modal
+    size="lg"
+    @hide="hide"
+    hide-footer
+    :title="visibleTitle"
+    :visible="visible"
+  >
     <image-label
       v-if="item && dataFields"
       class="image-label"
@@ -93,6 +99,7 @@ export default Vue.extend({
       if (!!this.image && container) {
         container.innerHTML = "";
         container.appendChild(this.image.cloneNode() as HTMLImageElement);
+        container.children[0].style.width = "100%";
       }
     }
   }
@@ -101,10 +108,9 @@ export default Vue.extend({
 
 <style scoped>
 .image-container {
-  /* Keep the image under 25% of screen width. */
-  max-height: 25vw;
-  max-width: 25vw;
-
+  max-height: 100%;
+  max-width: 100%;
+  overflow: auto;
   text-align: center;
 }
 

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -200,6 +200,14 @@ export default Vue.extend({
         this.clearImage(elem);
         const image = this.image.cloneNode() as HTMLImageElement;
         elem.appendChild(image);
+
+        // fit image preview to available area with no overflows
+        if (
+          this.width === this.height &&
+          elem.children[0].height > elem.children[0].width
+        ) {
+          elem.children[0].style.height = elem.children[0].width + "px";
+        }
         this.hasRendered = true;
       }
     },

--- a/public/components/facets/FacetImage.vue
+++ b/public/components/facets/FacetImage.vue
@@ -6,6 +6,7 @@
     :subselection.prop="subSelection"
     :disabled.prop="!enableHighlighting"
     @facet-element-updated="updateSelection"
+    class="facet-image"
   >
     <div slot="header-label" :class="headerClass">
       <i :class="getGroupIcon(summary) + ' facet-header-icon'"></i>
@@ -19,10 +20,15 @@
       >
       </type-change-menu>
     </div>
-    <facet-template target="facet-terms-value">
+    <facet-template target="facet-terms-value" class="facet-content-container">
       <div slot="header" class="facet-image-preview-display">
         ${metadata}
       </div>
+      <div slot="label" class="facet-image-label" title="${value} ${label}">
+        ${value} ${label}
+      </div>
+      <div slot="annotation" class="collapse-unused" />
+      <div slot="value" class="collapse-unused" />
     </facet-template>
     <div slot="footer" class="facet-footer-container">
       <div v-if="facetDisplayMore" class="facet-footer-more">
@@ -155,7 +161,8 @@ export default Vue.extend({
       return this.facetValueCount - this.numToDisplay;
     },
     numToDisplay(): number {
-      return this.hasExamplars
+      return this.hasExamplars &&
+        this.summary.baseline.exemplars.length < this.baseNumToDisplay
         ? this.summary.baseline.exemplars.length
         : this.hasBaseline && this.facetValueCount < this.baseNumToDisplay
         ? this.facetValueCount
@@ -295,7 +302,29 @@ export default Vue.extend({
 });
 </script>
 
+<style>
+.facet-image .facet-terms-container {
+  max-height: 200px !important;
+  overflow-y: auto;
+  display: flex;
+  flex-wrap: wrap;
+}
+</style>
 <style scoped>
+.collapse-unused {
+  display: none;
+}
+.facet-image-label {
+  max-width: 75px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.facet-content-container {
+  display: inline-block;
+  width: 85px;
+  overflow: hidden;
+}
 .facet-image-preview-display {
   padding-left: 10px;
 }


### PR DESCRIPTION
Added CSS and updated the layout of the facet image component, also fixes the less/more behavior of that component (limiting preloading the examplars will be a separate story.) Fixed the image exploding outside of the image drilldown component with extra CSS. Fixed a similar issue in image preview checking if height is larger the than width in the event of equal size width and height and setting height to the width.