### PR TITLE
Model save improvements and result screen layout updates

### DIFF
--- a/public/components/LayerSelection.vue
+++ b/public/components/LayerSelection.vue
@@ -39,6 +39,7 @@ export default Vue.extend({
     availableBands(): BandCombination[] {
       return datasetGetters
         .getMultiBandCombinations(this.$store)
+        .slice() // copy so we don't mutate vuex store object
         .sort((a, b) => a.displayName.localeCompare(b.displayName));
     }
   },

--- a/public/components/PredictionsDataSlot.vue
+++ b/public/components/PredictionsDataSlot.vue
@@ -5,7 +5,11 @@
       v-model="viewTypeModel"
       :variables="variables"
     >
-      Samples Predicted
+      <p class="font-weight-bold">Samples Predicted</p>
+      <layer-selection
+        v-if="isRemoteSensing"
+        class="layer-button"
+      ></layer-selection>
     </view-type-toggle>
 
     <p class="predictions-data-slot-summary" v-if="hasResults">
@@ -187,6 +191,10 @@ export default Vue.extend({
       } else {
         return `${this.numItems} <b class="matching-color">matching</b> samples of ${this.numRows} processed by model`;
       }
+    },
+
+    isRemoteSensing(): boolean {
+      return routeGetters.isRemoteSensing(this.$store);
     }
   }
 });
@@ -226,5 +234,13 @@ export default Vue.extend({
 
 .pending {
   opacity: 0.5;
+}
+
+.layer-button {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 0;
+  margin-right: 10px;
+  margin-left: auto;
 }
 </style>

--- a/public/components/ResultFacets.vue
+++ b/public/components/ResultFacets.vue
@@ -194,14 +194,14 @@ export default Vue.extend({
   border-bottom: 1px solid #e0e0e0;
   color: rgba(0, 0, 0, 0.87);
   font-weight: 600;
-  padding: 1rem 0 0.25rem;
+  padding: 0.25rem 0 0.25rem;
 }
 
 .request-group-status {
   align-items: center; /* Keep the button taller. */
   display: flex;
-  margin-bottom: 0.5rem;
-  margin-top: 0.5rem;
+  margin-bottom: 0.25rem;
+  margin-top: 0.25rem;
 }
 
 .request-group-status button {

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -1,66 +1,30 @@
 <template>
-  <div class="result-summaries">
-    <p class="nav-link font-weight-bold">Results</p>
-    <p></p>
-    <div v-if="showResiduals" class="result-summaries-error">
-      <error-threshold-slider></error-threshold-slider>
+  <div class="result-panel">
+    <div class="result-summaries">
+      <p class="nav-link font-weight-bold">Results</p>
+      <p></p>
+      <div v-if="showResiduals" class="result-summaries-error">
+        <error-threshold-slider></error-threshold-slider>
+      </div>
+      <p class="nav-link font-weight-bold">
+        Predictions by Model
+      </p>
+      <result-facets :showResiduals="showResiduals" />
     </div>
-    <p class="nav-link font-weight-bold">
-      Predictions by Model
-    </p>
-    <result-facets :showResiduals="showResiduals" />
-
     <template v-if="isActiveSolutionCompleted">
-      <predictions-data-uploader
-        class="result-button-alignment"
-        @uploadstart="onUploadStart"
-        @uploadfinish="onUploadFinish"
-        :fitted-solution-id="fittedSolutionId"
-        :target="target"
-        :target-type="targetType"
-      ></predictions-data-uploader>
+      <save-model
+        :solutionId="solutionId"
+        :fittedSolutionId="fittedSolutionId"
+      ></save-model>
+      <hr />
       <b-button
-        block
-        variant="primary"
-        class="result-button-alignment"
+        variant="success"
+        class="save-button"
         v-b-modal.save-model-modal
       >
+        <i class="fa fa-floppy-o"></i>
         Save Model
       </b-button>
-      <b-modal
-        title="Save Model"
-        id="save-model-modal"
-        @ok="handleOk"
-        @cancel="resetModal"
-        @close="resetModal"
-      >
-        <form ref="saveModelForm" @submit.stop.prevent="saveModel">
-          <b-form-group
-            label="Model Name"
-            label-for="model-name-input"
-            invalid-feedback="Model Name is Required"
-            :state="saveNameState"
-          >
-            <b-form-input
-              id="model-name-input"
-              v-model="saveName"
-              :state="saveNameState"
-              required
-            ></b-form-input>
-          </b-form-group>
-          <b-form-group
-            label="Model Description"
-            label-for="model-desc-input"
-            :state="saveDescriptionState"
-          >
-            <b-form-input
-              id="model-desc-input"
-              v-model="saveDescription"
-              :state="saveDescriptionState"
-            ></b-form-input>
-          </b-form-group>
-        </form>
-      </b-modal>
     </template>
   </div>
 </template>
@@ -69,6 +33,7 @@
 import ResultFacets from "../components/ResultFacets";
 import PredictionsDataUploader from "../components/PredictionsDataUploader";
 import ErrorThresholdSlider from "../components/ErrorThresholdSlider";
+import SaveModel from "../components/SaveModel";
 import { getSolutionById } from "../util/solutions";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
@@ -99,7 +64,8 @@ export default Vue.extend({
     ResultFacets,
     PredictionsDataUploader,
     ErrorThresholdSlider,
-    vueSlider
+    vueSlider,
+    SaveModel
   },
 
   data() {
@@ -110,11 +76,7 @@ export default Vue.extend({
       symmetricSlider: true,
       file: null,
       uploadData: {},
-      uploadStatus: "",
-      saveName: "",
-      saveNameState: null,
-      saveDescription: "",
-      saveDescriptionState: null
+      uploadStatus: ""
     };
   },
 
@@ -184,11 +146,6 @@ export default Vue.extend({
   },
 
   methods: {
-    validForm() {
-      const valid = this.saveName.length > 0;
-      this.saveNameState = valid;
-      return valid;
-    },
     onUploadStart(uploadData) {
       this.uploadData = uploadData;
       this.uploadStatus = "started";
@@ -226,50 +183,6 @@ export default Vue.extend({
         const entry = createRouteEntry(PREDICTION_ROUTE, routeArgs);
         this.$router.push(entry);
       }
-    },
-    handleOk(bvModalEvt) {
-      // Prevent modal from closing
-      bvModalEvt.preventDefault();
-      // Trigger submit handler
-      this.saveModel();
-    },
-    resetModal() {
-      this.saveName = "";
-      this.saveNameState = null;
-      this.saveDescription = "";
-      this.saveDescriptionState = null;
-    },
-    saveModel() {
-      if (!this.validForm()) {
-        return;
-      }
-
-      appActions.logUserEvent(this.$store, {
-        feature: Feature.EXPORT_MODEL,
-        activity: Activity.MODEL_SELECTION,
-        subActivity: SubActivity.MODEL_SAVE,
-        details: {
-          solution: this.activeSolution.solutionId,
-          fittedSolution: this.fittedSolutionId
-        }
-      });
-
-      appActions
-        .saveModel(this.$store, {
-          fittedSolutionId: this.fittedSolutionId,
-          modelName: this.saveName,
-          modelDescription: this.saveDescription
-        })
-        .then(err => {
-          if (err) {
-            console.warn(err);
-          }
-        });
-
-      this.$nextTick(() => {
-        this.$bvModal.hide("save-model-modal");
-        this.resetModal();
-      });
     }
   }
 });
@@ -322,7 +235,17 @@ export default Vue.extend({
   margin: 0 20%;
 }
 
-.result-button-alignment {
-  padding: 0 0 15px;
+.save-button {
+  flex-shrink: 0;
+  flex-grow: 0;
+  margin-top: 15px;
+  margin-bottom: 0px;
+  margin-left: auto;
+  margin-right: 8px;
+}
+
+.result-panel {
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/public/components/ResultTargetVariable.vue
+++ b/public/components/ResultTargetVariable.vue
@@ -159,4 +159,8 @@ export default Vue.extend({
   .facets-group {
   box-shadow: none;
 }
+.result-target-variable {
+  flex-shrink: 0;
+  margin-bottom: 0;
+}
 </style>

--- a/public/components/ResultsComparison.vue
+++ b/public/components/ResultsComparison.vue
@@ -1,14 +1,18 @@
 <template>
   <div
     class="results-slots"
-    v-bind:class="{ 'one-slot': !hasHighlights, 'two-slots': hasHighlights }"
+    :class="{ 'one-slot': !hasHighlights, 'two-slots': hasHighlights }"
   >
     <view-type-toggle
-      class="flex-shrink-0"
       v-model="viewTypeModel"
       :variables="variables"
+      class="view-toggle"
     >
-      Samples Modeled
+      <p class="font-weight-bold">Samples</p>
+      <layer-selection
+        v-if="isRemoteSensing"
+        class="layer-button"
+      ></layer-selection>
     </view-type-toggle>
 
     <div v-if="hasHighlights" class="flex-grow-1">
@@ -44,6 +48,7 @@ import _ from "lodash";
 import Vue from "vue";
 import ResultsDataSlot from "../components/ResultsDataSlot";
 import ViewTypeToggle from "../components/ViewTypeToggle";
+import LayerSelection from "../components/LayerSelection";
 import { Dictionary } from "../util/dict";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as resultsGetters } from "../store/results/module";
@@ -67,7 +72,8 @@ export default Vue.extend({
 
   components: {
     ResultsDataSlot,
-    ViewTypeToggle
+    ViewTypeToggle,
+    LayerSelection
   },
 
   data() {
@@ -169,6 +175,10 @@ export default Vue.extend({
       return routeArgs && routeArgs.includes(TaskTypes.FORECASTING);
     },
 
+    isRemoteSensing(): boolean {
+      return routeGetters.isRemoteSensing(this.$store);
+    },
+
     topSlotTitle(): string {
       return this.errorTitle(
         this.numIncludedResultItems,
@@ -220,7 +230,7 @@ export default Vue.extend({
 });
 </script>
 
-<style>
+<style scoped>
 .results-slots {
   display: flex;
   flex-direction: column;
@@ -241,5 +251,12 @@ export default Vue.extend({
 }
 .erroneous-color {
   color: #e05353;
+}
+.layer-button {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 0;
+  margin-right: 10px;
+  margin-left: auto;
 }
 </style>

--- a/public/components/ResultsComparison.vue
+++ b/public/components/ResultsComparison.vue
@@ -8,7 +8,7 @@
       :variables="variables"
       class="view-toggle"
     >
-      <p class="font-weight-bold">Samples</p>
+      <p class="font-weight-bold mr-auto">Samples</p>
       <layer-selection
         v-if="isRemoteSensing"
         class="layer-button"
@@ -230,6 +230,19 @@ export default Vue.extend({
 });
 </script>
 
+<!-- used in generated strings so can't be scoped -->
+<style>
+.matching-color {
+  color: #255dcc;
+}
+.other-color {
+  color: #333;
+}
+.erroneous-color {
+  color: #e05353;
+}
+</style>
+
 <style scoped>
 .results-slots {
   display: flex;
@@ -243,20 +256,17 @@ export default Vue.extend({
 .one-slot .results-data-slot {
   height: 100%;
 }
-.matching-color {
-  color: #255dcc;
-}
-.other-color {
-  color: #333;
-}
-.erroneous-color {
-  color: #e05353;
-}
 .layer-button {
   display: flex;
   flex-direction: column;
   flex-grow: 0;
   margin-right: 10px;
   margin-left: auto;
+}
+.view-toggle >>> .form-group {
+  margin-bottom: 0px;
+}
+.view-toggle {
+  flex-shrink: 0;
 }
 </style>

--- a/public/components/SaveModel.vue
+++ b/public/components/SaveModel.vue
@@ -108,6 +108,7 @@ export default Vue.extend({
     // apply model workflow.
     apply() {
       this.resetModal();
+      this.$bvModal.show("predictions-data-upload-modal");
     },
 
     // Return to the search screen.

--- a/public/components/SaveModel.vue
+++ b/public/components/SaveModel.vue
@@ -1,0 +1,187 @@
+<template>
+  <div>
+    <b-modal
+      title="Save Model"
+      id="save-model-modal"
+      no-stacking
+      @ok="handleSaveOk"
+      @cancel="resetModal"
+      @close="resetModal"
+    >
+      <!-- show form to save model if unsaved -->
+      <form ref="saveModelForm" @submit.stop.prevent="saveModel">
+        <b-form-group
+          label="Model Name"
+          label-for="model-name-input"
+          invalid-feedback="Model Name is Required"
+          :state="saveNameState"
+        >
+          <b-form-input
+            id="model-name-input"
+            v-model="saveName"
+            :state="saveNameState"
+            required
+          ></b-form-input>
+        </b-form-group>
+        <b-form-group
+          label="Model Description"
+          label-for="model-desc-input"
+          :state="saveDescriptionState"
+        >
+          <b-form-input
+            id="model-desc-input"
+            v-model="saveDescription"
+            :state="saveDescriptionState"
+          ></b-form-input>
+        </b-form-group>
+      </form>
+    </b-modal>
+    <b-modal
+      id="save-success-modal"
+      :title-html="successTitle"
+      header-class="success-modal-header"
+    >
+      <p>
+        The model {{ this.saveName.toUpperCase() }} will now be available on the
+        start page for re-use. To use it now on new data, click
+        <b>Apply Model</b> or <b>Go Back to Start Page</b> to work on something
+        else.
+      </p>
+      <template v-slot:modal-footer>
+        <b-button variant="secondary" @click="back()">
+          Go Back to Start Page
+        </b-button>
+        <b-button variant="primary" @click="apply()">
+          Apply Model
+        </b-button>
+      </template>
+    </b-modal>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import {
+  actions as appActions,
+  getters as appGetters
+} from "../store/app/module";
+import { Feature, Activity, SubActivity } from "../util/userEvents";
+import { routeModule } from "../store/route/module";
+import { createRouteEntry } from "../util/routes";
+import router from "../router/router";
+import { SEARCH_ROUTE } from "../store/route";
+
+export default Vue.extend({
+  name: "save-model",
+
+  props: {
+    solutionId: String as () => string,
+    fittedSolutionId: String as () => string
+  },
+
+  data() {
+    return {
+      saveName: "",
+      saveNameState: null,
+      saveDescription: "",
+      saveDescriptionState: null
+    };
+  },
+
+  computed: {
+    successTitle(): string {
+      return `<i class="fa fa-check-circle header-icon"></i> Model ${this.saveName.toUpperCase()} was successfully saved`;
+    }
+  },
+
+  methods: {
+    // process or reject model save based on form state
+    handleSaveOk(bvModalEvt) {
+      // Prevent modal from closing
+      bvModalEvt.preventDefault();
+
+      // Trigger submit handler
+      this.saveModel();
+    },
+
+    // CDB: Currently will open up the file upload dialog. Should transition to the
+    // apply model workflow.
+    apply() {
+      this.resetModal();
+    },
+
+    // Return to the search screen.
+    back() {
+      this.resetModal();
+      const routeEntry = createRouteEntry(SEARCH_ROUTE);
+      router.push(routeEntry);
+    },
+
+    // clear dialog state
+    resetModal() {
+      this.saveName = "";
+      this.saveNameState = null;
+      this.saveDescription = "";
+      this.saveDescriptionState = null;
+    },
+
+    // save model
+    async saveModel() {
+      if (!this.validForm()) {
+        return;
+      }
+
+      appActions.logUserEvent(this.$store, {
+        feature: Feature.EXPORT_MODEL,
+        activity: Activity.MODEL_SELECTION,
+        subActivity: SubActivity.MODEL_SAVE,
+        details: {
+          solution: this.solutionId,
+          fittedSolution: this.fittedSolutionId
+        }
+      });
+
+      try {
+        await appActions.saveModel(this.$store, {
+          fittedSolutionId: this.fittedSolutionId,
+          modelName: this.saveName,
+          modelDescription: this.saveDescription
+        });
+      } catch (err) {
+        console.warn(err);
+      }
+      this.$bvModal.show("save-success-modal");
+    },
+
+    // ensure required fields are filled out
+    validForm() {
+      const valid = this.saveName.length > 0;
+      this.saveNameState = valid;
+      return valid;
+    }
+  },
+
+  watch: {
+    // Watches the dataset save name so that the valid/invalid state can
+    // be updated in response to user action.
+    saveName() {
+      // allowed transitions are null -> true, true -> false, false -> true
+      if (this.saveNameState === null && !!this.saveName) {
+        this.saveNameState = true;
+      } else if (this.saveNameState !== null) {
+        this.saveNameState = !!this.saveName;
+      }
+    }
+  }
+});
+</script>
+
+<style>
+.success-modal-header {
+  background: #d5ecdb;
+}
+.header-icon {
+  color: #35a54c;
+  margin-right: 5px;
+}
+</style>

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -8,7 +8,7 @@
         >Samples to Model From</b-nav-item
       >
       <b-nav-item
-        class="font-weight-bold"
+        class="font-weight-bold mr-auto"
         @click="setExcludedActive"
         :active="!includedActive"
         >Excluded Samples</b-nav-item

--- a/public/components/ViewTypeToggle.vue
+++ b/public/components/ViewTypeToggle.vue
@@ -3,7 +3,7 @@
     <b-nav :tabs="hasTabs">
       <slot></slot>
       <template>
-        <b-form-group class="view-button ml-auto">
+        <b-form-group class="view-button">
           <b-form-radio-group
             buttons
             v-model="content"

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -1,32 +1,10 @@
 <template>
   <div class="container-fluid d-flex flex-column h-100 results-view">
     <div class="row flex-0-nav"></div>
-
-    <div class="row align-items-center justify-content-center bg-white">
-      <div class="col-12 col-md-6 d-flex flex-column">
-        <h5 class="header-label">
-          Select Model That Best Predicts {{ targetLabel.toUpperCase() }}
-        </h5>
-
-        <div class="row col-12 pl-4">
-          <div>
-            {{ targetLabel.toUpperCase() }} is being modeled as a
-            {{ targetType }}
-          </div>
-        </div>
-        <div class="row col-12 pl-4">
-          <p>
-            Use interactive feature highlighting to analyze models. Go back to
-            revise features, if needed.
-          </p>
-        </div>
-      </div>
-
-      <div class="col-12 col-md-6 d-flex flex-column">
-        <result-target-variable
-          class="col-12 d-flex flex-column result-target-variables"
-        ></result-target-variable>
-      </div>
+    <div class="row align-items-center justify-content-left bg-white">
+      <h5 class="header-label ">
+        Check Models: Review results to understand model performance
+      </h5>
     </div>
 
     <div class="row flex-1 pb-3">
@@ -156,6 +134,7 @@ export default Vue.extend({
 }
 .header-label {
   padding: 1rem 0 0.5rem 0;
+  margin-left: 200px;
   font-weight: bold;
 }
 .results-view .table td {
@@ -182,13 +161,5 @@ export default Vue.extend({
   .results-result-summaries {
     height: unset;
   }
-}
-.result-target-variables {
-  min-width: 500px;
-  max-width: 600px !important;
-  align-self: flex-end;
-}
-.result-target-variables .facet-sparkline-container {
-  height: 30px !important;
 }
 </style>


### PR DESCRIPTION
fixes #1704, fixes #1702 

- Factors model save dialog out of result summary component into its own
- Adds new file save success dialog that supports return to start or apply as options as per design
- Removes prediction upload related code from result summary component into the prediction upload component
- Tweaks a bunch of CSS to recover vertical space in the application as per design