### PR TITLE
Predictions screen cleanup

### DIFF
--- a/public/components/PredictionSummaries.vue
+++ b/public/components/PredictionSummaries.vue
@@ -29,7 +29,7 @@
     </div>
 
     <!-- TODO: For show right now.-->
-    <b-button block variant="primary">
+    <b-button variant="primary" class="float-right mt-2">
       Export Predictions
     </b-button>
 

--- a/public/components/PredictionsDataSlot.vue
+++ b/public/components/PredictionsDataSlot.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="predictions-data-slot">
     <view-type-toggle
-      class="flex-shrink-0"
+      class="view-toggle"
       v-model="viewTypeModel"
       :variables="variables"
     >
-      <p class="font-weight-bold">Samples Predicted</p>
+      <p class="font-weight-bold mr-auto">Samples Predicted</p>
       <layer-selection
         v-if="isRemoteSensing"
         class="layer-button"
@@ -242,5 +242,12 @@ export default Vue.extend({
   flex-grow: 0;
   margin-right: 10px;
   margin-left: auto;
+}
+
+.view-toggle >>> .form-group {
+  margin-bottom: 0px;
+}
+.view-toggle {
+  flex-shrink: 0;
 }
 </style>

--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -160,6 +160,7 @@ export default Vue.extend({
     timestamp: String as () => string,
     requestId: String as () => string,
     solutionId: String as () => string,
+    singleSolution: Boolean as () => boolean,
     scores: Array as () => number[],
     targetSummary: Object as () => VariableSummary,
     predictedSummary: Object as () => VariableSummary,
@@ -308,7 +309,11 @@ export default Vue.extend({
     },
 
     isSelected(): boolean {
-      return this.predictedSummary && this.solutionId === this.routeSolutionId;
+      return (
+        !this.singleSolution &&
+        this.predictedSummary &&
+        this.solutionId === this.routeSolutionId
+      );
     },
 
     isTopN(): boolean {

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -10,7 +10,10 @@
       <div v-if="showResiduals" class="result-summaries-error">
         <error-threshold-slider></error-threshold-slider>
       </div>
-      <result-facets :showResiduals="showResiduals" />
+      <result-facets
+        :showResiduals="showResiduals"
+        :single-solution="isSingleSolution"
+      />
     </div>
     <template v-if="isActiveSolutionCompleted">
       <div class="d-flex flex-row flex-shrink-0 justify-content-end">
@@ -31,6 +34,7 @@
           :fittedSolutionId="fittedSolutionId"
         ></save-model>
         <b-button
+          v-if="!isSingleSolution"
           variant="success"
           class="save-button"
           v-b-modal.save-model-modal
@@ -155,6 +159,14 @@ export default Vue.extend({
         this.activeSolution &&
         this.activeSolution.progress === SOLUTION_COMPLETED
       );
+    },
+
+    // Indicates whether or not the contained result facets should show "relevant"
+    // results, which consist of those that match the target/dataset, or a single
+    // result, which matches the route solutionID.  The latter case occurs when the
+    // user selects a model directly from the search screen.
+    isSingleSolution(): boolean {
+      return routeGetters.isSingleSolution(this.$store);
     }
   }
 });

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -24,6 +24,7 @@
           :target-type="targetType"
         ></predictions-data-uploader>
         <b-button
+          v-if="isSingleSolution"
           variant="primary"
           class="apply-button"
           v-b-modal.predictions-data-upload-modal

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -420,6 +420,11 @@ export const getters = {
     return dataset;
   },
 
+  isSingleSolution(state: Route, getters: any): boolean {
+    const isSingleSolution = <string>state.query.singleSolution;
+    return !!isSingleSolution;
+  },
+
   /**
    * Check if the current task includes Remote Sensing.
    * @param {Route} state

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -88,6 +88,7 @@ export const getters = {
   getRouteTask: read(moduleGetters.getRouteTask),
   getRouteFittedSolutionID: read(moduleGetters.getRouteFittedSolutionId),
   getRoutePredictionsDataset: read(moduleGetters.getRoutePredictionsDataset),
+  isSingleSolution: read(moduleGetters.isSingleSolution),
   isRemoteSensing: read(moduleGetters.isRemoteSensing),
   getBandCombinationId: read(moduleGetters.getBandCombinationId)
 };

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -37,6 +37,7 @@ export interface RouteArgs {
   varRanked?: string;
   produceRequestId?: string;
   fittedSolutionId?: string;
+  singleSolution?: string;
   predictionsDataset?: string;
   bandCombinationId?: string;
 

--- a/public/util/solutions.ts
+++ b/public/util/solutions.ts
@@ -140,7 +140,8 @@ export async function openModelSolution(
     dataset: args.datasetName,
     target: args.targetFeature,
     task: task,
-    solutionId: solutionId
+    solutionId: solutionId,
+    singleSolution: true.toString()
   };
 
   const entry = createRouteEntry(RESULTS_ROUTE, routeDefintion);


### PR DESCRIPTION
mainly fixes #1752, also fixes #1641, fixes #1642, fixes #1567

- Ensures that when a model is clicked on the search screen, only the selected model displays results screen 
- Fixes a few minor alignment issues in the predictions screen

