### PR TITLE
#1697 timeseries edge case

### DIFF
--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -292,6 +292,7 @@ export function getSubSelectionValues(
   if (!hasFilterBuckets && !rowSelection) {
     return summary.baseline?.buckets?.map(b => [null, b.count / max]);
   }
+  const isNumeric = summary.type === NUMERICAL_SUMMARY;
   const rowLabels = getRowSelectionLabels(rowSelection, summary);
   let subSelectionValues = null;
 
@@ -302,17 +303,40 @@ export function getSubSelectionValues(
     }, {});
     subSelectionValues = summary.baseline.buckets.map(b => {
       const bucketCount = filterKeys[b.key] ? filterKeys[b.key] : 0;
-      return rowLabels.indexOf(b.key) > -1
+      return rowLabelMatches(rowLabels, b.key, isNumeric)
         ? [bucketCount / max, null]
         : [null, bucketCount / max];
     });
   } else {
     subSelectionValues = summary.baseline.buckets.map(b => [
-      rowLabels.indexOf(b.key) > -1 ? b.count / max : null,
+      rowLabelMatches(rowLabels, b.key, isNumeric) ? b.count / max : null,
       null
     ]);
   }
   return subSelectionValues;
+}
+
+export function rowLabelMatches(
+  rowLabels: string[],
+  bucketKey: string,
+  isNumeric: boolean
+): boolean {
+  if (isNumeric) {
+    const numBk = _.toNumber(bucketKey);
+    return rowLabels.reduce((hasRl: boolean, rl: string) => {
+      if (_.toNumber(rl) === numBk) {
+        hasRl = true;
+      }
+      return hasRl;
+    }, false);
+  } else {
+    return rowLabels.reduce((hasRl: boolean, rl: string) => {
+      if (rl === bucketKey) {
+        hasRl = true;
+      }
+      return hasRl;
+    }, false);
+  }
 }
 
 export function getRowSelectionLabels(

--- a/public/views/VariableGrouping.vue
+++ b/public/views/VariableGrouping.vue
@@ -18,8 +18,8 @@
             To predict a value over time <strong>(forecasting)</strong> your
             target should be a <strong>timeseries.</strong><br />
             Select a <strong>time</strong> column, a
-            <strong>count</strong> column and
-            <strong>grouping</strong> column(s) to create multiple timeseries.
+            <strong>value</strong> column and optionally add one or more
+            <strong>series id</strong> column(s) to create multiple timeseries.
           </p>
         </b-col>
         <b-col v-if="isGeocoordinate" cols="12">
@@ -40,7 +40,7 @@
           >
             <b-col cols="5">
               <template v-if="index === 0">
-                <b>Group Column(s):</b>
+                <b>Series ID Column(s):</b>
               </template>
             </b-col>
 
@@ -338,11 +338,7 @@ export default Vue.extend({
     isReady(): boolean {
       const hasBasicFields =
         this.xCol !== null && this.yCol !== null && this.groupingType !== null;
-      if (this.isGeocoordinate) {
-        return hasBasicFields;
-      } else {
-        return hasBasicFields && this.idCols.length > 1;
-      }
+      return hasBasicFields;
     },
     summaries(): VariableSummary[] {
       let summaries = datasetGetters.getVariableSummaries(this.$store);


### PR DESCRIPTION
Allows no grouping/series id column to be set for timeseries, and updates the text in the layout to note that & to use the preferred naming.

Also Fixes #1661 - While we did special comparisons to find the numeric facet labels that contain a selected row, we had no such code for finding the indexes of those labels, which is fine until there's string comparisons where need numerical ones.