### PR TITLE
Ensures correct id is used on model load

### DIFF
--- a/public/components/ModelPreview.vue
+++ b/public/components/ModelPreview.vue
@@ -46,7 +46,7 @@ export default Vue.extend({
   methods: {
     onResult() {
       openModelSolution(this.$router, {
-        datasetName: this.model.datasetName,
+        datasetId: this.model.datasetId,
         targetFeature: this.model.target,
         fittedSolutionId: this.model.fittedSolutionId,
         variableFeatures: this.model.variables

--- a/public/components/SolutionPreview.vue
+++ b/public/components/SolutionPreview.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
   methods: {
     onResult() {
       openModelSolution(this.$router, {
-        datasetName: this.solution.dataset,
+        datasetId: this.solution.dataset,
         targetFeature: this.solution.feature,
         solutionId: this.solution.solutionId,
         variableFeatures: this.solution.features.map(f => f.featureName)

--- a/public/util/solutions.ts
+++ b/public/util/solutions.ts
@@ -107,7 +107,7 @@ export function isTopSolutionByScore(
 export async function openModelSolution(
   router: VueRouter,
   args: {
-    datasetName: string;
+    datasetId: string;
     targetFeature: string;
     fittedSolutionId?: string;
     solutionId?: string;
@@ -117,14 +117,14 @@ export async function openModelSolution(
   let task = routeGetters.getRouteTask(store);
   if (!task) {
     const taskResponse = await dataActions.fetchTask(store, {
-      dataset: args.datasetName,
+      dataset: args.datasetId,
       targetName: args.targetFeature,
       variableNames: args.variableFeatures // solution.features.map(f => f.featureName)
     });
     task = taskResponse.data.task.join(",");
   }
   const solutionArgs = {
-    dataset: args.datasetName,
+    dataset: args.datasetId,
     target: args.targetFeature
   };
   await Promise.all([
@@ -137,7 +137,7 @@ export async function openModelSolution(
         .getSolutions(store)
         .find(s => s.fittedSolutionId === args.fittedSolutionId).solutionId;
   const routeDefintion = {
-    dataset: args.datasetName,
+    dataset: args.datasetId,
     target: args.targetFeature,
     task: task,
     solutionId: solutionId,


### PR DESCRIPTION
The server expects datasets to be referenced by `datasetID`.  The code to load models was using `datasetName`, which worked in a lot of cases because the D3M dataset def happened to have the same value in in the ID and name fields.  Newer D3M datasets, like `merced` used different values, so those were failing when a model was saved.