### PR TITLE
#1651 single color shap

### DIFF
--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -651,22 +651,9 @@ export function explainCellColor(
       d3mRowWeightExtrema(tableFields, dataItems)[data.item[D3M_INDEX_FIELD]]
   );
 
-  let red: number;
-  let green: number;
-  let blue: number;
-  if (weight > 0) {
-    red = 242 - 128 * absoluteWeight;
-    green = 242 - 64 * absoluteWeight;
-    blue = 255;
-  } else if (weight === 0) {
-    red = 255;
-    green = 255;
-    blue = 255;
-  } else {
-    red = 255;
-    green = 242 - 255 * absoluteWeight;
-    blue = 242 - 128 * absoluteWeight;
-  }
+  const red = 255 - 128 * absoluteWeight;
+  const green = 255 - 64 * absoluteWeight;
+  const blue = 255;
 
   return `background: rgba(${red}, ${green}, ${blue}, .75)`;
 }

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -358,7 +358,7 @@ export function getRowSelectionLabels(
     const bucketFloors = summary.baseline.buckets.map(b => _.toNumber(b.key));
     rowKeys = rowKeys.map(rk => _.toNumber(rk));
     rowLabels = rowKeys.map(rk => {
-      return `${bucketFloors.filter(bf => rk > bf).pop()}`;
+      return `${bucketFloors.filter(bf => rk >= bf).pop()}`;
     });
   } else {
     rowLabels = summary.baseline.buckets.reduce((acc, b) => {


### PR DESCRIPTION
Closes #1651 - As described, rolled back shap to single color by using only absolute values on the client side. Also fixes edge case discovered during development with row highlighting where a highlighted numeric value equals the label of a bucket.