### PR TITLE
Removed Timeseries View Toggle

### DIFF
--- a/public/components/ViewTypeToggle.vue
+++ b/public/components/ViewTypeToggle.vue
@@ -124,12 +124,20 @@ export default Vue.extend({
 
       return (hasLat && hasLon) || hasGeocoord;
     },
+
+    /* 
+      TODO - Reimplement test once the Timeseries view works again. 
+      See https://github.com/uncharted-distil/distil/issues/1690
+    */
     hasTimeseriesVariables(): boolean {
+      return false;
+      /*
       return (
         this.variables.filter(
           v => v.grouping && v.grouping.type === TIMESERIES_TYPE
         ).length > 0
       );
+      */
     }
   }
 });


### PR DESCRIPTION
closes #1690 

Stopped display the toggle to see Timeseries type grouping data until we have time to get the timeseries view working again.