### PR TITLE
Timeseries predictions

### DIFF
--- a/api/routes/solution_variable_rankings.go
+++ b/api/routes/solution_variable_rankings.go
@@ -67,12 +67,12 @@ func SolutionVariableRankingHandler(metaCtor api.MetadataStorageCtor, solutionCt
 
 		// if no ranking were generated, fall back on the dataset/target rank estimates
 		if len(rankings) == 0 {
-			summaryVariables, err := api.FetchSummaryVariables(dataset.Name, storage)
+			summaryVariables, err := api.FetchSummaryVariables(dataset.ID, storage)
 			if err != nil {
 				handleError(w, errors.Wrap(err, "unable to expand grouped variables"))
 				return
 			}
-			rankings, err = targetRank(dataset.Name, request.TargetFeature(), dataset.Folder, summaryVariables, dataset.Source)
+			rankings, err = targetRank(dataset.ID, request.TargetFeature(), dataset.Folder, summaryVariables, dataset.Source)
 			if err != nil {
 				handleError(w, errors.Wrap(err, "unable get variable ranking"))
 				return

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -483,7 +483,6 @@ func updateVariableTypes(solutionStorage api.SolutionStorage, metaStorage api.Me
 // Extracts the list of components that used to create a compound variable.
 func getComponentVariables(variable *model.Variable) []string {
 	componentVars := []string{}
-	// only implemented for geo coordinate groups
 	if variable.IsGrouping() {
 		if model.IsGeoCoordinate(variable.Grouping.GetType()) {
 			gcg := variable.Grouping.(*model.GeoCoordinateGrouping)
@@ -499,6 +498,9 @@ func getComponentVariables(variable *model.Variable) []string {
 		} else if model.IsRemoteSensing(variable.Grouping.GetType()) {
 			rsg := variable.Grouping.(*model.RemoteSensingGrouping)
 			componentVars = append(componentVars, rsg.BandCol, rsg.IDCol, rsg.ImageCol)
+		} else if model.IsTimeSeries(variable.Grouping.GetType()) {
+			tsg := variable.Grouping.(*model.TimeseriesGrouping)
+			componentVars = append(componentVars, tsg.XCol, tsg.YCol)
 		}
 	} else {
 		componentVars = append(componentVars, variable.Name)

--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -107,7 +107,10 @@ export default Vue.extend({
       // Join the last element of the truth timeseries and the first element of the forecast
       // time series.  Used when not visualizing an in-sample forecast.
       if (this.joinForecast) {
-        return [_.last(this.timeseries)].concat(this.forecast);
+        const last = _.clone(_.last(this.timeseries));
+        last.confidenceLow = last.value;
+        last.confidenceHigh = last.value;
+        return [last, ...this.forecast];
       }
       return this.forecast;
     }


### PR DESCRIPTION
1. Solution variable ranking fetches were using the dataset name rather than ID, causing predictions display to fail
2. Confidence visuals were not properly joined with the last ground truth element when visualizing forecast predictions
3. Timeseries predictions were displaying as categorical histograms due to the target type not being matched to the solution target type after prediction upload.