### PR TITLE
#1719 Error facet menu fix

### DIFF
--- a/public/components/facets/FacetError.vue
+++ b/public/components/facets/FacetError.vue
@@ -62,14 +62,20 @@ export default Vue.extend({
   padding: 6px 12px 5px;
   box-sizing: content-box;
 
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  color: rgba(0, 0, 0, 0.54);
+  display: flex;
+  align-items: center;
+  overflow-y: scroll !important;
 }
 
 .facet-header > i {
   color: red;
   padding-right: 6px;
+}
+
+.facet-header .dropdown-menu {
+  max-height: 200px;
+  overflow-y: auto;
 }
 
 .facet-header-dropdown {


### PR DESCRIPTION
Missing CSS was hiding the otherwise working menu. This fixes that, though in future we may want to consider some shared css for headers, or a header component that captures what we're doing in all of the facets here.