### PR TITLE
Image predictions

### DIFF
--- a/api/dataset/media.go
+++ b/api/dataset/media.go
@@ -71,7 +71,7 @@ func NewMediaDataset(dataset string, mediaType string, targetMediaType string, r
 		return nil, err
 	}
 
-	expandedInfo, err := ExpandZipDataset(dataset, zipPath)
+	expandedInfo, err := ExpandZipDataset(zipPath, dataset)
 	if err != nil {
 		return nil, err
 	}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -109,7 +109,7 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 		}
 
 		// create the dataset to be used for predictions
-		datasetName, datasetPath, err = CreateDataset(params.Dataset, predictionDatasetCtor, params.OutputPath, params.Config)
+		datasetName, _, err = CreateDataset(params.Dataset, predictionDatasetCtor, params.OutputPath, params.Config)
 		if err != nil {
 			return nil, err
 		}

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -136,6 +136,10 @@ export default Vue.extend({
       return circleSpinnerHTML();
     },
     dataset(): string {
+      const dataset = routeGetters.getRoutePredictionsDataset(this.$store);
+      if (dataset) {
+        return dataset;
+      }
       return routeGetters.getRouteDataset(this.$store);
     },
     hasClick(): boolean {


### PR DESCRIPTION
Fixes a few small regressions encountered when working with image predictions.
1. Fixes server-side arg ordering that was causing import to fail
1. Ensures correct path is stored in prediction dataset when imported
1. Updates image preview to use prediction dataset ID to fetch images when set, otherwise use solution dataset ID