### PR TITLE
#1680 Fix Exemplar Preload

### DIFF
--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -207,11 +207,11 @@ export function fetchSummaryExemplars(
         );
       }
     } else {
-      // if there a linked files, fetch those before resolving
+      // if there are linked files, fetch some of them before resolving
       return datasetActions.fetchFiles(store, {
         dataset: datasetName,
         variable: variableName,
-        urls: exemplars
+        urls: exemplars.slice(0, 5)
       });
     }
   }


### PR DESCRIPTION
Currently exemplar preloading subverts the natural on-demand loading of images in tables during scrolling into view or when clicking more on an image facet. This change limits that to loading the first 5 exemplars (as that's what's shown normally in image facets,) leaving the rest of the calls up to be made when additional image components are added to the page and load data.