### PR TITLE
Prediction confidence store

### DIFF
--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -127,9 +127,9 @@ type Column struct {
 
 // FilteredDataValue represents a data value combined with an optional weight.
 type FilteredDataValue struct {
-	Value      interface{} `json:"value"`
-	Weight     float64     `json:"weight,omitempty"`
-	Confidence float64     `json:"confidence,omitempty"`
+	Value      interface{}     `json:"value"`
+	Weight     float64         `json:"weight,omitempty"`
+	Confidence NullableFloat64 `json:"confidence,omitempty"`
 }
 
 // FilteredData provides the metadata and raw data values that match a supplied

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -127,8 +127,9 @@ type Column struct {
 
 // FilteredDataValue represents a data value combined with an optional weight.
 type FilteredDataValue struct {
-	Value  interface{} `json:"value"`
-	Weight float64     `json:"weight,omitempty"`
+	Value      interface{} `json:"value"`
+	Weight     float64     `json:"weight,omitempty"`
+	Confidence float64     `json:"confidence,omitempty"`
 }
 
 // FilteredData provides the metadata and raw data values that match a supplied

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -37,6 +37,7 @@ const (
 			index		BIGINT,
 			target		text,
 			value		text,
+			confidence double precision,
 			confidence_low double precision,
 			confidence_high double precision
 		);`

--- a/api/routes/results.go
+++ b/api/routes/results.go
@@ -135,7 +135,7 @@ func ResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.DataStora
 		// marshal data and sent the response back
 		err = handleJSON(w, outputs)
 		if err != nil {
-			handleError(w, errors.Wrap(err, "unable marshal solution result into JSON"))
+			handleError(w, errors.Wrap(err, "unable marshal result rows into JSON"))
 			return
 		}
 	}

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -171,6 +171,7 @@ export enum SummaryMode {
 export interface TableValue {
   value: any;
   weight: number;
+  confidence: number;
 }
 export interface TableData {
   numRows: number;


### PR DESCRIPTION
Confidence are now stored to the database if returned by TA2 on a produce call. Requires an update to the postgres image to add the confidence field to the result table.