### PR TITLE
Bulk insert source

### DIFF
--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -283,6 +283,19 @@ func (s *Storage) DeleteVariable(dataset string, storageName string, varName str
 	return nil
 }
 
+func (s *Storage) insertBulkCopy(storageName string, varNames []string, inserts [][]interface{}) error {
+	rowsCopied, err := s.client.CopyFrom(storageName, varNames, inserts)
+	if err != nil {
+		return errors.Wrapf(err, "unable to bulk copy data to postgres")
+	}
+
+	if rowsCopied != int64(len(inserts)) {
+		return errors.Errorf("only bulk copied %d of %d rows to postgres", rowsCopied, len(inserts))
+	}
+
+	return nil
+}
+
 // InsertBatch batches the data to insert for increased performance.
 func (s *Storage) InsertBatch(storageName string, varNames []string, inserts [][]interface{}) error {
 

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -284,7 +284,7 @@ func (s *Storage) DeleteVariable(dataset string, storageName string, varName str
 }
 
 func (s *Storage) insertBulkCopy(storageName string, varNames []string, inserts [][]interface{}) error {
-	rowsCopied, err := s.client.CopyFrom(storageName, varNames, inserts)
+	rowsCopied, err := s.batchClient.CopyFrom(storageName, varNames, inserts)
 	if err != nil {
 		return errors.Wrapf(err, "unable to bulk copy data to postgres")
 	}
@@ -405,7 +405,7 @@ func (s *Storage) UpdateVariableBatch(storageName string, varName string, update
 		return errors.Wrap(err, "unable to create temp table")
 	}
 
-	err = s.insertBatchData(tableNameTmp, []string{model.D3MIndexName, varName}, params)
+	err = s.insertBulkCopy(tableNameTmp, []string{model.D3MIndexName, varName}, params)
 	if err != nil {
 		return errors.Wrap(err, "unable to insert into temp table")
 	}

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -267,7 +267,7 @@ func (s *Storage) PersistResult(dataset string, storageName string, resultURI st
 	}
 
 	// store all results to the storage
-	err = s.InsertBatch(s.getResultTable(storageName), fields, insertData)
+	err = s.insertBulkCopy(s.getResultTable(storageName), fields, insertData)
 	if err != nil {
 		return errors.Wrap(err, "failed to insert result in database")
 	}

--- a/api/postgres/client.go
+++ b/api/postgres/client.go
@@ -44,6 +44,7 @@ type DatabaseDriver interface {
 	QueryRow(string, ...interface{}) pgx.Row
 	Exec(string, ...interface{}) (pgconn.CommandTag, error)
 	SendBatch(batch *pgx.Batch) pgx.BatchResults
+	CopyFrom(string, []string, [][]interface{}) (int64, error)
 }
 
 // ClientCtor repressents a client constructor to instantiate a postgres client.
@@ -81,6 +82,12 @@ func (ic IntegratedClient) Exec(sql string, params ...interface{}) (pgconn.Comma
 // SendBatch submits a batch.
 func (ic IntegratedClient) SendBatch(batch *pgx.Batch) pgx.BatchResults {
 	return ic.pgxClient.SendBatch(context.Background(), batch)
+}
+
+// CopyFrom copies data using the Postgres copy protocol for bulk data insertion.
+func (ic IntegratedClient) CopyFrom(storageName string, columns []string, rows [][]interface{}) (int64, error) {
+	sourceValues := pgx.CopyFromRows(rows)
+	return ic.pgxClient.CopyFrom(context.Background(), pgx.Identifier{storageName}, columns, sourceValues)
 }
 
 func (p pgxLogAdapter) Log(ctx context.Context, level pgx.LogLevel, msg string, data map[string]interface{}) {

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -267,12 +267,27 @@ func (d *Database) CreateSolutionMetadataTables() error {
 
 func (d *Database) executeInserts(tableName string) error {
 	ds := d.Tables[tableName]
-	insertCount, err := d.Client.CopyFrom(tableName, ds.GetColumns(), ds.GetInsertSource())
-	if err != nil {
-		return errors.Wrapf(err, "unable to insert batch to postgres")
+	if ds.GetInsertSourceLength() > 0 {
+		insertCount, err := d.Client.CopyFrom(fmt.Sprintf("%s_base", tableName), ds.GetColumns(), ds.GetInsertSource())
+		if err != nil {
+			return errors.Wrapf(err, "unable to insert batch to postgres")
+		}
+		if insertCount != int64(ds.GetInsertSourceLength()) {
+			return errors.Errorf("batch insert only copied %d rows from source out of %d", insertCount, ds.GetInsertSourceLength())
+		}
 	}
-	if insertCount != int64(ds.GetInsertSourceLength()) {
-		return errors.Errorf("batch insert only copied %d rows from source out of %d", insertCount, ds.GetInsertSourceLength())
+
+	batchCount := ds.GetBatchSize()
+	if batchCount > 0 {
+		batch := ds.GetBatch()
+		res := d.Client.SendBatch(batch)
+		defer res.Close()
+		for i := 0; i < batchCount; i++ {
+			_, err := res.Exec()
+			if err != nil {
+				return errors.Wrapf(err, "unable to insert batch to postgres")
+			}
+		}
 	}
 
 	return nil
@@ -353,7 +368,6 @@ func (d *Database) DeleteDataset(name string) {
 func (d *Database) IngestRow(tableName string, data []string) error {
 	ds := d.Tables[tableName]
 
-	insertStatement := ""
 	variables := ds.Variables
 	values := make([]interface{}, len(variables))
 	for i := 0; i < len(variables); i++ {
@@ -366,10 +380,8 @@ func (d *Database) IngestRow(tableName string, data []string) error {
 		} else {
 			val = data[i]
 		}
-		insertStatement = fmt.Sprintf("%s, $%d", insertStatement, i+1)
 		values[i] = val
 	}
-	insertStatement = fmt.Sprintf("INSERT INTO distil.public.\"%s_base\" (%s) VALUES (%s)", tableName, ds.fieldSQL, insertStatement[2:])
 	ds.AddInsertFromSource(values)
 
 	if ds.GetInsertSourceLength() >= d.BatchSize {


### PR DESCRIPTION
Switched to use copy from for inserts. It is faster overall so results, grouping keys, and ingest are marginally faster. The word stem table is the only one that isnt using this approach since the inserts there are a bit more complicated (only insert if it doesnt already exist).