### PR TITLE
D3M Dataset Import

### DIFF
--- a/api/dataset/d3m.go
+++ b/api/dataset/d3m.go
@@ -1,0 +1,74 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package dataset
+
+import (
+	"path"
+
+	"github.com/uncharted-distil/distil-compute/metadata"
+	"github.com/uncharted-distil/distil-compute/model"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
+	"github.com/uncharted-distil/distil/api/env"
+	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/util"
+)
+
+// D3M captures the needed information for a D3M dataset.
+type D3M struct {
+	DatasetName string
+	DatasetPath string
+}
+
+// NewD3MDataset creates a new d3m dataset from a dataset folder.
+func NewD3MDataset(datasetName string, datasetPath string) (*D3M, error) {
+
+	return &D3M{
+		DatasetName: datasetName,
+		DatasetPath: datasetPath,
+	}, nil
+}
+
+// CreateDataset processes the D3M dataset and updates it as needed to meet distil needs.
+func (d *D3M) CreateDataset(rootDataPath string, datasetName string, config *env.Config) (*api.RawDataset, error) {
+	if datasetName == "" {
+		datasetName = d.DatasetName
+	}
+
+	// read the metadata
+	meta, err := metadata.LoadMetadataFromOriginalSchema(path.Join(d.DatasetPath, compute.D3MDataSchema), false)
+	if err != nil {
+		return nil, err
+	}
+
+	// update the id & name & storage name
+	datasetID := model.NormalizeDatasetID(datasetName)
+	meta.Name = datasetName
+	meta.ID = datasetName
+	meta.StorageName = datasetID
+
+	// read the data
+	csvData, err := util.ReadCSVFile(path.Join(d.DatasetPath, meta.GetMainDataResource().ResPath), false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.RawDataset{
+		ID:       datasetID,
+		Name:     datasetName,
+		Data:     csvData,
+		Metadata: meta,
+	}, nil
+}

--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -229,18 +229,16 @@ func createDataset(datasetPath string, datasetName string, config *env.Config) (
 	}
 
 	// create the raw dataset
-	formattedPath, ds, group, err := createRawDataset(datasetPath, datasetName)
+	ds, group, err := createRawDataset(datasetPath, datasetName)
 	if err != nil {
 		return nil, err
 	}
 
 	// create the formatted d3m dataset
-	if ds != nil {
-		outputPath := path.Join(config.D3MOutputDir, config.AugmentedSubFolder)
-		datasetName, formattedPath, err = task.CreateDataset(datasetName, ds, outputPath, config)
-		if err != nil {
-			return nil, err
-		}
+	outputPath := path.Join(config.D3MOutputDir, config.AugmentedSubFolder)
+	datasetName, formattedPath, err := task.CreateDataset(datasetName, ds, outputPath, config)
+	if err != nil {
+		return nil, err
 	}
 
 	return &datasetCreationResult{
@@ -250,12 +248,12 @@ func createDataset(datasetPath string, datasetName string, config *env.Config) (
 	}, nil
 }
 
-func createRawDataset(datasetPath string, datasetName string) (string, task.DatasetConstructor, map[string]interface{}, error) {
+func createRawDataset(datasetPath string, datasetName string) (task.DatasetConstructor, map[string]interface{}, error) {
 	if util.IsArchiveFile(datasetPath) {
 		// expand the archive
 		expandedInfo, err := dataset.ExpandZipDataset(datasetPath, datasetName)
 		if err != nil {
-			return "", nil, nil, err
+			return nil, nil, err
 		}
 
 		datasetPath = expandedInfo.ExtractedFilePath
@@ -274,7 +272,7 @@ func createRawDataset(datasetPath string, datasetName string) (string, task.Data
 		var fileType string
 		fileType, err = dataset.CheckFileType(datasetPath)
 		if err != nil {
-			return "", nil, nil, err
+			return nil, nil, err
 		}
 		if fileType == "png" || fileType == "jpeg" || fileType == "jpg" {
 			ds, err = createMediaDataset(datasetName, fileType, datasetPath)
@@ -288,10 +286,10 @@ func createRawDataset(datasetPath string, datasetName string) (string, task.Data
 		}
 	}
 	if err != nil {
-		return "", nil, nil, err
+		return nil, nil, err
 	}
 
-	return datasetPath, ds, group, nil
+	return ds, group, nil
 }
 
 func rawDatasetIsTabular(datasetPath string) bool {


### PR DESCRIPTION
D3M datasets can be imported via archive file. The normal ingest pipeline will run on them and then they will be available like other types of import.