### PR TITLE
#1778 Additional Variable Facet Fix

### DIFF
--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -157,4 +157,8 @@ export default Vue.extend({
   padding: 4px 0;
   line-height: 30px;
 }
+
+.available-training-variables /deep/ .variable-facets-wrapper {
+  height: 100%;
+}
 </style>

--- a/public/components/TrainingVariables.vue
+++ b/public/components/TrainingVariables.vue
@@ -217,4 +217,8 @@ export default Vue.extend({
   padding: 4px 0;
   line-height: 30px;
 }
+
+.training-variables /deep/ .variable-facets-wrapper {
+  height: 100%;
+}
 </style>


### PR DESCRIPTION
Chrome display issue for in use and available training variables fixed by hard setting 100% height on the custom css for those instances of the variable facet component.