### PR TITLE
#1734 Result Screen Correctness Error Fix

### DIFF
--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -556,9 +556,7 @@ export const actions = {
       varMode: SummaryMode;
     }
   ) {
-    if (
-      !validateArgs(args, ["dataset", "solutionId", "highlight", "varMode"])
-    ) {
+    if (!validateArgs(args, ["dataset", "solutionId", "varMode"])) {
       return null;
     }
 
@@ -599,14 +597,13 @@ export const actions = {
     context: ResultsContext,
     args: {
       dataset: string;
+      target: string;
       requestIds: string[];
       highlight: Highlight;
-      varMode: SummaryMode;
+      varModes: Map<string, SummaryMode>;
     }
   ) {
-    if (
-      !validateArgs(args, ["dataset", "requestIds", "highlight", "varMode"])
-    ) {
+    if (!validateArgs(args, ["dataset", "target", "requestIds"])) {
       return null;
     }
 
@@ -620,7 +617,9 @@ export const actions = {
           dataset: args.dataset,
           solutionId: solution.solutionId,
           highlight: args.highlight,
-          varMode: args.varMode
+          varMode: args.varModes.has(args.target)
+            ? args.varModes.get(args.target)
+            : SummaryMode.Default
         });
       })
     );

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -473,11 +473,10 @@ export const actions = {
     } else if (task.includes(TaskTypes.CLASSIFICATION)) {
       resultActions.fetchCorrectnessSummaries(store, {
         dataset: dataset,
+        target: target,
         requestIds: requestIds,
         highlight: highlight,
-        varMode: varModes.has(target)
-          ? varModes.get(target)
-          : SummaryMode.Default
+        varModes: varModes
       });
     } else {
       console.error(`unhandled task type ${task}`);

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -153,7 +153,8 @@ export default Vue.extend({
 }
 .results-variable-summaries,
 .results-result-comparison,
-.results-result-summaries {
+.results-result-summaries,
+.results-variable-summaries /deep/ .variable-facets-wrapper {
   height: 100%;
 }
 @media (max-width: 767px) {


### PR DESCRIPTION
Fixes #1734. Missing error summaries were caused by over-restrictive argument validation for correctness summary calls and made worse by those calls requiring slightly different arguments than residual summaries for no reason - fixing those things ensure the correctness summary is called even without highlights defined. Also added a CSS rule to fix the feature summary variable display.