### PR TITLE
#1805 Fix Empty Categorical Labeling

### DIFF
--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -248,7 +248,7 @@ func (f *CategoricalField) parseHistogram(rows pgx.Rows) (*api.Histogram, error)
 				return nil, errors.Wrap(err, fmt.Sprintf("no %s histogram aggregation found", termsAggName))
 			}
 			if len(term) < 1 {
-				term = "&lt;empty&gt;"
+				term = "<none>"
 			}
 
 			buckets = append(buckets, &api.Bucket{


### PR DESCRIPTION
Fixes #1805. Replaces &lt empty $gt with <none> in the go.