### PR TITLE
#1811 fix included excluded tab styling.

### DIFF
--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="select-data-slot">
-    <view-type-toggle v-model="viewTypeModel" has-tabs :variables="variables">
+    <view-type-toggle has-tabs v-model="viewTypeModel" :variables="variables">
       <b-nav-item
         class="font-weight-bold"
         @click="setIncludedActive"
@@ -490,5 +490,22 @@ table tr {
   margin-top: auto;
   vertical-align: baseline;
   margin-bottom: -3px;
+}
+.select-data-slot .nav-link.active {
+  border-top: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #e0e0e0;
+  border-left: 1px solid #aaa;
+  border-top-left-radius: 2px;
+  border-top-left-radius: 0.125rem;
+  border-top-right-radius: 2px;
+  border-top-right-radius: 0.125rem;
+  color: rgba(0, 0, 0, 1);
+}
+.select-data-slot .nav-item > a {
+  color: rgba(0, 0, 0, 0.5);
+}
+.select-data-slot .nav-tabs .nav-link {
+  padding: 0.5rem 0.75rem 1rem;
 }
 </style>

--- a/public/views/SelectTraining.vue
+++ b/public/views/SelectTraining.vue
@@ -177,11 +177,6 @@ export default Vue.extend({
 .select-training-view {
   flex-direction: row-reverse;
 }
-.select-view .nav-link {
-  padding: 1rem 0 0.25rem 0;
-  border-bottom: 1px solid #e0e0e0;
-  color: rgba(0, 0, 0, 0.87);
-}
 .select-target-variables {
   min-width: 500px;
   max-width: 600px !important;


### PR DESCRIPTION
Fixes #1811 - New uncharted bootstrap css overrides all of the nice styles we'd leaned on previously for bootstrap tabs, so added CSS back targeted in the select data slot component to tabs in that area.