### PR TITLE
Ingest sample dataset

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -654,10 +654,18 @@ func SplitTimeSeries(timeseries []*api.TimeseriesObservation, trainPercentage fl
 
 // SampleDataset shuffles a dataset's rows and takes a subsample, returning
 // the raw byte data of the sampled dataset.
-func SampleDataset(rawData [][]string, maxRows int) ([]byte, error) {
+func SampleDataset(rawData [][]string, maxRows int, hasHeader bool) ([]byte, error) {
 	// initialize csv writer
 	output := &bytes.Buffer{}
 	writer := csv.NewWriter(output)
+
+	if hasHeader {
+		err := writer.Write(rawData[0])
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to write header to sampled data")
+		}
+		rawData = rawData[1:]
+	}
 
 	err := shuffleAndWrite(rawData, -1, maxRows, 0, writer, nil)
 	if err != nil {

--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -671,6 +671,7 @@ func SampleDataset(rawData [][]string, maxRows int, hasHeader bool) ([]byte, err
 	if err != nil {
 		return nil, err
 	}
+	writer.Flush()
 
 	return output.Bytes(), nil
 }

--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -290,14 +290,14 @@ func splitTrainTest(sourceFile string, trainFile string, testFile string, hasHea
 		for _, data := range categoryRowData {
 			maxCategoryTrainingRows := int(math.Max(1, float64(len(data))/float64(len(rowData))*float64(numTrainingRows)))
 			maxCategoryTestRows := int(math.Max(1, float64(len(data))/float64(len(rowData))*float64(numTestRows)))
-			err := shuffleAndWrite(data, targetCol, groupingCol, maxCategoryTrainingRows, maxCategoryTestRows, writerTrain, writerTest)
+			err := shuffleAndWrite(data, groupingCol, maxCategoryTrainingRows, maxCategoryTestRows, writerTrain, writerTest)
 			if err != nil {
 				return err
 			}
 		}
 	} else {
 		// randomly select from dataset based on row limits
-		err := shuffleAndWrite(rowData, targetCol, groupingCol, numTrainingRows, numTestRows, writerTrain, writerTest)
+		err := shuffleAndWrite(rowData, groupingCol, numTrainingRows, numTestRows, writerTrain, writerTest)
 		if err != nil {
 			return err
 		}
@@ -329,7 +329,7 @@ func (s *shuffleTracker) lessThanMax() bool {
 	return s.count < s.max
 }
 
-func shuffleAndWrite(rowData [][]string, targetCol int, groupCol int, maxTrainingCount int, maxTestCount int, writerTrain *csv.Writer, writerTest *csv.Writer) error {
+func shuffleAndWrite(rowData [][]string, groupCol int, maxTrainingCount int, maxTestCount int, writerTrain *csv.Writer, writerTest *csv.Writer) error {
 	if maxTrainingCount <= 0 {
 		maxTrainingCount = math.MaxInt64
 	}
@@ -361,11 +361,7 @@ func shuffleAndWrite(rowData [][]string, targetCol int, groupCol int, maxTrainin
 		// test data
 		tracker := shuffleTest
 		for _, data := range rowData {
-			err := tracker.writer.Write(data)
-			if err != nil {
-				return errors.Wrap(err, "unable to write data to train/test output")
-			}
-			tracker.count++
+			// could want to write 0 rows of data (ex: sampling)
 			if !tracker.lessThanMax() {
 				if tracker == shuffleTest {
 					tracker = shuffleTrain
@@ -373,6 +369,12 @@ func shuffleAndWrite(rowData [][]string, targetCol int, groupCol int, maxTrainin
 					break
 				}
 			}
+			err := tracker.writer.Write(data)
+			if err != nil {
+				return errors.Wrap(err, "unable to write data to train/test output")
+			}
+			tracker.count++
+
 		}
 	} else {
 		groupData := map[string][][]string{}
@@ -648,4 +650,19 @@ func SplitTimeSeries(timeseries []*api.TimeseriesObservation, trainPercentage fl
 		timestamps[i] = v.Time
 	}
 	return SplitTimeStamps(timestamps, trainPercentage)
+}
+
+// SampleDataset shuffles a dataset's rows and takes a subsample, returning
+// the raw byte data of the sampled dataset.
+func SampleDataset(rawData [][]string, maxRows int) ([]byte, error) {
+	// initialize csv writer
+	output := &bytes.Buffer{}
+	writer := csv.NewWriter(output)
+
+	err := shuffleAndWrite(rawData, -1, maxRows, 0, writer, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return output.Bytes(), nil
 }

--- a/api/env/config.go
+++ b/api/env/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	ImportErrorThreshold               float64 `env:"IMPORT_ERROR_THRESHOLD" envDefault:"0.1"`
 	IngestHardFail                     bool    `env:"INGEST_HARD_FAIL" envDefault:"false"`
 	IngestOverwrite                    bool    `env:"INGEST_OVERWRITE" envDefault:"false"`
+	IngestSampleRowLimit               int     `env:"INGEST_SAMPLE_ROW_LIMIT" envDefault:"25000"`
 	InitialDataset                     string  `env:"INITIAL_DATASET" envDefault:""`
 	MaxTrainingRows                    int     `env:"MAX_TRAINING_ROWS" envDefault:"100000"`
 	MaxTestRows                        int     `env:"MAX_TEST_ROWS" envDefault:"100000"`

--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -121,14 +121,18 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 		// ingest the imported dataset
 		ingestSteps := &task.IngestSteps{ClassificationOverwrite: false, RawGrouping: rawGrouping}
 		ingestConfig := task.NewConfig(*config)
-		datasetID, err = task.IngestDataset(source, dataCtor, esMetaCtor, datasetID, origins, api.DatasetTypeModelling, ingestConfig, ingestSteps)
+		ingestResult, err := task.IngestDataset(source, dataCtor, esMetaCtor, datasetID, origins, api.DatasetTypeModelling, ingestConfig, ingestSteps)
 		if err != nil {
 			handleError(w, err)
 			return
 		}
 
 		// marshal data and sent the response back
-		err = handleJSON(w, map[string]interface{}{"dataset": datasetID, "result": "ingested"})
+		err = handleJSON(w, map[string]interface{}{
+			"dataset":  ingestResult.DatasetID,
+			"sampled":  ingestResult.Sampled,
+			"rowCount": ingestResult.RowCount,
+			"result":   "ingested"})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
 			return

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -249,7 +249,7 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	// not sure if better to call canSample here, or as the first part of the sample step
 	sampled := false
 	rowCount := 0
-	if canSample(latestSchemaOutput) {
+	if canSample(latestSchemaOutput, config) {
 		log.Infof("sampling dataset")
 		latestSchemaOutput, sampled, rowCount, err = Sample(originalSchemaFile, latestSchemaOutput, dataset, config)
 		if err != nil {

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -143,20 +143,27 @@ func NewConfig(config env.Config) *IngestTaskConfig {
 	}
 }
 
+// IngestResult captures the result of a dataset ingest process.
+type IngestResult struct {
+	DatasetID string
+	Sampled   bool
+	RowCount  int
+}
+
 // IngestDataset executes the complete ingest process for the specified dataset.
 func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorageCtor, metaCtor api.MetadataStorageCtor,
-	dataset string, origins []*model.DatasetOrigin, datasetType api.DatasetType, config *IngestTaskConfig, steps *IngestSteps) (string, error) {
+	dataset string, origins []*model.DatasetOrigin, datasetType api.DatasetType, config *IngestTaskConfig, steps *IngestSteps) (*IngestResult, error) {
 	// Set the probability threshold
 	metadata.SetTypeProbabilityThreshold(config.ClassificationProbabilityThreshold)
 
 	metaStorage, err := metaCtor()
 	if err != nil {
-		return "", errors.Wrap(err, "unable to initialize metadata storage")
+		return nil, errors.Wrap(err, "unable to initialize metadata storage")
 	}
 
 	dataStorage, err := dataCtor()
 	if err != nil {
-		return "", errors.Wrap(err, "unable to initialize data storage")
+		return nil, errors.Wrap(err, "unable to initialize data storage")
 	}
 
 	sourceFolder := env.ResolvePath(datasetSource, dataset)
@@ -169,7 +176,7 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 		output, err = ClusterDataset(latestSchemaOutput, dataset, config)
 		if err != nil {
 			if config.HardFail {
-				return "", errors.Wrap(err, "unable to cluster all data")
+				return nil, errors.Wrap(err, "unable to cluster all data")
 			}
 			log.Errorf("unable to cluster all data: %v", err)
 		} else {
@@ -180,14 +187,14 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 
 	output, err = Merge(latestSchemaOutput, dataset, config)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to merge all data into a single file")
+		return nil, errors.Wrap(err, "unable to merge all data into a single file")
 	}
 	latestSchemaOutput = output
 	log.Infof("finished merging the dataset")
 
 	output, err = Clean(latestSchemaOutput, dataset, config)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to clean all data")
+		return nil, errors.Wrap(err, "unable to clean all data")
 	}
 	latestSchemaOutput = output
 	log.Infof("finished cleaning the dataset")
@@ -198,7 +205,7 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 			_, err = Classify(latestSchemaOutput, dataset, config)
 			if err != nil {
 				if config.HardFail {
-					return "", errors.Wrap(err, "unable to classify fields")
+					return nil, errors.Wrap(err, "unable to classify fields")
 				}
 				log.Errorf("unable to classify fields: %+v", err)
 			}
@@ -222,7 +229,7 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 		log.Infof("finished summarizing the dataset")
 		if err != nil {
 			if config.HardFail {
-				return "", errors.Wrap(err, "unable to summarize the dataset")
+				return nil, errors.Wrap(err, "unable to summarize the dataset")
 			}
 			log.Errorf("unable to summarize the dataset: %v", err)
 		}
@@ -233,25 +240,27 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	if config.GeocodingEnabled {
 		output, err = GeocodeForwardDataset(latestSchemaOutput, dataset, config)
 		if err != nil {
-			return "", errors.Wrap(err, "unable to geocode all data")
+			return nil, errors.Wrap(err, "unable to geocode all data")
 		}
 		latestSchemaOutput = output
 		log.Infof("finished geocoding the dataset")
 	}
 
 	// not sure if better to call canSample here, or as the first part of the sample step
+	sampled := false
+	rowCount := 0
 	if canSample(latestSchemaOutput) {
 		log.Infof("sampling dataset")
-		latestSchemaOutput, err = Sample(originalSchemaFile, latestSchemaOutput, dataset, config)
+		latestSchemaOutput, sampled, rowCount, err = Sample(originalSchemaFile, latestSchemaOutput, dataset, config)
 		if err != nil {
-			return "", errors.Wrap(err, "unable to sample dataset")
+			return nil, errors.Wrap(err, "unable to sample dataset")
 		}
 		log.Infof("finished sampling dataset")
 	}
 
 	datasetID, err := Ingest(originalSchemaFile, latestSchemaOutput, dataStorage, metaStorage, dataset, datasetSource, origins, datasetType, config, true, !definitiveClassification, true)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to ingest ranked data")
+		return nil, errors.Wrap(err, "unable to ingest ranked data")
 	}
 	log.Infof("finished ingesting the dataset")
 
@@ -260,7 +269,7 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 		log.Infof("creating groupings in metadata")
 		err = SetGroups(datasetID, steps.RawGrouping, metaStorage, config)
 		if err != nil {
-			return "", errors.Wrap(err, "unable to set grouping")
+			return nil, errors.Wrap(err, "unable to set grouping")
 		}
 		log.Infof("done creating groupings in metadata")
 	}
@@ -269,17 +278,17 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	if config.FeaturizationEnabled && canFeaturize(dataset, metaStorage) {
 		_, featurizedDatasetPath, err := FeaturizeDataset(originalSchemaFile, latestSchemaOutput, dataset, metaStorage, config)
 		if err != nil {
-			return "", errors.Wrap(err, "unable to featurize dataset")
+			return nil, errors.Wrap(err, "unable to featurize dataset")
 		}
 		log.Infof("finished featurizing the dataset")
 		ingestedDataset, err := metaStorage.FetchDataset(dataset, true, true)
 		if err != nil {
-			return "", errors.Wrap(err, "unable to load metadata")
+			return nil, errors.Wrap(err, "unable to load metadata")
 		}
 		ingestedDataset.LearningDataset = featurizedDatasetPath
 		err = metaStorage.UpdateDataset(ingestedDataset)
 		if err != nil {
-			return "", errors.Wrap(err, "unable to store updated metadata")
+			return nil, errors.Wrap(err, "unable to store updated metadata")
 		}
 	}
 
@@ -290,7 +299,11 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	}
 	log.Infof("finished updating extremas")
 
-	return datasetID, nil
+	return &IngestResult{
+		DatasetID: datasetID,
+		Sampled:   sampled,
+		RowCount:  rowCount,
+	}, nil
 }
 
 // Ingest the metadata to ES and the data to Postgres.

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -242,7 +242,7 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	// not sure if better to call canSample here, or as the first part of the sample step
 	if canSample(latestSchemaOutput) {
 		log.Infof("sampling dataset")
-		latestSchemaOutput, err = Sample(latestSchemaOutput, dataset, config)
+		latestSchemaOutput, err = Sample(originalSchemaFile, latestSchemaOutput, dataset, config)
 		if err != nil {
 			return "", errors.Wrap(err, "unable to sample dataset")
 		}
@@ -551,11 +551,12 @@ func loadMetadataForIngest(originalSchemaFile string, schemaFile string, source 
 		log.Warnf("unable to load importance from file: %v", err)
 	}
 
-	// load stats
+	// load stats and adjust for header row (may want to do in the LoadDatasetStats function)
 	err = metadata.LoadDatasetStats(meta, dataDir)
 	if err != nil {
 		log.Warnf("unable to load stats: %v", err)
 	}
+	meta.NumRows = meta.NumRows - 1
 
 	// load summary
 	metadata.LoadSummaryFromDescription(meta, path.Join(datasetDir, config.SummaryOutputPathRelative))

--- a/api/task/sample.go
+++ b/api/task/sample.go
@@ -1,0 +1,84 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package task
+
+import (
+	"os"
+	"path"
+
+	"github.com/pkg/errors"
+	log "github.com/unchartedsoftware/plog"
+
+	"github.com/uncharted-distil/distil-compute/metadata"
+	"github.com/uncharted-distil/distil-compute/model"
+	"github.com/uncharted-distil/distil/api/compute"
+	"github.com/uncharted-distil/distil/api/util"
+)
+
+// Sample takes a sample of the dataset since larger datasets can lead to broken
+// user experience through long lasting TA2 processing.
+func Sample(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
+	// load metadata from original schema
+	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to load original schema file")
+	}
+	mainDR := meta.GetMainDataResource()
+
+	// extract a sample by simply reading the main CSV file and selecting a subset
+	csvFilePath := path.Join(path.Dir(schemaFile), mainDR.ResPath)
+	csvData, err := util.ReadCSVFile(csvFilePath, false)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to parse complete csv dataset")
+	}
+
+	sampledData, err := compute.SampleDataset(csvData, config.SampleRowLimit)
+	if err != nil {
+		return "", err
+	}
+
+	// copy the full csv to keep it if needed
+	err = util.CopyFile(csvFilePath, path.Join(path.Dir(schemaFile), "learningData-full.csv"))
+	if err != nil {
+		return "", err
+	}
+
+	// output to the expected location (learningData.csv)
+	err = util.WriteFileWithDirs(csvFilePath, sampledData, os.ModePerm)
+	if err != nil {
+		return "", err
+	}
+
+	return schemaFile, nil
+}
+
+func canSample(schemaFile string) bool {
+	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)
+	if err != nil {
+		log.Warnf("unable to load schema file for sampling: %+v", err)
+		return false
+	}
+
+	for _, dr := range meta.DataResources {
+		for _, v := range dr.Variables {
+			if model.IsRemoteSensing(v.Type) || model.IsTimeSeries(v.Type) {
+				return false
+			}
+		}
+	}
+
+	return true
+}

--- a/api/task/sample.go
+++ b/api/task/sample.go
@@ -45,7 +45,7 @@ func Sample(schemaFile string, dataset string, config *IngestTaskConfig) (string
 		return "", errors.Wrap(err, "unable to parse complete csv dataset")
 	}
 
-	sampledData, err := compute.SampleDataset(csvData, config.SampleRowLimit)
+	sampledData, err := compute.SampleDataset(csvData, config.SampleRowLimit, true)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fixes #1817 

The dataset is sampled right before ingest, but after classification to increase the odds of it properly identifying remote sensing and timeseries datasets. I am fairly certain it would not quite work so this part will probably need updating as more testing becomes possible with remote sensing datasets. Currently remote sensing is not sampled by checking for a geobounds type in the variables. Timeseries dont get detected on ingest so they will most certainly get subsampled.