### PR TITLE
#1818 results ellipsis fix

### DIFF
--- a/public/components/FixedHeaderTable.vue
+++ b/public/components/FixedHeaderTable.vue
@@ -80,7 +80,7 @@ export default Vue.extend({
               ? cellOffsetWidth
               : remainingCellWidth
             : cellOffsetWidth < maxCellWidth ||
-              !!tbodyCells[i].querySelector("div")
+              !!tbodyCells[i].querySelector("div.container")
             ? cellOffsetWidth
             : maxCellWidth;
         remainingCellWidth = remainingCellWidth - headCellWidth;


### PR DESCRIPTION
Fixes #1818 - improved the selector that determines whether or not we use a cell's width in determining the column's width such that we only use the cell width when it's a sparkline (whose has parent with a div the container class,) not just on any div (which we have in the table cells when we have weights.)