### PR TITLE
Properly handles null/undefined when sorting by importance

### DIFF
--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -523,6 +523,12 @@ export function sortSolutionSummariesByImportance(
   });
   // sort by importance
   summaries.sort((a, b) => {
+    if (!importance[b.key]) {
+      return -1;
+    }
+    if (!importance[a.key]) {
+      return 1;
+    }
     return importance[b.key] - importance[a.key];
   });
   return summaries;


### PR DESCRIPTION
fixes #1808 

Importances that were undefined were not being properly handled in the sort.