### PR TITLE
Use variable name rather than display name when comparing to csv header

### DIFF
--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -124,9 +124,8 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 		}
 		rawHeader := rawCSVData[0]
 		for i, f := range rawHeader {
-			// TODO: may have to check the name rather than display name
 			// TODO: col index not necessarily the same as index and thats what needs checking
-			if meta.GetMainDataResource().Variables[i].DisplayName != f {
+			if meta.GetMainDataResource().Variables[i].Name != f {
 				return nil, errors.Errorf("variables in new prediction file do not match variables in original dataset")
 			}
 		}


### PR DESCRIPTION
Fixes #1825 

The display name replaces underscores with spaces, which resulted the JIDO var `GIN_status` becoming `GIN status` when it was treated as a display name.  We were using the display name to compare to the CSV file header names when determining whether or not the input was aligned, which resulted in a mismatch on anything with underscores.
