### PR TITLE
Postgres Querying Performance

### DIFF
--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -293,6 +293,9 @@ func (s *Storage) insertBulkCopy(storageName string, varNames []string, inserts 
 		return errors.Errorf("only bulk copied %d of %d rows to postgres", rowsCopied, len(inserts))
 	}
 
+	// update the stats to make sure postgres runs the best queries possible
+	s.updateStats(storageName)
+
 	return nil
 }
 
@@ -367,6 +370,9 @@ func (s *Storage) insertBatchData(storageName string, varNames []string, inserts
 		}
 		resBatch.Close()
 	}
+
+	// update the stats to make sure postgres runs the best queries possible
+	s.updateStats(storageName)
 
 	return nil
 }

--- a/api/model/storage/postgres/storage.go
+++ b/api/model/storage/postgres/storage.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	log "github.com/unchartedsoftware/plog"
 
 	"github.com/uncharted-distil/distil-compute/model"
 
@@ -104,4 +105,11 @@ func (s *Storage) GetStorageName(dataset string) (string, error) {
 	}
 
 	return currentName, nil
+}
+
+func (s *Storage) updateStats(storageName string) {
+	_, err := s.client.Exec(fmt.Sprintf("ANALYZE \"%s\"", storageName))
+	if err != nil {
+		log.Warnf("error updating postgres stats for %s: %+v", storageName, err)
+	}
 }

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -439,6 +439,14 @@ func (d *Database) InsertRemainingRows() error {
 			if err != nil {
 				return errors.Wrap(err, "unable to insert remaining rows for table "+tableName)
 			}
+
+			if tableName != WordStemTableName {
+				tableName = fmt.Sprintf("%s_base", tableName)
+			}
+			_, err = d.Client.Exec(fmt.Sprintf("ANALYZE \"%s\"", tableName))
+			if err != nil {
+				log.Warnf("error updating stats for %s: %+v", tableName, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #1813 

Update postgres stats when bulk ingest occurs to help postgres use faster query plans. For this particular dataset, it was using a really bad join query plan most likely because the bulk insert of the results made postgres unaware of the new data.