### PR TITLE
Remove call to geo referencing

### DIFF
--- a/public/components/ForecastHorizon.vue
+++ b/public/components/ForecastHorizon.vue
@@ -7,12 +7,7 @@
     @cancel="showError = false"
   >
     <b-form-group label="Interval size" description="Size of the prediction">
-      <b-form-spinbutton
-        v-model="intervalLength"
-        class="flex-0"
-        inline
-        min="1"
-      />
+      <b-form-spinbutton v-model="intervalLength" inline min="1" />
       <!-- Add a dateTime scale selection. -->
       <b-dropdown
         v-if="isDateTime"
@@ -150,7 +145,6 @@ export default Vue.extend({
           requestMsg
         );
 
-        // this.$bvModal.hide("forecast-horizon-modal");
         this.predidctionFinish(response);
       } catch (error) {
         this.showError = true;

--- a/public/components/StatusSidebar.vue
+++ b/public/components/StatusSidebar.vue
@@ -12,6 +12,9 @@
           class="new-update-notification fa fa-refresh fa-spin"
         ></i>
       </div>
+      <!-- TODO
+        * Disabled because the current solution is not responsive enough:
+        * https://github.com/uncharted-distil/distil/issues/1815
       <div class="status-icon-wrapper" @click="onStatusIconClick(1)">
         <i
           class="status-icon fa fa-2x fa-location-arrow"
@@ -26,6 +29,7 @@
           class="new-update-notification fa fa-refresh fa-spin"
         ></i>
       </div>
+      -->
       <div class="status-icon-wrapper" @click="onStatusIconClick(2)">
         <i class="status-icon fa fa-2x fa-share-alt" aria-hidden="true"></i>
         <i
@@ -198,7 +202,7 @@ export default Vue.extend({
 });
 </script>
 
-<style>
+<style scoped>
 .status-sidebar {
   background-color: #fff;
   width: 55px;
@@ -220,7 +224,7 @@ export default Vue.extend({
 }
 .status-sidebar .new-update-notification {
   position: absolute;
-  color: #dc3545;
+  color: var(--red);
   top: 10px;
   right: 10px;
 }

--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -340,12 +340,17 @@ export default Vue.extend({
           type: type
         })
         .then(() => {
+          /* TODO
+           * Disabled because the current solution is not responsive enough:
+           * https://github.com/uncharted-distil/distil/issues/1815
           if (isLocationType(type)) {
             return datasetActions.geocodeVariable(this.$store, {
               dataset: dataset,
               field: field
             });
-          } else if (type === "image") {
+          } else if (type === "image") { 
+          */
+          if (type === "image") {
             return datasetActions.fetchClusters(this.$store, {
               dataset: this.dataset
             });

--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -226,7 +226,7 @@ export default Vue.extend({
         this.type === this.originalType && // we haven't changed the type (check from server)
         !this.isColTypeReviewed && // check if user ever reviewed the col type (client)
         this.hasSchemaType &&
-        this.schemaType.type != "unknown" && // don't flag for check when the schema type was unknown (which is the base type)
+        this.schemaType.type !== "unknown" && // don't flag for check when the schema type was unknown (which is the base type)
         this.hasNonSchemaTypes &&
         this.topNonSchemaType.probability >= PROBABILITY_THRESHOLD && // it has both schema and ML types
         !isEquivalentType(this.schemaType.type, this.topNonSchemaType.type)

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -133,6 +133,10 @@ export const actions = {
     context: DatasetContext,
     args: { dataset: string; field: string }
   ): Promise<any> {
+    return null;
+    /* TODO
+     * Disabled because the current solution is not responsive enough:
+     * https://github.com/uncharted-distil/distil/issues/1815
     if (!validateArgs(args, ["dataset", "field"])) {
       return null;
     }
@@ -157,6 +161,7 @@ export const actions = {
       });
       console.error(error);
     }
+    */
   },
 
   fetchGeocodingResults(


### PR DESCRIPTION
closes #1815 

- Remove call to `datasetActions.geocodeVariable()` when a user change the type of a variable.
- Disable `datasetActions.geocodeVariable()` to return `null`.
- Remove the icon from the **StatusSidebar** component.