### PR TITLE
Expand Geo and Timeseries facet expanded on Select Target page.

### DIFF
--- a/public/components/facets/FacetTimeseries.vue
+++ b/public/components/facets/FacetTimeseries.vue
@@ -19,8 +19,7 @@
       @categorical-click="onCategoricalClick"
       @facet-click="onFacetClick"
       @range-change="onRangeChange"
-    >
-    </facet-sparklines>
+    />
     <component
       :is="facetType"
       v-if="!!timelineSummary && expand"
@@ -37,8 +36,7 @@
       @numerical-click="onHistogramNumericalClick"
       @categorical-click="onHistogramCategoricalClick"
       @range-change="onHistogramRangeChange"
-    >
-    </component>
+    />
   </div>
 </template>
 
@@ -65,6 +63,10 @@ import {
   COLLAPSE_ACTION_TYPE
 } from "../../util/types";
 
+/**
+ * Timeseries Facet.
+ * @param {Boolean} [expanded=false] - To display the facet expanded; Collapsed by default.
+ */
 export default Vue.extend({
   name: "facet-timeseries",
 
@@ -86,14 +88,15 @@ export default Vue.extend({
       String as () => string,
       Object as () => any,
       Function as () => Function
-    ]
+    ],
+    expanded: { type: Boolean, default: false }
   },
 
   data() {
     return {
       customHtml: this.html,
       footerHtml: undefined,
-      expand: false
+      expand: this.expanded
     };
   },
 

--- a/public/components/facets/GeocoordinateFacet.vue
+++ b/public/components/facets/GeocoordinateFacet.vue
@@ -11,8 +11,7 @@
         :field="target"
         :expandCollapse="expandCollapse"
         :expand="expand"
-      >
-      </type-change-menu>
+      />
     </div>
     <div class="geofacet-container">
       <div
@@ -48,7 +47,7 @@
         :highlight="latHighlight"
         @numerical-click="latHistogramClick"
         @range-change="latRangeChange"
-      ></facet-numerical>
+      />
       <facet-numerical
         :instanceName="lonSummary.label"
         :summary="lonSummary"
@@ -57,7 +56,7 @@
         :highlight="lonHighlight"
         @numerical-click="lonHistogramClick"
         @range-change="lonRangeChange"
-      ></facet-numerical>
+      />
     </div>
   </div>
 </template>
@@ -174,6 +173,10 @@ const BLACK_PALETTE = [
   "#000000"
 ];
 
+/**
+ * Geocoordinate Facet.
+ * @param {Boolean} [expanded=false] - To display the facet expanded; Collapsed by default.
+ */
 export default Vue.extend({
   name: "geocoordinate-facet",
 
@@ -193,7 +196,8 @@ export default Vue.extend({
     logActivity: {
       type: String as () => Activity,
       default: Activity.DATA_PREPARATION
-    }
+    },
+    expanded: { type: Boolean, default: false }
   },
 
   data() {
@@ -207,15 +211,17 @@ export default Vue.extend({
       selectedRect: null as leaflet.Rectangle,
       baseLineLayer: null as leaflet.Layer,
       filteredLayer: null as leaflet.Layer,
-      expand: false,
+      expand: this.expanded,
       enabledTypeChanges: new Array(0),
       blockNextEvent: false
     };
   },
+
   computed: {
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);
     },
+
     latSummary(): VariableSummary {
       const latSummary: VariableSummary = {
         label: LATITUDE_TYPE,
@@ -228,6 +234,7 @@ export default Vue.extend({
       };
       return latSummary;
     },
+
     lonSummary(): VariableSummary {
       const lonSummary: VariableSummary = {
         label: LONGITUDE_TYPE,
@@ -240,6 +247,7 @@ export default Vue.extend({
       };
       return lonSummary;
     },
+
     latHighlight(): Object {
       if (this.hasValidGeoHighlight) {
         return {
@@ -255,6 +263,7 @@ export default Vue.extend({
         return null;
       }
     },
+
     lonHighlight(): Object {
       if (this.hasValidGeoHighlight) {
         return {
@@ -270,21 +279,27 @@ export default Vue.extend({
         return null;
       }
     },
+
     target(): string {
       return this.summary.key;
     },
+
     instanceName(): string {
       return "unique-map";
     },
+
     mapID(): string {
       return `map-${this.instanceName}`;
     },
+
     // Computes the bounds of the summary data.
     bucketBounds(): helpers.BBox {
       return bbox(this.bucketFeatures);
     },
-    // Creates a GeoJSON feature collection that can be passed directly to a Leaflet layer for rendering.  The collection represents
-    // the baseline bucket set for geocoordinate, and does not change as filters / highlights are introduced.
+
+    // Creates a GeoJSON feature collection that can be passed directly to a Leaflet layer
+    // for rendering.  The collection represents the baseline bucket set for geocoordinate,
+    // and does not change as filters / highlights are introduced.
     bucketFeatures(): helpers.FeatureCollection {
       // compute the bucket size in degrees
       const buckets = this.summary.baseline.buckets;
@@ -321,12 +336,12 @@ export default Vue.extend({
       return featureCollection(features);
     },
 
-    // Creates a GeoJSON feature collection that can be passed directly to a Leaflet layer for rendering.  The collection
-    // represents the subset of buckets to be rendered based on the currently applied filters and highlights.
+    // Creates a GeoJSON feature collection that can be passed directly to a Leaflet layer
+    // for rendering.  The collection represents the subset of buckets to be rendered based
+    // on the currently applied filters and highlights.
     filteredBucketFeatures(): helpers.FeatureCollection {
-      // compute the bucket size in degrees
-
       if (this.summary.filtered) {
+        // compute the bucket size in degrees
         const buckets = this.summary.filtered.buckets;
         const xSize = _.toNumber(buckets[1].key) - _.toNumber(buckets[0].key);
         const ySize =
@@ -382,6 +397,7 @@ export default Vue.extend({
         Number.MIN_SAFE_INTEGER
       );
     },
+
     filteredMinCount(): number {
       return this.filteredBucketFeatures.features.reduce(
         (min, feature) =>
@@ -393,17 +409,21 @@ export default Vue.extend({
     headerLabel(): string {
       return this.summary.label.toUpperCase();
     },
+
     hasFilters(): boolean {
       return routeGetters.getDecodedFilters(this.$store).length > 0;
     },
+
     // is the display in included (blue) or excluded (black) mode
     includedActive(): boolean {
       return routeGetters.getRouteInclude(this.$store);
     },
+
     // is data currently being highlighted
     highlight(): Highlight {
       return routeGetters.getDecodedHighlight(this.$store);
     },
+
     hasValidGeoHighlight(): Boolean {
       return (
         !!this.highlight &&
@@ -414,9 +434,11 @@ export default Vue.extend({
         !!this.highlight.value.maxY
       );
     },
+
     selectedRows(): RowSelection {
       return routeGetters.getDecodedRowSelection(this.$store);
     },
+
     selectedPoints(): helpers.Point[] {
       if (this.selectedRows) {
         const tableItems = this.includedActive
@@ -435,6 +457,7 @@ export default Vue.extend({
       return [];
     }
   },
+
   methods: {
     calcBucketKey(value: string, type: string): string {
       const numValue = _.toNumber(value);
@@ -445,6 +468,7 @@ export default Vue.extend({
       const step = _.toNumber(buckets[1].key) - _.toNumber(buckets[0].key);
       return _.toString(numValue - (numValue % step));
     },
+
     numericWithMetadata(buckets: Bucket[]): BucketData {
       const extrema = {
         min: _.toNumber(buckets[0].key),
@@ -524,6 +548,7 @@ export default Vue.extend({
         "numerical-click"
       );
     },
+
     lonHistogramClick(
       context: string,
       key: string,
@@ -543,6 +568,7 @@ export default Vue.extend({
         "numerical-click"
       );
     },
+
     latRangeChange(
       context: string,
       key: string,
@@ -559,6 +585,7 @@ export default Vue.extend({
         "range-change"
       );
     },
+
     lonRangeChange(
       context: string,
       key: string,
@@ -575,6 +602,7 @@ export default Vue.extend({
         "range-change"
       );
     },
+
     onHistogramAction(
       context: string,
       key: string,
@@ -620,6 +648,7 @@ export default Vue.extend({
         details: { key: key, value: value }
       });
     },
+
     expandCollapse(action) {
       if (action === EXPAND_ACTION_TYPE) {
         this.expand = true;
@@ -627,6 +656,7 @@ export default Vue.extend({
         this.expand = false;
       }
     },
+
     async selectFeature() {
       const training = routeGetters
         .getDecodedTrainingVariableNames(this.$store)
@@ -668,6 +698,7 @@ export default Vue.extend({
 
       this.$router.push(entry);
     },
+
     async removeFeature() {
       const training = routeGetters.getDecodedTrainingVariableNames(
         this.$store
@@ -690,6 +721,7 @@ export default Vue.extend({
 
       removeFiltersByName(this.$router, this.summary.key);
     },
+
     clearSelectionRect() {
       if (this.selectedRect) {
         this.selectedRect.remove();
@@ -704,6 +736,7 @@ export default Vue.extend({
         this.closeButton = null;
       }
     },
+
     onMouseUp(event: MouseEvent) {
       if (this.currentRect) {
         // prevent creation of a single point highlight via click
@@ -721,6 +754,7 @@ export default Vue.extend({
         this.currentRect = null;
       }
     },
+
     onMouseMove(event: MouseEvent) {
       if (this.currentRect) {
         const offset = $(this.map.getContainer()).offset();
@@ -731,6 +765,7 @@ export default Vue.extend({
         this.currentRect.setBounds(bounds);
       }
     },
+
     onMouseDown(event: MouseEvent) {
       const mapEventTarget = event.target as HTMLElement;
 
@@ -776,6 +811,7 @@ export default Vue.extend({
         this.map.dragging.disable();
       }
     },
+
     setSelection(rect: leaflet.Rectangle) {
       this.clearSelection();
 
@@ -802,6 +838,7 @@ export default Vue.extend({
         maxY: ne.lat
       });
     },
+
     clearSelection() {
       if (this.selectedRect) {
         const rectPath = (<any>this.selectedRect)._path;
@@ -812,6 +849,7 @@ export default Vue.extend({
         this.closeButton.remove();
       }
     },
+
     createHighlight(value: {
       minX: number;
       maxX: number;
@@ -836,6 +874,7 @@ export default Vue.extend({
         value: value
       });
     },
+
     drawHighlight() {
       if (
         this.highlight &&
@@ -863,6 +902,7 @@ export default Vue.extend({
         this.setSelection(rect);
       }
     },
+
     paint() {
       // NOTE: this component re-mounts on any change, so do everything in here
       if (!this.highlight) {
@@ -1029,16 +1069,19 @@ export default Vue.extend({
     selectedPoints() {
       this.paint();
     },
+
     bucketFeatures() {
       if (this.summary.baseline) {
         this.paint();
       }
     },
+
     filteredBucketFeatures() {
       if (this.summary.filtered) {
         this.paint();
       }
     },
+
     includedActive() {
       if (!this.includedActive) {
         this.clearSelectionRect();
@@ -1057,8 +1100,8 @@ export default Vue.extend({
   font-family: inherit;
   font-size: 0.867rem;
   font-weight: 700;
-  color: rgba(0, 0, 0, 0.54);
-  background: white;
+  color: var(--color-text-second);
+  background: var(--white);
   padding: 4px 8px 6px;
   position: relative;
   z-index: 1;
@@ -1071,13 +1114,13 @@ export default Vue.extend({
 .facet-card .geofacet-container .action-btn {
   position: relative;
   bottom: 37px;
-  background: white;
+  background: var(--white);
 }
 
 .facet-card .geofacet-container .action-btn:hover {
-  color: #fff;
-  background-color: #9e9e9e;
-  border-color: #9e9e9e;
+  color: var(--white);
+  background-color: var(--gray-600);
+  border-color: var(--gray-600);
 }
 
 .header-title {

--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -46,6 +46,7 @@
                 :enable-highlighting="[enableHighlighting, enableHighlighting]"
                 :ignore-highlights="[ignoreHighlights, ignoreHighlights]"
                 :instanceName="instanceName"
+                :expanded="expandGeoAndTimeseriesFacets"
                 @numerical-click="onNumericalClick"
                 @categorical-click="onCategoricalClick"
                 @facet-click="onFacetClick"
@@ -64,6 +65,7 @@
                 :isAvailableFeatures="isAvailableFeatures"
                 :isFeaturesToModel="isFeaturesToModel"
                 :log-activity="logActivity"
+                :expanded="expandGeoAndTimeseriesFacets"
                 @histogram-numerical-click="onNumericalClick"
                 @histogram-range-change="onRangeChange"
               >
@@ -257,6 +259,7 @@ export default Vue.extend({
         return getRouteFacetPage(this.routePageKey(), this.$route);
       }
     },
+
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);
     },
@@ -333,13 +336,20 @@ export default Vue.extend({
       });
       return typeChangeStatus;
     },
+
     hasPages(): boolean {
       return this.numSummaries > this.rowsPerPage;
     },
+
     variableFacetListClass(): string {
       return this.hasPages
         ? "variable-facets-list-with-footer"
         : "variable-facets-list";
+    },
+
+    expandGeoAndTimeseriesFacets(): Boolean {
+      // The Geocoordinates and Timeseries Facets are expanded on SELECT_TARGET_ROUTE
+      return routeGetters.isPageSelectTarget(this.$store);
     }
   },
 
@@ -461,14 +471,14 @@ button {
 }
 
 .page-link {
-  color: #868e96;
+  color: var(--gray-600);
 }
 
 .page-item.active .page-link {
   z-index: 2;
-  color: #fff;
-  background-color: #868e96;
-  border-color: #868e96;
+  color: var(--white);
+  background-color: var(--gray-700);
+  border-color: var(--gray-700);
 }
 
 /* To display scrollbars on the list of variables facets. */
@@ -490,9 +500,9 @@ button {
   .facets-root-container
   .facets-group-container
   .facets-group {
-  background: white;
+  background: var(--white);
   font-size: 0.867rem;
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--color-text-base);
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1);
   transition: box-shadow 0.3s ease-in-out;
 }

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -8,6 +8,7 @@ import {
   BandID
 } from "../dataset/index";
 import {
+  SELECT_TARGET_ROUTE,
   JOINED_VARS_INSTANCE_PAGE,
   AVAILABLE_TARGET_VARS_INSTANCE_PAGE,
   AVAILABLE_TRAINING_VARS_INSTANCE_PAGE,
@@ -431,11 +432,7 @@ export const getters = {
     return !!isApplyModel;
   },
 
-  /**
-   * Check if the current task includes Remote Sensing.
-   * @param {Route} state
-   * @returns {Boolean}
-   */
+  /* Check if the current task includes Remote Sensing. */
   isRemoteSensing(state: Route): boolean {
     // Get the list of task of the route.
     const task = state.query.task as string;
@@ -447,11 +444,7 @@ export const getters = {
     return task.includes(TaskTypes.REMOTE_SENSING);
   },
 
-  /**
-   * Check if the current task includes Timeseries.
-   * @param {Route} state
-   * @returns {Boolean}
-   */
+  /* Check if the current task includes Timeseries. */
   isTimeseries(state: Route): boolean {
     // Get the list of task of the route.
     const task = state.query.task as string;
@@ -493,5 +486,10 @@ export const getters = {
       qualityStr,
       ModelQuality.HIGHER_QUALITY
     );
+  },
+
+  /* Check if the current page is SELECT_TARGET_ROUTE. */
+  isPageSelectTarget(state: Route): Boolean {
+    return state.path === SELECT_TARGET_ROUTE;
   }
 };

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -94,5 +94,6 @@ export const getters = {
   getBandCombinationId: read(moduleGetters.getBandCombinationId),
   getModelLimit: read(moduleGetters.getModelLimit),
   getModelTimeLimit: read(moduleGetters.getModelTimeLimit),
-  getModelQuality: read(moduleGetters.getModelQuality)
+  getModelQuality: read(moduleGetters.getModelQuality),
+  isPageSelectTarget: read(moduleGetters.isPageSelectTarget)
 };


### PR DESCRIPTION
closes #1840 

- Add `expanded` *prop* on Geo and Timeseries Facets to decide they Expand/Collapse state.
- Add `isPageSelectTarget()` to check if we are on a `SELECT_TARGET_ROUTE`. 
- Add `expandGeoAndTimeseriesFacets()` *computed* on `VariableFacets` component.
