### PR TITLE
Display empty lines instead of 0 for missing values in timeseries

### DIFF
--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -244,7 +244,7 @@ func (s *Storage) FetchTimeseries(dataset string, storageName string, timeseries
 	where := fmt.Sprintf("WHERE %s", strings.Join(wheres, " AND "))
 
 	// Get count by category.
-	query := fmt.Sprintf("SELECT timeline.TimeStamps, COALESCE(filteredEvents.Counts, 0) FROM "+
+	query := fmt.Sprintf("SELECT timeline.TimeStamps, COALESCE(filteredEvents.Counts, 'NaN') FROM "+
 		"(SELECT DISTINCT \"%s\" as TimeStamps FROM %s) timeline LEFT JOIN "+
 		"(SELECT \"%s\" as TimeStamps, \"%s\" as Counts FROM %s %s ) filteredEvents "+
 		"ON timeline.TimeStamps = filteredEvents.TimeStamps ORDER BY timeline.TimeStamps",

--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -316,8 +316,6 @@ export default Vue.extend({
       this.injectTimeseries();
       if (this.forecast) {
         this.injectTimeRangeHighligh();
-      }
-      if (this.forecast) {
         this.injectConfidence();
         this.injectForecast();
       }

--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -184,6 +184,7 @@ export default Vue.extend({
     injectTimeseries() {
       const line = d3
         .line()
+        .defined(d => _.isFinite(d[1])) // Define a filter for non number values.
         .x(d => this.xScale(d[0]))
         .y(d => this.yScale(d[1]))
         .curve(d3.curveLinear);
@@ -193,10 +194,17 @@ export default Vue.extend({
         .attr("transform", `translate(${this.margin.left}, 0)`)
         .attr("class", "line-chart");
 
-      g.datum(this.timeseries.map(x => [x.time, x.value]));
+      const datum = this.timeseries.map(x => [x.time, x.value]);
 
+      // Empty values line
       g.append("path")
-        .attr("fill", "none")
+        .datum(datum.filter(line.defined()))
+        .attr("class", "line-void")
+        .attr("d", line);
+
+      // Sparkline.
+      g.append("path")
+        .datum(datum)
         .attr("class", "line-timeseries")
         .attr("d", line);
     },
@@ -310,20 +318,28 @@ export default Vue.extend({
 }
 
 .line-timeseries {
-  stroke: rgb(200, 200, 200);
+  fill: none;
+  stroke: var(--gray-700); /* rgb(120, 120, 120); */
+  stroke-width: 1.5;
+}
+
+.line-void {
+  fill: none;
+  stroke: var(--gray-500);
+  stroke-dasharray: 2 5;
 }
 
 .line-forecast {
-  stroke: rgb(2, 117, 216);
+  stroke: var(--blue); /* rgb(2, 117, 216); */
 }
 
 .line-confidence {
-  fill: rgb(2, 117, 216);
+  fill: var(--blue); /* rgb(2, 117, 216); */
   opacity: 0.3;
 }
 
 .area-score {
-  fill: rgb(200, 200, 200);
+  fill: var(--gray-500); /* rgb(200, 200, 200); */
   opacity: 0.2;
   stroke: none;
 }

--- a/public/components/SparklineChart.vue
+++ b/public/components/SparklineChart.vue
@@ -10,40 +10,23 @@ import _ from "lodash";
 import Vue from "vue";
 import { TimeSeriesValue } from "../store/dataset/index";
 
+const MARGIN = { top: 24, right: 48, bottom: 16, left: 48 };
+
 export default Vue.extend({
   name: "sparkline-chart",
 
   props: {
     margin: {
       type: Object as () => any,
-      default: () => ({
-        top: 24,
-        right: 48,
-        bottom: 16,
-        left: 48
-      })
+      default: () => MARGIN
     },
-    timeseries: {
-      type: Array as () => TimeSeriesValue[]
-    },
-    forecast: {
-      type: Array as () => TimeSeriesValue[]
-    },
-    highlightRange: {
-      type: Array as () => number[]
-    },
-    xAxisTitle: {
-      type: String as () => string
-    },
-    yAxisTitle: {
-      type: String as () => string
-    },
-    xAxisDateTime: {
-      type: Boolean as () => boolean
-    },
-    joinForecast: {
-      type: Boolean as () => boolean
-    }
+    timeseries: Array as () => TimeSeriesValue[],
+    forecast: Array as () => TimeSeriesValue[],
+    highlightRange: Array as () => number[],
+    xAxisTitle: String,
+    yAxisTitle: String,
+    xAxisDateTime: Boolean,
+    joinForecast: Boolean
   },
 
   data() {
@@ -289,17 +272,27 @@ export default Vue.extend({
         return;
       }
 
-      this.svg
-        .append("rect")
+      const g = this.svg.append("g").attr("class", "area-scoring");
+      const x0 = this.xScale(this.highlightRange[0]);
+      const x1 = this.xScale(this.highlightRange[1]);
+      const translate = `translate(${this.margin.left}, 0)`;
+
+      // Line to demarcate the scoring test.
+      g.append("line")
+        .attr("class", "line-score")
+        .attr("transform", translate)
+        .attr("x1", x0)
+        .attr("x2", x0)
+        .attr("y1", 0)
+        .attr("y2", this.height);
+
+      // area to show the scoring test
+      g.append("rect")
         .attr("class", "area-score")
-        .attr("transform", `translate(${this.margin.left}, 0)`)
-        .attr("x", this.xScale(this.highlightRange[0]))
+        .attr("transform", translate)
+        .attr("x", x0)
         .attr("y", 0)
-        .attr(
-          "width",
-          this.xScale(this.highlightRange[1]) -
-            this.xScale(this.highlightRange[0])
-        )
+        .attr("width", x1 - x0)
         .attr("height", this.height);
     },
 
@@ -320,10 +313,10 @@ export default Vue.extend({
 
       this.clearSVG();
       this.injectAxes();
+      this.injectTimeseries();
       if (this.forecast) {
         this.injectTimeRangeHighligh();
       }
-      this.injectTimeseries();
       if (this.forecast) {
         this.injectConfidence();
         this.injectForecast();
@@ -365,17 +358,23 @@ export default Vue.extend({
 }
 
 .line-forecast {
-  stroke: var(--blue); /* rgb(2, 117, 216); */
+  stroke: var(--blue);
 }
 
 .line-confidence {
-  fill: var(--blue); /* rgb(2, 117, 216); */
+  fill: var(--blue);
   opacity: 0.3;
 }
 
+.line-score {
+  stroke: var(--yellow);
+  stroke-width: 2;
+  opacity: 0.5;
+}
+
 .area-score {
-  fill: var(--gray-500); /* rgb(200, 200, 200); */
-  opacity: 0.2;
+  fill: var(--yellow);
+  opacity: 0.04;
   stroke: none;
 }
 

--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -1,22 +1,21 @@
 <template>
   <div :class="displayClass" v-observe-visibility="visibilityChanged">
     <sparkline-svg
-      :timeseries-extrema="timeseriesExtrema"
       :timeseries="timeseries"
+      :timeseries-extrema="timeseriesExtrema"
       :forecast="forecast"
       :forecast-extrema="forecastExtrema"
       :highlight-range="highlightRange"
       :join-forecast="!!predictionsId"
       :isDateTime="isDateTime()"
-    >
-    </sparkline-svg>
+    />
     <i class="fa fa-plus zoom-sparkline-icon" @click.stop="onClick"></i>
     <b-modal
       id="sparkline-zoom-modal"
-      :title="timeseriesId"
-      @hide="hideModal"
-      :visible="zoomSparkline"
       hide-footer
+      :title="timeseriesId"
+      :visible="zoomSparkline"
+      @hide="hideModal"
     >
       <div v-if="forecast">
         <div class="sparkline-legend">
@@ -31,6 +30,7 @@
         </div>
       </div>
       <sparkline-chart
+        v-if="zoomSparkline"
         :timeseries="timeseries"
         :forecast="forecast"
         :highlight-range="highlightRange"
@@ -38,8 +38,7 @@
         :y-axis-title="yCol"
         :x-axis-date-time="isDateTime()"
         :join-forecast="!!predictionsId"
-        v-if="zoomSparkline"
-      ></sparkline-chart>
+      />
     </b-modal>
   </div>
 </template>
@@ -219,6 +218,7 @@ export default Vue.extend({
         return datasets.isDateTime[this.timeseriesId];
       }
     },
+
     visibilityChanged(isVisible: boolean) {
       this.isVisible = isVisible;
       if (this.isVisible && !this.hasRequested) {

--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -17,17 +17,17 @@
       :visible="zoomSparkline"
       @hide="hideModal"
     >
-      <div v-if="forecast">
-        <div class="sparkline-legend">
-          <div class="sparkline-legend-historical"></div>
-          <div class="sparkline-legend-label">Historical</div>
-          <div class="sparkline-legend-predicted"></div>
-          <div class="sparkline-legend-label">Predicted</div>
-          <div class="sparkline-legend-variability"></div>
-          <div class="sparkline-legend-label">Variability</div>
-          <div class="sparkline-legend-scoring"></div>
-          <div class="sparkline-legend-label">Scoring</div>
-        </div>
+      <div v-if="forecast" class="sparkline-legend">
+        <div class="sparkline-legend-historical"></div>
+        <div class="sparkline-legend-label">Historical</div>
+        <div class="sparkline-legend-missing"></div>
+        <div class="sparkline-legend-label">Missing</div>
+        <div class="sparkline-legend-predicted"></div>
+        <div class="sparkline-legend-label">Predicted</div>
+        <div class="sparkline-legend-variability"></div>
+        <div class="sparkline-legend-label">Variability</div>
+        <div class="sparkline-legend-scoring"></div>
+        <div class="sparkline-legend-label">Scoring</div>
       </div>
       <sparkline-chart
         v-if="zoomSparkline"
@@ -323,20 +323,20 @@ export default Vue.extend({
 }
 
 .sparkline-legend-historical {
-  background: rgb(200, 200, 200);
+  background: var(--gray-700);
   width: 16px;
   height: 2px;
 }
 
 .sparkline-legend-predicted {
-  background: rgb(2, 117, 216);
+  background: var(--blue);
   width: 16px;
   height: 2px;
   margin-left: 14px;
 }
 
 .sparkline-legend-variability {
-  background: rgb(2, 117, 216);
+  background: var(--blue);
   opacity: 0.3;
   width: 12px;
   height: 12px;
@@ -344,10 +344,18 @@ export default Vue.extend({
 }
 
 .sparkline-legend-scoring {
-  background: rgb(200, 200, 200);
-  opacity: 0.2;
+  background: var(--yellow);
+  opacity: 0.5;
   width: 12px;
   height: 12px;
+  margin-left: 14px;
+}
+
+.sparkline-legend-missing {
+  border-color: var(--gray-500);
+  border-style: dotted;
+  border-width: 0 0 2px 0;
+  width: 16px;
   margin-left: 14px;
 }
 </style>

--- a/public/components/SparklineSvg.vue
+++ b/public/components/SparklineSvg.vue
@@ -334,18 +334,28 @@ export default Vue.extend({
         return false;
       }
 
-      this.svg
-        .append("rect")
-        .attr("transform", `translate(${this.margin.left}, ${this.margin.top})`)
+      const g = this.svg.append("g").attr("class", "area-scoring");
+      const x0 = this.xScale(this.highlightRange[0]);
+      const x1 = this.xScale(this.highlightRange[1]);
+      const translate = `translate(${this.margin.left}, ${this.margin.top})`;
+
+      // Line to demarcate the scoring test.
+      g.append("line")
+        .attr("class", "sparkline-line-score")
+        .attr("transform", translate)
+        .attr("x1", x0)
+        .attr("x2", x0)
+        .attr("y1", 0)
+        .attr("y2", this.height);
+
+      // area to show the scoring test
+      g.append("rect")
         .attr("class", "sparkline-area-score")
-        .attr("x", this.xScale(this.highlightRange[0]))
+        .attr("transform", translate)
+        .attr("x", x0)
         .attr("y", 0)
-        .attr(
-          "width",
-          this.xScale(this.highlightRange[1]) -
-            this.xScale(this.highlightRange[0])
-        )
-        .attr("height", this.height());
+        .attr("width", x1 - x0)
+        .attr("height", this.height);
 
       return true;
     },
@@ -498,8 +508,8 @@ export default Vue.extend({
 
       this.clearSVG();
       this.computeLayout();
-      this.injectHighlightRegion();
       this.injectSparkline();
+      this.injectHighlightRegion();
       this.injectPrediction();
       this.injectAxis();
 
@@ -562,9 +572,15 @@ svg .sparkline-axis-title {
   stroke: none;
 }
 
+.sparkline-line-score {
+  stroke: var(--yellow);
+  stroke-width: 2;
+  opacity: 0.5;
+}
+
 .sparkline-area-score {
-  fill: var(--gray-500); /* rgb(200, 200, 200); */
-  opacity: 0.3;
+  fill: var(--yellow);
+  opacity: 0.04;
   stroke: none;
 }
 </style>

--- a/public/components/SparklineSvg.vue
+++ b/public/components/SparklineSvg.vue
@@ -275,7 +275,7 @@ export default Vue.extend({
 
       const line = d3
         .line()
-        .defined(d => !_.isNaN(d[1])) // Define a filter for NaN values.
+        .defined(d => _.isFinite(d[1])) // Define a filter for non number values.
         .x(d => this.xScale(d[0]))
         .y(d => this.yScale(d[1]))
         .curve(d3.curveLinear);


### PR DESCRIPTION
closes #1706 

Change backend to send `null` value instead of `0` if data is missing.
Added a **void** sparkline to illustrate the missing data. The strokes are so thin than using a gradient will be indistinguishable from real data.

### Sparkline
**Before** and **After**
![Screen Shot 2020-07-30 at 16 07 56](https://user-images.githubusercontent.com/636801/88969456-e6e98f80-d27e-11ea-9a67-a8640a6e9d87.png)


### Line Chart
**Before**
![Screen Shot 2020-07-30 at 16 20 19](https://user-images.githubusercontent.com/636801/88970579-aa1e9800-d280-11ea-80a8-dfa33fb63166.png)

 **After**
![Screen Shot 2020-07-30 at 16 18 52](https://user-images.githubusercontent.com/636801/88970569-a559e400-d280-11ea-8bd4-4cb121bd38df.png)


