### PR TITLE
#1839 Hide Series ID select in Timeseries

### DIFF
--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -40,7 +40,11 @@ import {
   hasComputedVarPrefix,
   IMAGE_TYPE,
   REMOTE_SENSING_TYPE,
-  TIMESERIES_TYPE
+  TIMESERIES_TYPE,
+  isLatitudeGroupType,
+  isLongitudeGroupType,
+  isValueGroupType,
+  isTimeGroupType
 } from "../util/types";
 
 // Postfixes for special variable names
@@ -727,4 +731,37 @@ export function getListFields(
     key: f.key,
     type: f.type
   }));
+}
+
+export function hasTimeseriesFeatures(variables: Variable[]): boolean {
+  const valueColumns = variables.filter(v => isValueGroupType(v.colType));
+  const timeColumns = variables.filter(v => isTimeGroupType(v.colType));
+
+  if (
+    (valueColumns.length === 1 &&
+      timeColumns.length === 1 &&
+      valueColumns[0].colName !== timeColumns[0].colName) ||
+    (valueColumns.length > 1 && timeColumns.length > 0) ||
+    (valueColumns.length > 0 && timeColumns.length > 1)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export function hasGeoordinateFeatures(variables: Variable[]): boolean {
+  const latColumns = variables.filter(v => isLatitudeGroupType(v.colType));
+  const lonColumns = variables.filter(v => isLongitudeGroupType(v.colType));
+  if (
+    (latColumns.length === 1 &&
+      lonColumns.length === 1 &&
+      latColumns[0].colName !== lonColumns[0].colName) ||
+    (latColumns.length > 1 && lonColumns.length > 0) ||
+    (latColumns.length > 0 && lonColumns.length > 1)
+  ) {
+    return true;
+  }
+
+  return false;
 }

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -229,6 +229,14 @@ const REAL_COLLECTION_SUGGESTIONS = [
   GEOBOUNDS_TYPE
 ];
 
+const LATITUDE_GROUPING_TYPES = [LATITUDE_TYPE, REAL_TYPE];
+
+const LONGITUDE_GROUPING_TYPES = [LONGITUDE_TYPE, REAL_TYPE];
+
+const TIME_GROUPING_TYPES = [INTEGER_TYPE, DATE_TIME_TYPE, TIMESTAMP_TYPE];
+
+const VALUE_GROUPING_TYPES = [INTEGER_TYPE, REAL_TYPE];
+
 export const BASIC_SUGGESTIONS = [
   INTEGER_TYPE,
   REAL_TYPE,
@@ -444,6 +452,22 @@ export function hasComputedVarPrefix(varName: string): boolean {
 
 export function isClusterType(type: string): boolean {
   return CLUSTER_TYPES.indexOf(type) !== -1;
+}
+
+export function isLatitudeGroupType(type: string): boolean {
+  return LATITUDE_GROUPING_TYPES.indexOf(type) !== -1;
+}
+
+export function isLongitudeGroupType(type: string): boolean {
+  return LONGITUDE_GROUPING_TYPES.indexOf(type) !== -1;
+}
+
+export function isTimeGroupType(type: string): boolean {
+  return TIME_GROUPING_TYPES.indexOf(type) !== -1;
+}
+
+export function isValueGroupType(type: string): boolean {
+  return VALUE_GROUPING_TYPES.indexOf(type) !== -1;
 }
 
 export function addClusterPrefix(varName: string): string {

--- a/public/views/VariableGrouping.vue
+++ b/public/views/VariableGrouping.vue
@@ -18,8 +18,9 @@
             To predict a value over time <strong>(forecasting)</strong> your
             target should be a <strong>timeseries.</strong><br />
             Select a <strong>time</strong> column, a
-            <strong>value</strong> column and optionally add one or more
-            <strong>series id</strong> column(s) to create multiple timeseries.
+            <strong>value</strong> column and if available, optionally add one
+            or more <strong>series id</strong> column(s) to create multiple
+            timeseries.
           </p>
         </b-col>
         <b-col v-if="isGeocoordinate" cols="12">
@@ -33,35 +34,43 @@
       </b-row>
       <b-row>
         <b-col cols="6" v-if="isTimeseries">
-          <b-row
-            class="mt-1 mb-1"
-            v-for="(idCol, index) in idCols"
-            :key="idCol.value"
-          >
-            <b-col cols="5">
-              <template v-if="index === 0">
-                <b>Series ID Column(s):</b>
-              </template>
-            </b-col>
+          <template v-if="idCols.length > 0">
+            <b-row
+              class="mt-1 mb-1"
+              v-for="(idCol, index) in idCols"
+              :key="idCol.value"
+            >
+              <b-col cols="5">
+                <template
+                  v-if="index === 0 && idOptions(idCol.value).length !== 0"
+                >
+                  <b>Series ID Column(s):</b>
+                </template>
+              </b-col>
 
-            <b-col cols="7" class="d-flex align-content-center">
-              <b-form-select
-                class="mr-auto"
-                v-model="idCol.value"
-                :options="idOptions(idCol.value)"
-                @input="onIdChange"
-              />
-              <b-button
-                class="ml-1"
-                variant="outline-danger"
-                v-if="idCol.value"
-                title="Clear Selection"
-                @click="removeIdCol(idCol.value)"
+              <b-col
+                cols="7"
+                class="d-flex align-content-center"
+                v-if="idOptions(idCol.value).length !== 0"
               >
-                <i class="fa fa-times-circle"></i>
-              </b-button>
-            </b-col>
-          </b-row>
+                <b-form-select
+                  class="mr-auto"
+                  v-model="idCol.value"
+                  :options="idOptions(idCol.value)"
+                  @input="onIdChange"
+                />
+                <b-button
+                  class="ml-1"
+                  variant="outline-danger"
+                  v-if="idCol.value"
+                  title="Clear Selection"
+                  @click="removeIdCol(idCol.value)"
+                >
+                  <i class="fa fa-times-circle"></i>
+                </b-button>
+              </b-col>
+            </b-row>
+          </template>
 
           <b-row class="mt-1 mb-1">
             <b-col cols="5">
@@ -384,7 +393,6 @@ export default Vue.extend({
         [ORDINAL_TYPE]: true,
         [CATEGORICAL_TYPE]: true
       };
-      const def = [{ value: null, text: "Choose ID", disabled: true }];
       const suggestions = this.variables
         .filter(v => ID_COL_TYPES[v.colType])
         .filter(v => v.colName === idCol || !this.isIDCol(v.colName))
@@ -392,7 +400,11 @@ export default Vue.extend({
           return { value: v.colName, text: v.colDisplayName };
         });
 
-      return [].concat(def, suggestions);
+      if (suggestions.length > 0) {
+        const def = [{ value: null, text: "Choose ID", disabled: true }];
+        return [].concat(def, suggestions);
+      }
+      return [];
     },
     onIdChange(arg) {
       const values = this.idCols.map(c => c.value).filter(v => v);


### PR DESCRIPTION
For one part of #1839.  Catches the both the case where we have no options series id to select from the start, and the case where we run out of options to select to make the workflow clearer in those cases.