### PR TITLE
Sampling Shortcut

### DIFF
--- a/api/task/sample.go
+++ b/api/task/sample.go
@@ -47,6 +47,10 @@ func Sample(originalSchemaFile string, schemaFile string, dataset string, config
 		return "", false, 0, errors.Wrap(err, "unable to parse complete csv dataset")
 	}
 
+	if len(csvData) <= config.SampleRowLimit {
+		return schemaFile, false, len(csvData), nil
+	}
+
 	sampledData, err := compute.SampleDataset(csvData, config.SampleRowLimit, true)
 	if err != nil {
 		return "", false, 0, err


### PR DESCRIPTION
If there arent enough rows for sample to be required, then shortcut the sampling step to not copy data around.