### PR TITLE
Handles case where only 1 numerical bucket exists

### DIFF
--- a/public/components/facets/FacetNumerical.vue
+++ b/public/components/facets/FacetNumerical.vue
@@ -106,7 +106,7 @@ export default Vue.extend({
       const values = [];
       if (hasBaseline(summary)) {
         const buckets = summary.baseline.buckets;
-        const bucketSize = buckets[1].key
+        const bucketSize = buckets[1]?.key
           ? parseFloat(buckets[1].key) - parseFloat(buckets[0].key)
           : 0;
         for (let i = 0, n = buckets.length; i < n; ++i) {


### PR DESCRIPTION
The jido test set has a lot of features that are numerics consisting of a single value.  This caused exceptions in the numerical facet rendering.