### PR TITLE
Empty Value Apply Shap

### DIFF
--- a/public/components/PredictionsDataTable.vue
+++ b/public/components/PredictionsDataTable.vue
@@ -45,7 +45,6 @@
 
       <template v-slot:cell()="data">
         <div
-          v-if="data.value.value.length > 0"
           :title="data.value.value"
           :style="cellColor(data.value.weight, data)"
         >

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -97,7 +97,6 @@
 
       <template v-slot:cell()="data">
         <div
-          v-if="data.value.value.length > 0"
           :title="data.value.value"
           :style="cellColor(data.value.weight, data)"
         >

--- a/public/views/Predictions.vue
+++ b/public/views/Predictions.vue
@@ -128,6 +128,7 @@ export default Vue.extend({
   padding: 0.3rem;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-height: 1.875rem;
 }
 
 .variable-summaries {

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -147,6 +147,7 @@ export default Vue.extend({
   padding: 0.3rem;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-height: 1.875rem;
 }
 .result-facets {
   margin-bottom: 12px;


### PR DESCRIPTION
SHAP values are now displayed in cells that have empty values since that can still be indicative.