### PR TITLE
Feature Count And List

### DIFF
--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -161,6 +161,9 @@ export default Vue.extend({
     formatBytes(n: number): string {
       return formatBytes(n);
     },
+    filterVariablesByFeature(variables: Variable[]): Variable[] {
+      return filterVariablesByFeature(variables);
+    },
     setActiveDataset() {
       if (this.isImportReady || this.importPending) {
         return;

--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -13,7 +13,10 @@
         <i class="fa fa-table"></i> <b>Dateset Name:</b>
         {{ dataset.name }}
       </a>
-      <a class="nav-link"><b>Features:</b> {{ dataset.variables.length }}</a>
+      <a class="nav-link"
+        ><b>Features:</b>
+        {{ dataset.variables.filter(v => v.distilRole === "data").length }}</a
+      >
       <a class="nav-link"><b>Rows:</b> {{ dataset.numRows }}</a>
       <a class="nav-link"><b>Size:</b> {{ formatBytes(dataset.numBytes) }}</a>
       <a v-if="isImportReady">
@@ -133,10 +136,9 @@ export default Vue.extend({
       );
     },
     topVariables(): Variable[] {
-      return sortVariablesByImportance(this.dataset.variables.slice(0)).slice(
-        0,
-        NUM_TOP_FEATURES
-      );
+      return sortVariablesByImportance(
+        this.dataset.variables.filter(v => v.distilRole === "data").slice(0)
+      ).slice(0, NUM_TOP_FEATURES);
     },
     percentComplete(): number {
       return 100;

--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -15,7 +15,7 @@
       </a>
       <a class="nav-link"
         ><b>Features:</b>
-        {{ dataset.variables.filter(v => v.distilRole === "data").length }}</a
+        {{ filterVariablesByFeature(dataset.variables).length }}</a
       >
       <a class="nav-link"><b>Rows:</b> {{ dataset.numRows }}</a>
       <a class="nav-link"><b>Size:</b> {{ formatBytes(dataset.numBytes) }}</a>
@@ -101,7 +101,7 @@ import Vue from "vue";
 import ErrorModal from "../components/ErrorModal";
 import { createRouteEntry } from "../util/routes";
 import { formatBytes } from "../util/bytes";
-import { sortVariablesByImportance, isDatamartProvenance } from "../util/data";
+import { sortVariablesByImportance, , filterVariablesByFeature } from "../util/data";
 import { getters as routeGetters } from "../store/route/module";
 import { Dataset, Variable } from "../store/dataset/index";
 import { actions as datasetActions } from "../store/dataset/module";

--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -101,7 +101,11 @@ import Vue from "vue";
 import ErrorModal from "../components/ErrorModal";
 import { createRouteEntry } from "../util/routes";
 import { formatBytes } from "../util/bytes";
-import { sortVariablesByImportance, , filterVariablesByFeature } from "../util/data";
+import {
+  sortVariablesByImportance,
+  isDatamartProvenance,
+  filterVariablesByFeature
+} from "../util/data";
 import { getters as routeGetters } from "../store/route/module";
 import { Dataset, Variable } from "../store/dataset/index";
 import { actions as datasetActions } from "../store/dataset/module";

--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -141,7 +141,7 @@ export default Vue.extend({
     },
     topVariables(): Variable[] {
       return sortVariablesByImportance(
-        this.dataset.variables.filter(v => v.distilRole === "data").slice(0)
+        filterVariablesByFeature(this.dataset.variables).slice(0)
       ).slice(0, NUM_TOP_FEATURES);
     },
     percentComplete(): number {

--- a/public/components/DatasetPreviewCard.vue
+++ b/public/components/DatasetPreviewCard.vue
@@ -13,7 +13,10 @@
     <div class="card-body">
       <div class="row align-items-center justify-content-center">
         <div class="col-6">
-          <div><b>Features:</b> {{ dataset.variables.length }}</div>
+          <div>
+            <b>Features:</b>
+            {{ dataset.variables.filter(v => v.distilRole === "data").length }}
+          </div>
           <div><b>Rows:</b> {{ dataset.numRows }}</div>
           <div><b>Size:</b> {{ formatBytes(dataset.numBytes) }}</div>
         </div>

--- a/public/components/DatasetPreviewCard.vue
+++ b/public/components/DatasetPreviewCard.vue
@@ -65,6 +65,9 @@ export default Vue.extend({
     formatBytes(n: number): string {
       return formatBytes(n);
     },
+    filterVariablesByFeature(variables: Variable[]): Variable[] {
+      return filterVariablesByFeature(variables);
+    },
     removeFromJoin(arg) {
       this.$emit("remove-from-join", arg);
     }

--- a/public/components/DatasetPreviewCard.vue
+++ b/public/components/DatasetPreviewCard.vue
@@ -15,7 +15,7 @@
         <div class="col-6">
           <div>
             <b>Features:</b>
-            {{ dataset.variables.filter(v => v.distilRole === "data").length }}
+            {{ filterVariablesByFeature(dataset.variables).length }}
           </div>
           <div><b>Rows:</b> {{ dataset.numRows }}</div>
           <div><b>Size:</b> {{ formatBytes(dataset.numBytes) }}</div>
@@ -36,7 +36,10 @@
 <script lang="ts">
 import _ from "lodash";
 import Vue from "vue";
-import { sortVariablesByImportance } from "../util/data";
+import {
+  sortVariablesByImportance,
+  filterVariablesByFeature
+} from "../util/data";
 import { formatBytes } from "../util/bytes";
 import { Dataset, Variable } from "../store/dataset/index";
 

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -87,6 +87,7 @@ export interface Variable {
   min: number;
   max: number;
   role: string[];
+  distilRole: string;
 }
 
 export interface Dataset {

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -297,6 +297,10 @@ export function removeSummary(
   }
 }
 
+export function filterVariablesByFeature(variables: Variable[]): Variable[] {
+  return variables.filter(v => v.distilRole === "data");
+}
+
 export function filterSummariesByDataset(
   summaries: VariableSummary[],
   dataset: string


### PR DESCRIPTION
The client was counting every variable in the dataset and listing them all. However, there are quite a few variables that are not available to the user (grouping related ones, or clustering results) that should not count in the dataset summary.

This filters variables to only consider ones that have a data role. It isn't quite perfect since we still have issues with variables that get folded into groups (like band for remote sensing).