### PR TITLE
Adding Min/Max/Mean to Timerseries tables

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -49,6 +49,9 @@ type TimeseriesObservation struct {
 type TimeseriesData struct {
 	Timeseries []*TimeseriesObservation
 	IsDateTime bool
+	Min        NullableFloat64
+	Max        NullableFloat64
+	Mean       NullableFloat64
 }
 
 // DataStorageCtor represents a client constructor to instantiate a data

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -49,9 +49,9 @@ type TimeseriesObservation struct {
 type TimeseriesData struct {
 	Timeseries []*TimeseriesObservation
 	IsDateTime bool
-	Min        NullableFloat64
-	Max        NullableFloat64
-	Mean       NullableFloat64
+	Min        float64
+	Max        float64
+	Mean       float64
 }
 
 // DataStorageCtor represents a client constructor to instantiate a data

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -172,7 +172,7 @@ func (s *Storage) parseDateTimeTimeseriesForecast(rows pgx.Rows) ([]*api.Timeser
 }
 
 // Calculate the Min, Max, and Mean of a list of TimerseriesObservation
-func getMinMaxMean(timeseries []*api.TimeseriesObservation) (api.NullableFloat64, api.NullableFloat64, api.NullableFloat64) {
+func getMinMaxMean(timeseries []*api.TimeseriesObservation) (float64, float64, float64) {
 	min := math.Inf(1)
 	max := math.Inf(-1)
 	sum := float64(0)
@@ -196,11 +196,11 @@ func getMinMaxMean(timeseries []*api.TimeseriesObservation) (api.NullableFloat64
 		mean := sum / float64(len(timeseries))
 
 		// Send them back as NullableFloat64
-		return api.NullableFloat64(min), api.NullableFloat64(max), api.NullableFloat64(mean)
+		return min, max, mean
 	}
 
 	// Otherwise, send a NaN
-	var null = api.NullableFloat64(math.NaN())
+	var null = math.NaN()
 	return null, null, null
 }
 

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -171,6 +171,39 @@ func (s *Storage) parseDateTimeTimeseriesForecast(rows pgx.Rows) ([]*api.Timeser
 	return points, nil
 }
 
+// Calculate the Min, Max, and Mean of a list of TimerseriesObservation
+func getMinMaxMean(timeseries []*api.TimeseriesObservation) (api.NullableFloat64, api.NullableFloat64, api.NullableFloat64) {
+	min := math.Inf(1)
+	max := math.Inf(-1)
+	sum := float64(0)
+
+	var value float64
+	for _, timeserie := range timeseries {
+		value = float64(timeserie.Value)
+		if !math.IsNaN(value) {
+			min = math.Min(value, min)
+			max = math.Max(value, max)
+			sum += value
+		}
+	}
+
+	// Check that the values have been updated
+	minOk := !math.IsInf(min, 0)
+	maxOk := !math.IsInf(max, 0)
+	if minOk && maxOk {
+
+		// Calculate the mean
+		mean := sum / float64(len(timeseries))
+
+		// Send them back as NullableFloat64
+		return api.NullableFloat64(min), api.NullableFloat64(max), api.NullableFloat64(mean)
+	}
+
+	// Otherwise, send a NaN
+	var null = api.NullableFloat64(math.NaN())
+	return null, null, null
+}
+
 func (f *TimeSeriesField) fetchRepresentationTimeSeries(categoryBuckets []*api.Bucket, mode api.SummaryMode) ([]string, error) {
 
 	var timeseriesExemplars []string
@@ -286,9 +319,15 @@ func (s *Storage) FetchTimeseries(dataset string, storageName string, timeseries
 	// sum duplicate timestamps
 	response = removeDuplicates(response)
 
+	// Calculate Min/Max/Mean
+	var min, max, mean = getMinMaxMean(response)
+
 	return &api.TimeseriesData{
 		Timeseries: response,
 		IsDateTime: dateTime,
+		Min:        min,
+		Max:        max,
+		Mean:       mean,
 	}, nil
 }
 
@@ -350,9 +389,16 @@ func (s *Storage) FetchTimeseriesForecast(dataset string, storageName string, ti
 	}
 	// Sum duplicate timestamps
 	response = removeDuplicates(response)
+
+	// Calculate Min/Max/Mean
+	var min, max, mean = getMinMaxMean(response)
+
 	return &api.TimeseriesData{
 		Timeseries: response,
 		IsDateTime: dateTime,
+		Min:        min,
+		Max:        max,
+		Mean:       mean,
 	}, nil
 }
 

--- a/api/routes/timeseries.go
+++ b/api/routes/timeseries.go
@@ -89,9 +89,9 @@ func TimeseriesHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.DataSto
 		err = handleJSON(w, TimeseriesResult{
 			Timeseries: timeseries.Timeseries,
 			IsDateTime: timeseries.IsDateTime,
-			Min:        timeseries.Min,
-			Max:        timeseries.Max,
-			Mean:       timeseries.Mean,
+			Min:        api.NullableFloat64(timeseries.Min),
+			Max:        api.NullableFloat64(timeseries.Max),
+			Mean:       api.NullableFloat64(timeseries.Mean),
 		})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal dataset result into JSON"))

--- a/api/routes/timeseries.go
+++ b/api/routes/timeseries.go
@@ -28,6 +28,9 @@ import (
 type TimeseriesResult struct {
 	Timeseries []*api.TimeseriesObservation `json:"timeseries"`
 	IsDateTime bool                         `json:"isDateTime"`
+	Min        api.NullableFloat64          `json:"min"`
+	Max        api.NullableFloat64          `json:"max"`
+	Mean       api.NullableFloat64          `json:"mean"`
 }
 
 // TimeseriesHandler returns timeseries data.
@@ -86,6 +89,9 @@ func TimeseriesHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.DataSto
 		err = handleJSON(w, TimeseriesResult{
 			Timeseries: timeseries.Timeseries,
 			IsDateTime: timeseries.IsDateTime,
+			Min:        timeseries.Min,
+			Max:        timeseries.Max,
+			Mean:       timeseries.Mean,
 		})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal dataset result into JSON"))

--- a/api/routes/timeseries_forecast.go
+++ b/api/routes/timeseries_forecast.go
@@ -124,9 +124,9 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 			Forecast:          forecast.Timeseries,
 			ForecastTestRange: []float64{split.SplitValue, split.EndValue},
 			IsDateTime:        timeseries.IsDateTime,
-			Min:               forecast.Min,
-			Max:               forecast.Max,
-			Mean:              forecast.Mean,
+			Min:               api.NullableFloat64(forecast.Min),
+			Max:               api.NullableFloat64(forecast.Max),
+			Mean:              api.NullableFloat64(forecast.Mean),
 		})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal dataset result into JSON"))

--- a/api/routes/timeseries_forecast.go
+++ b/api/routes/timeseries_forecast.go
@@ -31,6 +31,9 @@ type TimeseriesForecastResult struct {
 	Forecast          []*api.TimeseriesObservation `json:"forecast"`
 	ForecastTestRange []float64                    `json:"forecastTestRange"`
 	IsDateTime        bool                         `json:"isDateTime"`
+	Min               api.NullableFloat64          `json:"min"`
+	Max               api.NullableFloat64          `json:"max"`
+	Mean              api.NullableFloat64          `json:"mean"`
 }
 
 // TimeseriesForecastHandler returns timeseries data.
@@ -121,6 +124,9 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 			Forecast:          forecast.Timeseries,
 			ForecastTestRange: []float64{split.SplitValue, split.EndValue},
 			IsDateTime:        timeseries.IsDateTime,
+			Min:               forecast.Min,
+			Max:               forecast.Max,
+			Mean:              forecast.Mean,
 		})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal dataset result into JSON"))

--- a/public/components/ForecastHorizon.vue
+++ b/public/components/ForecastHorizon.vue
@@ -188,6 +188,7 @@ export default Vue.extend({
         predictionDataset: predictionDataset,
         produceRequestId: response.produceRequestId,
         target: this.target,
+        task: TaskTypes.TIME_SERIES,
         varModes: varModes,
       };
 

--- a/public/components/ForecastHorizon.vue
+++ b/public/components/ForecastHorizon.vue
@@ -54,7 +54,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Extrema } from "../store/dataset/index";
+import { Extrema, TaskTypes } from "../store/dataset/index";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
 import {
@@ -150,6 +150,7 @@ export default Vue.extend({
         fittedSolutionId: this.fittedSolutionId,
         target: this.target,
         targetType: this.targetType,
+        task: TaskTypes.TIME_SERIES,
         intervalCount: this.intervalCount,
         intervalLength: this.intervalLengthFormatted,
       };

--- a/public/components/PredictionsDataTable.vue
+++ b/public/components/PredictionsDataTable.vue
@@ -16,8 +16,8 @@
         <div :key="computedField" :title="data.value.value">
           {{ data.value.value }}
           <icon-base icon-name="fork" class="icon-fork" width="14" height="14">
-            <icon-fork
-          /></icon-base>
+            <icon-fork />
+          </icon-base>
         </div>
       </template>
 
@@ -33,18 +33,24 @@
           :key="imageField.key"
           :type="imageField.type"
           :image-url="data.item[imageField.key].value"
-        ></image-preview>
+        />
       </template>
 
       <template
-        v-for="listField in listFields"
+        v-for="(listField, index) in listFields"
         v-slot:[cellSlot(listField.key)]="data"
       >
-        <span :title="formatList(data)">{{ formatList(data) }}</span>
+        <span :key="index" :title="formatList(data)">
+          {{ formatList(data) }}
+        </span>
       </template>
 
       <template v-slot:cell()="data">
+        <template v-if="['min', 'max', 'mean'].includes(data.field.key)">
+          {{ data.value | cleanNumber }}
+        </template>
         <div
+          v-else
           :title="data.value.value"
           :style="cellColor(data.value.weight, data)"
         >
@@ -66,8 +72,7 @@
           :timeseries-id="data.item[timeseriesGrouping.idCol].value"
           :predictions-id="predictions.requestId"
           :include-forecast="true"
-        >
-        </sparkline-preview>
+        />
       </template>
     </b-table>
   </fixed-header-table>
@@ -76,12 +81,12 @@
 <script lang="ts">
 import Vue from "vue";
 import _ from "lodash";
-import IconBase from "./icons/IconBase";
-import IconFork from "./icons/IconFork";
-import FixedHeaderTable from "./FixedHeaderTable";
-import PredictionsDataSlot from "../components/PredictionsDataSlot";
-import SparklinePreview from "./SparklinePreview";
-import ImagePreview from "./ImagePreview";
+import IconBase from "./icons/IconBase.vue";
+import IconFork from "./icons/IconFork.vue";
+import FixedHeaderTable from "./FixedHeaderTable.vue";
+import PredictionsDataSlot from "../components/PredictionsDataSlot.vue";
+import SparklinePreview from "./SparklinePreview.vue";
+import ImagePreview from "./ImagePreview.vue";
 import {
   Extrema,
   TableRow,
@@ -143,6 +148,13 @@ export default Vue.extend({
     instanceName: String as () => string,
   },
 
+  filters: {
+    /* Display number with only two decimal. */
+    cleanNumber(value) {
+      return _.isNumber(value) ? value.toFixed(2) : "—";
+    },
+  },
+
   computed: {
     predictions(): Predictions {
       return requestGetters.getActivePredictions(this.$store);
@@ -150,6 +162,10 @@ export default Vue.extend({
 
     predictedCol(): string {
       return this.predictions ? `${this.predictions.predictedKey}` : "";
+    },
+
+    fittedSolutionId(): string {
+      return predictionsGetters.getFittedSolutionIdFromPrediction(this.$store);
     },
 
     truthDataset(): string {
@@ -163,9 +179,19 @@ export default Vue.extend({
     },
 
     items(): TableRow[] {
-      const items = predictionsGetters.getIncludedPredictionTableDataItems(
+      let items = predictionsGetters.getIncludedPredictionTableDataItems(
         this.$store
       );
+
+      // In the case of timeseries, we add their Min/Max/Mean.
+      if (this.isTimeseries) {
+        items = items?.map((item) => {
+          const timeserieId = item[this.timeseriesGroupings[0].idCol].value;
+          const minMaxMean = this.timeserieInfo(timeserieId);
+          return { ...item, ...minMaxMean };
+        });
+      }
+
       return updateTableRowSelection(
         items,
         this.rowSelection,
@@ -184,7 +210,25 @@ export default Vue.extend({
     },
 
     tableFields(): TableColumn[] {
-      return formatFieldsAsArray(this.fields);
+      const tableFields = formatFieldsAsArray(this.fields);
+
+      if (!this.isTimeseries) return tableFields;
+
+      // For Timeseries we want to display the Min/Max/Mean
+      return tableFields.concat([
+        {
+          key: "min",
+          sortable: true,
+        },
+        {
+          key: "max",
+          sortable: true,
+        },
+        {
+          key: "mean",
+          sortable: true,
+        },
+      ] as TableColumn[]);
     },
 
     computedFields(): string[] {
@@ -205,6 +249,10 @@ export default Vue.extend({
       const variables = datasetGetters.getVariables(this.$store);
       return getTimeseriesGroupingsFromFields(variables, this.fields);
     },
+
+    isTimeseries(): boolean {
+      return routeGetters.isTimeseries(this.$store);
+    },
   },
 
   updated() {
@@ -215,6 +263,11 @@ export default Vue.extend({
   },
 
   methods: {
+    timeserieInfo(id: string): Extrema {
+      const timeseries = predictionsGetters.getPredictedTimeseries(this.$store);
+      return timeseries?.[this.fittedSolutionId]?.info?.[id];
+    },
+
     onRowClick(row: TableRow) {
       if (!isRowSelected(this.rowSelection, row[D3M_INDEX_FIELD])) {
         addRowSelection(

--- a/public/components/PredictionsDataTable.vue
+++ b/public/components/PredictionsDataTable.vue
@@ -265,7 +265,7 @@ export default Vue.extend({
   methods: {
     timeserieInfo(id: string): Extrema {
       const timeseries = predictionsGetters.getPredictedTimeseries(this.$store);
-      return timeseries?.[this.fittedSolutionId]?.info?.[id];
+      return timeseries?.[this.predictions.requestId]?.info?.[id];
     },
 
     onRowClick(row: TableRow) {

--- a/public/components/PredictionsDataTable.vue
+++ b/public/components/PredictionsDataTable.vue
@@ -212,7 +212,7 @@ export default Vue.extend({
     tableFields(): TableColumn[] {
       const tableFields = formatFieldsAsArray(this.fields);
 
-      if (!this.isTimeseries) return tableFields;
+      if (!this.isTimeseries || _.isEmpty(tableFields)) return tableFields;
 
       // For Timeseries we want to display the Min/Max/Mean
       return tableFields.concat([

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -282,7 +282,7 @@ export default Vue.extend({
     tableFields(): TableColumn[] {
       const tableFields = formatFieldsAsArray(this.fields);
 
-      if (!this.isTimeseries) return tableFields;
+      if (!this.isTimeseries || _.isEmpty(tableFields)) return tableFields;
 
       // For Timeseries we want to display the Min/Max/Mean
       return tableFields.concat([

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -53,15 +53,16 @@
           :timeseries-id="data.item[timeseriesGrouping.idCol].value"
           :solution-id="solutionId"
           :include-forecast="isTargetTimeseries"
-        >
-        </sparkline-preview>
+        />
       </template>
 
       <template
-        v-for="listField in listFields"
+        v-for="(listField, index) in listFields"
         v-slot:[cellSlot(listField.key)]="data"
       >
-        <span :title="formatList(data)">{{ formatList(data) }}</span>
+        <span :key="index" :title="formatList(data)">
+          {{ formatList(data) }}
+        </span>
       </template>
 
       <template v-slot:[cellSlot(errorCol)]="data">
@@ -96,7 +97,11 @@
       </template>
 
       <template v-slot:cell()="data">
+        <template v-if="['min', 'max', 'mean'].includes(data.field.key)">
+          {{ data.value | cleanNumber }}
+        </template>
         <div
+          v-else
           :title="data.value.value"
           :style="cellColor(data.value.weight, data)"
         >
@@ -110,11 +115,11 @@
 <script lang="ts">
 import Vue from "vue";
 import _ from "lodash";
-import IconBase from "./icons/IconBase";
-import IconFork from "./icons/IconFork";
-import FixedHeaderTable from "./FixedHeaderTable";
-import SparklinePreview from "./SparklinePreview";
-import ImagePreview from "./ImagePreview";
+import IconBase from "./icons/IconBase.vue";
+import IconFork from "./icons/IconFork.vue";
+import FixedHeaderTable from "./FixedHeaderTable.vue";
+import SparklinePreview from "./SparklinePreview.vue";
+import ImagePreview from "./ImagePreview.vue";
 import {
   Extrema,
   TableRow,
@@ -175,6 +180,13 @@ export default Vue.extend({
     instanceName: String as () => string,
   },
 
+  filters: {
+    /* Display number with only two decimal. */
+    cleanNumber(value) {
+      return _.isNumber(value) ? value.toFixed(2) : "—";
+    },
+  },
+
   computed: {
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);
@@ -233,8 +245,19 @@ export default Vue.extend({
     },
 
     items(): TableRow[] {
+      let items = this.dataItems;
+
+      // In the case of timeseries, we add their Min/Max/Mean.
+      if (this.isTimeseries) {
+        items = items?.map((item) => {
+          const timeserieId = item[this.timeseriesGroupings[0].idCol].value;
+          const minMaxMean = this.timeserieInfo(timeserieId);
+          return { ...item, ...minMaxMean };
+        });
+      }
+
       return updateTableRowSelection(
-        this.dataItems,
+        items,
         this.rowSelection,
         this.instanceName
       );
@@ -257,7 +280,25 @@ export default Vue.extend({
     },
 
     tableFields(): TableColumn[] {
-      return formatFieldsAsArray(this.fields);
+      const tableFields = formatFieldsAsArray(this.fields);
+
+      if (!this.isTimeseries) return tableFields;
+
+      // For Timeseries we want to display the Min/Max/Mean
+      return tableFields.concat([
+        {
+          key: "min",
+          sortable: true,
+        },
+        {
+          key: "max",
+          sortable: true,
+        },
+        {
+          key: "mean",
+          sortable: true,
+        },
+      ] as TableColumn[]);
     },
 
     computedFields(): string[] {
@@ -292,6 +333,10 @@ export default Vue.extend({
     sortFunction(): any {
       return this.sortingByResidualError ? this.sortingByErrorFunction : null;
     },
+
+    isTimeseries(): boolean {
+      return routeGetters.isTimeseries(this.$store);
+    },
   },
 
   updated() {
@@ -302,6 +347,11 @@ export default Vue.extend({
   },
 
   methods: {
+    timeserieInfo(id: string): Extrema {
+      const timeseries = resultsGetters.getPredictedTimeseries(this.$store);
+      return timeseries?.[this.solutionId]?.info?.[id];
+    },
+
     onRowClick(row: TableRow) {
       if (!isRowSelected(this.rowSelection, row[D3M_INDEX_FIELD])) {
         addRowSelection(

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -171,7 +171,7 @@ export default Vue.extend({
     tableFields(): TableColumn[] {
       const tableFields = formatFieldsAsArray(this.fields);
 
-      if (!this.isTimeseries) return tableFields;
+      if (!this.isTimeseries || _.isEmpty(tableFields)) return tableFields;
 
       // For Timeseries we want to display the Min/Max/Mean
       return tableFields.concat([

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -128,7 +128,7 @@ export default Vue.extend({
   filters: {
     /* Display number with only two decimal. */
     cleanNumber(value) {
-      return parseFloat(value).toFixed(2);
+      return _.isNumber(value) ? value.toFixed(2) : "—";
     },
   },
 
@@ -150,7 +150,7 @@ export default Vue.extend({
       if (this.isTimeseries) {
         items = items?.map((item) => {
           const timeserieId = item[this.timeseriesGroupings[0].idCol].value;
-          const minMaxMean = this.timeserieExtremas(timeserieId);
+          const minMaxMean = this.timeserieInfo(timeserieId);
           return { ...item, ...minMaxMean };
         });
       }
@@ -228,11 +228,9 @@ export default Vue.extend({
   },
 
   methods: {
-    timeserieExtremas(id: string): Extrema {
-      const extremas = datasetGetters.getTimeseriesExtrema(this.$store);
-      return extremas[this.dataset] && extremas[this.dataset][id]
-        ? { ...extremas[this.dataset][id] }
-        : { min: null, max: null, mean: null };
+    timeserieInfo(id: string): Extrema {
+      const timeseries = datasetGetters.getTimeseries(this.$store);
+      return timeseries?.[this.dataset]?.info?.[id];
     },
 
     onSortChanged() {

--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -46,8 +46,8 @@
 <script lang="ts">
 import * as d3 from "d3";
 import Vue from "vue";
-import SparklineChart from "../components/SparklineChart";
-import SparklineSvg from "../components/SparklineSvg";
+import SparklineChart from "../components/SparklineChart.vue";
+import SparklineSvg from "../components/SparklineSvg.vue";
 import { Dictionary } from "../util/dict";
 import { TimeseriesExtrema, TimeSeriesValue } from "../store/dataset/index";
 import {
@@ -97,6 +97,7 @@ export default Vue.extend({
         ? "facet-sparkline-preview-container"
         : "sparkline-preview-container";
     },
+
     timeseries(): TimeSeriesValue[] {
       if (this.solutionId) {
         const timeseries = resultsGetters.getPredictedTimeseries(this.$store);

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1022,6 +1022,9 @@ export const actions = {
         id: args.timeseriesId,
         timeseries: <TimeSeriesValue[]>response.data.timeseries,
         isDateTime: <boolean>response.data.isDateTime,
+        min: <number>response.data.min,
+        max: <number>response.data.max,
+        mean: <number>response.data.mean,
       });
     } catch (error) {
       console.error(error);

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -342,6 +342,7 @@ export interface TimeSeriesValue {
 export interface TimeSeries {
   timeseriesData: Dictionary<TimeSeriesValue[]>;
   isDateTime: Dictionary<boolean>;
+  info: Dictionary<Extrema>;
 }
 
 export interface DatasetState {

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -125,6 +125,7 @@ export interface DatasetOrigin {
 export interface Extrema {
   min: number;
   max: number;
+  mean?: number;
 }
 
 export interface Bucket {

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -247,27 +247,42 @@ export const mutations = {
       id: string;
       timeseries: TimeSeriesValue[];
       isDateTime: boolean;
+      min: number;
+      max: number;
+      mean: number;
     }
   ) {
     if (!state.timeseries[args.dataset]) {
       Vue.set(state.timeseries, args.dataset, {});
     }
+
     if (!state.timeseries[args.dataset].timeseriesData) {
       Vue.set(state.timeseries[args.dataset], "timeseriesData", {});
-    }
-    if (!state.timeseries[args.dataset].isDateTime) {
-      Vue.set(state.timeseries[args.dataset], "isDateTime", {});
     }
     Vue.set(
       state.timeseries[args.dataset].timeseriesData,
       args.id,
       Object.freeze(args.timeseries)
     );
+
+    if (!state.timeseries[args.dataset].isDateTime) {
+      Vue.set(state.timeseries[args.dataset], "isDateTime", {});
+    }
     Vue.set(
       state.timeseries[args.dataset].isDateTime,
       args.id,
       args.isDateTime
     );
+
+    // Set the min/max/mean for each timeseries data
+    if (!state.timeseries[args.dataset].info) {
+      Vue.set(state.timeseries[args.dataset], "info", {});
+    }
+    Vue.set(state.timeseries[args.dataset].info, args.id, {
+      min: args.min as number,
+      max: args.max as number,
+      mean: args.mean as number,
+    });
 
     const validTimeseries = args.timeseries.filter((t) => !_.isNil(t));
     const minX = _.minBy(validTimeseries, (d) => d.time).time;
@@ -295,18 +310,6 @@ export const mutations = {
     Vue.set(x, "max", Math.max(x.max, maxX));
     Vue.set(y, "min", Math.min(y.min, minY));
     Vue.set(y, "max", Math.max(y.max, maxY));
-
-    // Calculate the min/max/mean for each timeseries data
-    const data = state.timeseries[args.dataset].timeseriesData;
-    Object.keys(data).forEach((key) => {
-      const timeserie = data[key];
-      const info = {
-        min: _.minBy(timeserie, (d) => d.value).value,
-        max: _.maxBy(timeserie, (d) => d.value).value,
-        mean: _.meanBy(timeserie, (d) => d.value),
-      };
-      Vue.set(state.timeseriesExtrema[args.dataset], key, info);
-    });
   },
 
   setJoinDatasetsTableData(

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -288,12 +288,25 @@ export const mutations = {
       });
       return;
     }
+
     const x = state.timeseriesExtrema[args.dataset].x;
     const y = state.timeseriesExtrema[args.dataset].y;
     Vue.set(x, "min", Math.min(x.min, minX));
     Vue.set(x, "max", Math.max(x.max, maxX));
     Vue.set(y, "min", Math.min(y.min, minY));
     Vue.set(y, "max", Math.max(y.max, maxY));
+
+    // Calculate the min/max/mean for each timeseries data
+    const data = state.timeseries[args.dataset].timeseriesData;
+    Object.keys(data).forEach((key) => {
+      const timeserie = data[key];
+      const info = {
+        min: _.minBy(timeserie, (d) => d.value).value,
+        max: _.maxBy(timeserie, (d) => d.value).value,
+        mean: _.meanBy(timeserie, (d) => d.value),
+      };
+      Vue.set(state.timeseriesExtrema[args.dataset], key, info);
+    });
   },
 
   setJoinDatasetsTableData(

--- a/public/store/predictions/actions.ts
+++ b/public/store/predictions/actions.ts
@@ -328,6 +328,9 @@ export const actions = {
         id: args.timeseriesId,
         timeseries: response.data.timeseries,
         isDateTime: response.data.isDateTime,
+        min: <number>response.data.min,
+        max: <number>response.data.max,
+        mean: <number>response.data.mean,
       });
       mutations.updatePredictedForecast(context, {
         predictionsId: args.predictionsId,

--- a/public/store/predictions/mutations.ts
+++ b/public/store/predictions/mutations.ts
@@ -45,27 +45,42 @@ export const mutations = {
       id: string;
       timeseries: number[][];
       isDateTime: boolean;
+      min: number;
+      max: number;
+      mean: number;
     }
   ) {
     if (!state.timeseries[args.predictionsId]) {
       Vue.set(state.timeseries, args.predictionsId, {});
     }
+
     if (!state.timeseries[args.predictionsId].timeseriesData) {
       Vue.set(state.timeseries[args.predictionsId], "timeseriesData", {});
-    }
-    if (!state.timeseries[args.predictionsId].isDateTime) {
-      Vue.set(state.timeseries[args.predictionsId], "isDateTime", {});
     }
     Vue.set(
       state.timeseries[args.predictionsId].timeseriesData,
       args.id,
       args.timeseries
     );
+
+    if (!state.timeseries[args.predictionsId].isDateTime) {
+      Vue.set(state.timeseries[args.predictionsId], "isDateTime", {});
+    }
     Vue.set(
       state.timeseries[args.predictionsId].isDateTime,
       args.id,
       args.isDateTime
     );
+
+    // Set the min/max/mean for each timeseries data
+    if (!state.timeseries[args.predictionsId].info) {
+      Vue.set(state.timeseries[args.predictionsId], "info", {});
+    }
+    Vue.set(state.timeseries[args.predictionsId].info, args.id, {
+      min: args.min as number,
+      max: args.max as number,
+      mean: args.mean as number,
+    });
   },
 
   updatePredictedForecast(

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -763,9 +763,9 @@ export const actions = {
         id: args.timeseriesId,
         timeseries: response.data.timeseries,
         isDateTime: response.data.isDateTime,
-        min: response.data.min,
-        max: response.data.max,
-        mean: response.data.mean,
+        min: <number>response.data.min,
+        max: <number>response.data.max,
+        mean: <number>response.data.mean,
       });
       mutations.updatePredictedForecast(context, {
         solutionId: args.solutionId,

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -763,6 +763,9 @@ export const actions = {
         id: args.timeseriesId,
         timeseries: response.data.timeseries,
         isDateTime: response.data.isDateTime,
+        min: response.data.min,
+        max: response.data.max,
+        mean: response.data.mean,
       });
       mutations.updatePredictedForecast(context, {
         solutionId: args.solutionId,

--- a/public/store/results/index.ts
+++ b/public/store/results/index.ts
@@ -9,6 +9,7 @@ import {
 export interface TimeSeries {
   timeseriesData: Dictionary<TimeSeriesValue[]>;
   isDateTime: Dictionary<boolean>;
+  info: Dictionary<Extrema>;
 }
 
 export interface Forecast {

--- a/public/store/results/mutations.ts
+++ b/public/store/results/mutations.ts
@@ -85,27 +85,42 @@ export const mutations = {
       id: string;
       timeseries: number[][];
       isDateTime: boolean;
+      min: number;
+      max: number;
+      mean: number;
     }
   ) {
     if (!state.timeseries[args.solutionId]) {
       Vue.set(state.timeseries, args.solutionId, {});
     }
+
     if (!state.timeseries[args.solutionId].timeseriesData) {
       Vue.set(state.timeseries[args.solutionId], "timeseriesData", {});
-    }
-    if (!state.timeseries[args.solutionId].isDateTime) {
-      Vue.set(state.timeseries[args.solutionId], "isDateTime", {});
     }
     Vue.set(
       state.timeseries[args.solutionId].timeseriesData,
       args.id,
       Object.freeze(args.timeseries)
     );
+
+    if (!state.timeseries[args.solutionId].isDateTime) {
+      Vue.set(state.timeseries[args.solutionId], "isDateTime", {});
+    }
     Vue.set(
       state.timeseries[args.solutionId].isDateTime,
       args.id,
       args.isDateTime
     );
+
+    // Set the min/max/mean for each timeseries data
+    if (!state.timeseries[args.solutionId].info) {
+      Vue.set(state.timeseries[args.solutionId], "info", {});
+    }
+    Vue.set(state.timeseries[args.solutionId].info, args.id, {
+      min: args.min as number,
+      max: args.max as number,
+      mean: args.mean as number,
+    });
   },
 
   updatePredictedForecast(


### PR DESCRIPTION
closes #1678 

For the moment this is only added to the **SelectDataSlot** component, on the **Create** page.

If the goal is to make this available on **ALL** Timeseries table, then I will add the Min/Max/Mean calculation into the SQL request. Which will make things tidier.