### PR TITLE
#1910 Exclusion color fix, clean up

### DIFF
--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -164,8 +164,6 @@ const fetchVariableSummaries = async (context, args) => {
     ...mainPageVariables,
   ];
 
-  console.log(searchedPresortedVariables, allActiveVariables);
-
   return Promise.all([
     datasetActions.fetchIncludedVariableSummaries(store, {
       dataset: dataset,

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -125,31 +125,57 @@ body {
 }
 
 html {
-  --facet-terms-bar-2-normal: #999999;
-  --facet-terms-bar-2-normal-contrast: #999999;
-  --facet-terms-bar-2-normal-contrast-hover: #bbbbbb;
-  --facet-terms-bar-2-selected: #999999;
-  --facet-terms-bar-2-selected-contrast: #999999;
-  --facet-terms-bar-2-selected-contrast-hover: #bbbbbb;
-  --facet-terms-bar-2-unselected: #999999;
-  --facet-terms-bar-2-unselected-contrast: #999999;
-  --facet-terms-bar-2-unselected-contrast-hover: #bbbbbb;
-  --facet-terms-bar-2-muted: #999999;
-  --facet-terms-bar-2-muted-contrast: #999999;
-  --facet-terms-bar-2-muted-contrast-hover: #bbbbbb;
+  --facet-terms-bar-3-normal: #999999;
+  --facet-terms-bar-3-normal-contrast: #999999;
+  --facet-terms-bar-3-normal-contrast-hover: #bbbbbb;
+  --facet-terms-bar-3-selected: #999999;
+  --facet-terms-bar-3-selected-contrast: #999999;
+  --facet-terms-bar-3-selected-contrast-hover: #bbbbbb;
+  --facet-terms-bar-3-unselected: #999999;
+  --facet-terms-bar-3-unselected-contrast: #999999;
+  --facet-terms-bar-3-unselected-contrast-hover: #bbbbbb;
+  --facet-terms-bar-3-muted: #999999;
+  --facet-terms-bar-3-muted-contrast: #999999;
+  --facet-terms-bar-3-muted-contrast-hover: #bbbbbb;
 
-  --facet-bars-2-normal: #999999;
-  --facet-bars-2-normal-contrast: #999999;
-  --facet-bars-2-normal-contrast-hover: #bbbbbb;
-  --facet-bars-2-selected: #999999;
-  --facet-bars-2-selected-contrast: #999999;
-  --facet-bars-2-selected-contrast-hover: #bbbbbb;
-  --facet-bars-2-unselected: #999999;
-  --facet-bars-2-unselected-contrast: #999999;
-  --facet-bars-2-unselected-contrast-hover: #bbbbbb;
-  --facet-bars-2-muted: #999999;
-  --facet-bars-2-muted-contrast: #999999;
-  --facet-bars-2-muted-contrast-hover: #bbbbbb;
+  --facet-bars-3-normal: #999999;
+  --facet-bars-3-normal-contrast: #999999;
+  --facet-bars-3-normal-contrast-hover: #bbbbbb;
+  --facet-bars-3-selected: #999999;
+  --facet-bars-3-selected-contrast: #999999;
+  --facet-bars-3-selected-contrast-hover: #bbbbbb;
+  --facet-bars-3-unselected: #999999;
+  --facet-bars-3-unselected-contrast: #999999;
+  --facet-bars-3-unselected-contrast-hover: #bbbbbb;
+  --facet-bars-3-muted: #999999;
+  --facet-bars-3-muted-contrast: #999999;
+  --facet-bars-3-muted-contrast-hover: #bbbbbb;
+
+  --facet-terms-bar-2-normal: #000000;
+  --facet-terms-bar-2-normal-contrast: #000000;
+  --facet-terms-bar-2-normal-contrast-hover: #333333;
+  --facet-terms-bar-2-selected: #000000;
+  --facet-terms-bar-2-selected-contrast: #000000;
+  --facet-terms-bar-2-selected-contrast-hover: #333333;
+  --facet-terms-bar-2-unselected: #000000;
+  --facet-terms-bar-2-unselected-contrast: #000000;
+  --facet-terms-bar-2-unselected-contrast-hover: #333333;
+  --facet-terms-bar-2-muted: #000000;
+  --facet-terms-bar-2-muted-contrast: #000000;
+  --facet-terms-bar-2-muted-contrast-hover: #333333;
+
+  --facet-bars-2-normal: #000000;
+  --facet-bars-2-normal-contrast: #000000;
+  --facet-bars-2-normal-contrast-hover: #333333;
+  --facet-bars-2-selected: #000000;
+  --facet-bars-2-selected-contrast: #000000;
+  --facet-bars-2-selected-contrast-hover: #333333;
+  --facet-bars-2-unselected: #000000;
+  --facet-bars-2-unselected-contrast: #000000;
+  --facet-bars-2-unselected-contrast-hover: #333333;
+  --facet-bars-2-muted: #000000;
+  --facet-bars-2-muted-contrast: #000000;
+  --facet-bars-2-muted-contrast-hover: #333333;
 
   --facet-terms-bar-1-normal: #ff0067;
   --facet-terms-bar-1-normal-contrast: #ff0067;

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -17,6 +17,8 @@ import {
   GEOCOORDINATE_TYPE,
   TIMESERIES_TYPE,
 } from "../util/types";
+import store from "../store/store";
+import { getters as routeGetters } from "../store/route/module";
 import { getTimeseriesSummaryTopCategories } from "../util/data";
 import { getSelectedRows } from "../util/row";
 import {
@@ -288,6 +290,7 @@ export function getSubSelectionValues(
   rowSelection: RowSelection,
   max: number
 ): number[][] {
+  const include = routeGetters.getRouteInclude(store);
   const hasFilterBuckets = hasFiltered(summary);
   if (!hasFilterBuckets && !rowSelection) {
     return summary.baseline?.buckets?.map((b) => [null, b.count / max]);
@@ -317,14 +320,16 @@ export function getSubSelectionValues(
         ? filteredKeys[b.key]
         : 0;
       return hasRowLabels
-        ? [bucketCount / max, null]
-        : [null, bucketCount / max];
+        ? [null, bucketCount / max, null]
+        : include
+        ? [null, null, bucketCount / max]
+        : [bucketCount / max, null, null];
     });
   } else {
     subSelectionValues = summary.baseline.buckets.map((b) =>
       rowLabelMatches(rowLabels, b.key, isNumeric)
-        ? [b.count / max, null]
-        : [null, b.count / max]
+        ? [null, b.count / max, null]
+        : [null, null, b.count / max]
     );
   }
   return subSelectionValues;


### PR DESCRIPTION
Fixes #1910 - Reworked the CSS to have black styles for at the correct depth for facets so they can be used for exclusion, updated facets.ts util function getSubSelectionValues to leverage include state (via store & routeGetters import) to set values in the expected positions given exclusion state.

Also cleaned up a left over debugging console.log.