### PR TITLE
added front end support for saving predictions

### DIFF
--- a/public/components/PredictionSummaries.vue
+++ b/public/components/PredictionSummaries.vue
@@ -24,23 +24,22 @@
         </div>
       </div>
     </div>
-
-    <!-- TODO: For show right now.-->
-    <!-- 
-    <b-button variant="primary" class="float-right mt-2">
+    <b-button variant="primary" class="float-right mt-2" v-b-modal.export>
       Export Predictions
     </b-button>
 
-    <b-modal id="export" title="Export">
-      <div class="check-message-container">
-        <i class="fa fa-check-circle fa-3x check-icon"></i>
+    <b-modal id="export" title="Export" @ok="savePredictions">
+      <div class="check-message-container d-flex justify-content-around">
+        <i class="fa fa-file-text-o fa-3x" aria-hidden="true"></i>
         <div>
-          This action will export predictions and return to the application
-          start screen.
+          <b-form-input
+            v-model="text"
+            placeholder="Enter name to save as"
+            @change="updateFileName"
+          ></b-form-input>
         </div>
       </div>
     </b-modal>
-    -->
   </div>
 </template>
 
@@ -56,7 +55,10 @@ import { getSolutionById } from "../util/solutions";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
 import { getters as requestGetters } from "../store/requests/module";
-import { getters as predictionsGetters } from "../store/predictions/module";
+import {
+  getters as predictionsGetters,
+  actions as predictionActions,
+} from "../store/predictions/module";
 import {
   actions as appActions,
   getters as appGetters,
@@ -89,6 +91,9 @@ export default Vue.extend({
     FacetNumerical,
     FacetCategorical,
     FileUploader,
+  },
+  data: {
+    saveFileName: "",
   },
 
   computed: {
@@ -239,6 +244,27 @@ export default Vue.extend({
         requestGetters.getRelevantPredictions(this.$store),
         requestId
       ).dataset;
+    },
+
+    updateFileName(val: string) {
+      this.saveFileName = val;
+    },
+
+    async savePredictions() {
+      const csvStr = await predictionActions.fetchExportData(this.$store, {
+        produceRequestId: this.produceRequestId,
+      });
+      if (!csvStr) {
+        console.error("No CSV Data");
+        return;
+      }
+      const hiddenElement = document.createElement("a");
+      const fileName =
+        this.saveFileName === "" ? "predictions" : this.saveFileName;
+      hiddenElement.href = "data:text/csv;charset=utf-8," + encodeURI(csvStr);
+      hiddenElement.target = "_blank";
+      hiddenElement.download = `${fileName}.csv`;
+      hiddenElement.click();
     },
   },
 });

--- a/public/store/predictions/actions.ts
+++ b/public/store/predictions/actions.ts
@@ -365,4 +365,21 @@ export const actions = {
       console.error(error);
     }
   },
+
+  async fetchExportData(
+    context: PredictionContext,
+    args: {
+      produceRequestId: string;
+    }
+  ): Promise<string> {
+    try {
+      const endPoint = "/distil/export-results/";
+      const params = `${args.produceRequestId}`;
+      const response = await axios.get(endPoint + params);
+      return response.data;
+    } catch (error) {
+      console.error(error);
+    }
+    return null;
+  },
 };

--- a/public/store/predictions/module.ts
+++ b/public/store/predictions/module.ts
@@ -73,6 +73,8 @@ export const actions = {
 
   // time series forecast data
   fetchForecastedTimeseries: dispatch(moduleActions.fetchForecastedTimeseries),
+  // csv export data
+  fetchExportData: dispatch(moduleActions.fetchExportData),
 };
 
 // Typed mutations


### PR DESCRIPTION
Added modal on prediction screen where user can download their predictions.
The modal contains a text input field where the user can define the name for the file (defaults to predictions.csv).
Added a fetchExportData function that calls the backend which generates the csv data.