### PR TITLE
#1738 Duplicate Cluster Call Fix

### DIFF
--- a/public/views/VariableGrouping.vue
+++ b/public/views/VariableGrouping.vue
@@ -516,14 +516,15 @@ export default Vue.extend({
         grouping: grouping,
       });
 
-      // If this dataset contains multiple timeseries, then we need to request clustering be run on it
-      if (this.isTimeseries && ids.length > 0) {
-        await datasetActions.fetchClusters(this.$store, {
-          dataset: this.dataset,
-        });
-      }
-
       if (gotoTarget) {
+        // If this dataset contains multiple timeseries,
+        // and we're doing the final submit,
+        // then we need to request clustering be run on it.
+        if (this.isTimeseries && ids.length > 0) {
+          await datasetActions.fetchClusters(this.$store, {
+            dataset: this.dataset,
+          });
+        }
         this.gotoTargetSelection();
       }
 


### PR DESCRIPTION
Fixes #1738 - Now only calls clustering from the timeseries creation step if we're actually confirming that we're save the current time series that has been built on the creation step, and thus we're going back to the target selection step.