### PR TITLE
the fixed-table-header was hiding information if it went beyond 200px…

### DIFF
--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -279,6 +279,7 @@ export default Vue.extend({
   display: flex;
   flex-grow: 1;
   background-color: white;
+  overflow-x: scroll;
 }
 
 .results-data-no-results {


### PR DESCRIPTION
…. I opted to allow no limit and use a scrollbar. All information can now be seen, if the information is smaller than the entire table size the residual space is evenly distributed among the cells.
closes #1909 