### PR TITLE
Offer the user a chance to not sample their dataset.

### DIFF
--- a/public/components/FileUploader.vue
+++ b/public/components/FileUploader.vue
@@ -24,7 +24,7 @@
           v-model="importDataName"
           :state="importDataNameState"
           required
-        ></b-form-input>
+        />
       </b-form-group>
 
       <p>Source File (csv, zip)</p>
@@ -79,6 +79,7 @@ export default Vue.extend({
       this.importDataName = "";
       this.importDataNameState = null;
     },
+
     async handleOk() {
       const deconflictedName = generateUniqueDatasetName(this.importDataName);
 
@@ -88,6 +89,7 @@ export default Vue.extend({
         filename: this.file.name,
         datasetID: deconflictedName,
       });
+
       try {
         // Upload the file and notify when complete
         const response = await datasetActions.uploadDataFile(this.$store, {
@@ -103,7 +105,7 @@ export default Vue.extend({
 
   watch: {
     // Watches for file name changes, setting a dataset import name value if the user
-    // hans't done so.
+    // hasn't done so.
     file() {
       if (!this.importDataName && this.file?.name) {
         // use the filname without the extension
@@ -124,5 +126,3 @@ export default Vue.extend({
   },
 });
 </script>
-
-<style></style>

--- a/public/components/FileUploaderStatus.vue
+++ b/public/components/FileUploaderStatus.vue
@@ -1,13 +1,26 @@
 <template>
   <div>
+    <!-- Waiting -->
     <b-alert :show="status === 'started'" variant="info">
       Importing <b>{{ filename }}</b> as <b>{{ datasetID }}</b
       >...
     </b-alert>
+
+    <!-- Success -->
     <b-alert :show="status === 'success'" dismissible variant="success">
       <i class="fa fa-check-circle-o" aria-hidden="true"></i> Imported
       <b>{{ filename }}</b> as <b>{{ datasetID }}</b>
+      <template v-if="isSampling">
+        &mdash; Because of its size, the dataset has been sampled to
+        {{ rowCount }} rows.
+        <b-button @click="onClick" variant="success" size="sm">
+          <i class="fa fa-download" aria-hidden="true"></i>
+          Import the full dataset
+        </b-button>
+      </template>
     </b-alert>
+
+    <!-- Error -->
     <b-alert :show="status === 'error'" dismissible variant="danger">
       <i class="fa fa-times-circle-o" aria-hidden="true"></i> An unexpected
       error has happened while importing <b>{{ filename }}</b>
@@ -20,19 +33,32 @@ import Vue from "vue";
 
 export default Vue.extend({
   name: "file-uploader-status",
+
   props: {
+    datasetID: String,
+    filename: String,
+    importResponse: Object,
+    numRows: Number,
     status: {
       type: String,
       required: true,
     },
-    filename: {
-      type: String,
+  },
+
+  computed: {
+    isSampling(): boolean {
+      return !!this.importResponse?.sampled;
     },
-    datasetID: {
-      type: String,
+
+    rowCount(): number {
+      return this.importResponse?.rowCount ?? 0;
+    },
+  },
+
+  methods: {
+    onClick() {
+      this.$emit("importfull");
     },
   },
 });
 </script>
-
-<style></style>

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -78,6 +78,7 @@ export const actions = {
   searchDatasets: dispatch(moduleActions.searchDatasets),
   geocodeVariable: dispatch(moduleActions.geocodeVariable),
   importDataset: dispatch(moduleActions.importDataset),
+  importFullDataset: dispatch(moduleActions.importFullDataset),
   deleteVariable: dispatch(moduleActions.deleteVariable),
   setGrouping: dispatch(moduleActions.setGrouping),
   removeGrouping: dispatch(moduleActions.removeGrouping),


### PR DESCRIPTION
closes #1870 

Explain to the user that if their dataset is bigger than `INGEST_SAMPLE_ROW_LIMIT` we sampled it.

I added a button to let the user reimport the dataset without sampling. This was done by making the sampling limit the Max value of Go MaxInt32, so this might be a future bottle neck if we have more two billions rows (2,147,483,647).

The following example was made with `INGEST_SAMPLE_ROW_LIMIT` set to 250.

**First import**
![Screen Shot 2020-09-11 at 16 10 42](https://user-images.githubusercontent.com/636801/92969267-9e5eed80-f44a-11ea-91f6-39b1ea523871.png)


**after click on the button: Second import**
![Screen Shot 2020-09-11 at 16 13 54](https://user-images.githubusercontent.com/636801/92969297-ac147300-f44a-11ea-845b-7bf9ad131dde.png)
