### PR TITLE
added support for disabling view type radio buttons if there is no tr…

### DIFF
--- a/public/components/FilterBadge.vue
+++ b/public/components/FilterBadge.vue
@@ -55,9 +55,6 @@ export default Vue.extend({
   computed: {
     filterName(): string {
       const type = getVarType(this.filter.key);
-      if (isClusterType(type)) {
-        return removeClusterPrefix(this.filter.key);
-      }
       return this.filter.displayName;
     },
     NUMERICAL_FILTER(): string {

--- a/public/components/FilterBadge.vue
+++ b/public/components/FilterBadge.vue
@@ -42,7 +42,7 @@ import {
   TEXT_FILTER,
 } from "../util/filters";
 import { clearHighlight } from "../util/highlights";
-import { getVarType, isClusterType, removeClusterPrefix } from "../util/types";
+import { removeClusterPrefix } from "../util/types";
 
 export default Vue.extend({
   name: "filter-badge",
@@ -54,7 +54,6 @@ export default Vue.extend({
 
   computed: {
     filterName(): string {
-      const type = getVarType(this.filter.key);
       return this.filter.displayName;
     },
     NUMERICAL_FILTER(): string {

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -302,7 +302,7 @@ export default Vue.extend({
       const longitudes = [];
 
       const areas = this.dataItems.map((item) => {
-        const imageUrl = item.group_id.value;
+        const imageUrl = this.isRemoteSensing ? item.group_id.value : null;
         const fullCoordinates = item.coordinates.value.Elements;
         if (fullCoordinates.some((x) => x === undefined)) return;
 
@@ -354,6 +354,9 @@ export default Vue.extend({
 
     isRemoteSensing(): boolean {
       return routeGetters.isRemoteSensing(this.$store);
+    },
+    isGeoSpatial(): boolean {
+      return routeGetters.isGeoSpatial(this.$store);
     },
 
     /* Base layer for the map. */
@@ -752,9 +755,11 @@ export default Vue.extend({
         }).$mount();
 
         // Add interactivity to the layer.
-        layer
-          .bindTooltip(tooltip.$el as HTMLElement)
-          .on("click", () => this.showImageDrilldown(imageUrl, item));
+        layer.bindTooltip(tooltip.$el as HTMLElement).on("click", () => {
+          if (this.isRemoteSensing) {
+            this.showImageDrilldown(imageUrl, item);
+          }
+        });
 
         // Add the rectangle to the layer group.
         this.poiLayer.addLayer(layer);
@@ -817,7 +822,7 @@ export default Vue.extend({
       this.createMap();
       this.clear();
 
-      if (this.isRemoteSensing) {
+      if (this.isGeoSpatial) {
         // Display areas and update them on zoom to be sure they are selectable.
         this.displayAreas();
         this.map.on("zoomend", () => this.displayAreas());

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -754,8 +754,9 @@ export default Vue.extend({
         }).$mount();
 
         // Add interactivity to the layer.
+        layer.bindTooltip(tooltip.$el as HTMLElement);
         if (this.isRemoteSensing) {
-          layer.bindTooltip(tooltip.$el as HTMLElement).on("click", () => {
+          layer.on("click", () => {
             this.showImageDrilldown(imageUrl, item);
           });
         }

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -297,7 +297,6 @@ export default Vue.extend({
       if (!this.dataItems) {
         return [];
       }
-
       // Array to store the longitude width (degrees) of each areas.
       const longitudes = [];
 
@@ -755,11 +754,11 @@ export default Vue.extend({
         }).$mount();
 
         // Add interactivity to the layer.
-        layer.bindTooltip(tooltip.$el as HTMLElement).on("click", () => {
-          if (this.isRemoteSensing) {
+        if (this.isRemoteSensing) {
+          layer.bindTooltip(tooltip.$el as HTMLElement).on("click", () => {
             this.showImageDrilldown(imageUrl, item);
-          }
-        });
+          });
+        }
 
         // Add the rectangle to the layer group.
         this.poiLayer.addLayer(layer);

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="select-data-slot">
-    <view-type-toggle has-tabs v-model="viewTypeModel" :variables="variables">
+    <view-type-toggle
+      has-tabs
+      v-model="viewTypeModel"
+      :variables="variables"
+      :trainingVariables="trainingVariables"
+    >
       <b-nav-item
         class="font-weight-bold"
         @click="setIncludedActive"
@@ -184,7 +189,9 @@ export default Vue.extend({
     availableVariables(): Variable[] {
       return routeGetters.getAvailableVariables(this.$store);
     },
-
+    trainingVariables(): Variable[] {
+      return routeGetters.getTrainingVariables(this.$store);
+    },
     includedActive(): boolean {
       return routeGetters.getRouteInclude(this.$store);
     },

--- a/public/components/ViewTypeToggle.vue
+++ b/public/components/ViewTypeToggle.vue
@@ -79,7 +79,10 @@ export default Vue.extend({
       type: Boolean as () => boolean,
       default: false,
     },
-    trainingVariables: Array as () => Variable[],
+    trainingVariables: {
+      type: Array as () => Variable[],
+      default: [] as Variable[],
+    },
   },
 
   data() {
@@ -122,34 +125,29 @@ export default Vue.extend({
       return false;
     },
     hasGeoVariables(): boolean {
-      const hasGeocoord =
-        this.variables.filter(
-          (v) =>
-            v.grouping &&
-            [GEOCOORDINATE_TYPE, REMOTE_SENSING_TYPE].includes(v.grouping.type)
-        ).length > 0;
-      const hasLat =
-        this.variables.filter((v) => v.colType === LONGITUDE_TYPE).length > 0;
-      const hasLon =
-        this.variables.filter((v) => v.colType === LATITUDE_TYPE).length > 0;
+      const hasGeocoord = this.variables.some(
+        (v) =>
+          v.grouping &&
+          [GEOCOORDINATE_TYPE, REMOTE_SENSING_TYPE].includes(v.grouping.type)
+      );
+      const hasLat = this.variables.some((v) => v.colType === LONGITUDE_TYPE);
+      const hasLon = this.variables.some((v) => v.colType === LATITUDE_TYPE);
 
       return (hasLat && hasLon) || hasGeocoord;
     },
     hasTrainingGeoVariables(): boolean {
-      const hasGeocoord =
-        this.trainingVariables.filter(
-          (v) =>
-            (v.grouping &&
-              [GEOCOORDINATE_TYPE, GEOBOUNDS_TYPE].includes(v.grouping.type)) ||
-            v.colType === GEOBOUNDS_TYPE
-        ).length > 0;
-      const hasLat =
-        this.trainingVariables.filter((v) => v.colType === LONGITUDE_TYPE)
-          .length > 0;
-      const hasLon =
-        this.trainingVariables.filter((v) => v.colType === LATITUDE_TYPE)
-          .length > 0;
-
+      const hasGeocoord = this.trainingVariables.some(
+        (v) =>
+          (v.grouping &&
+            [GEOCOORDINATE_TYPE, GEOBOUNDS_TYPE].includes(v.grouping.type)) ||
+          v.colType === GEOBOUNDS_TYPE
+      );
+      const hasLat = this.trainingVariables.some(
+        (v) => v.colType === LONGITUDE_TYPE
+      );
+      const hasLon = this.trainingVariables.some(
+        (v) => v.colType === LATITUDE_TYPE
+      );
       return (hasLat && hasLon) || hasGeocoord;
     },
 

--- a/public/components/ViewTypeToggle.vue
+++ b/public/components/ViewTypeToggle.vue
@@ -15,6 +15,7 @@
             <b-form-radio
               :value="IMAGE_VIEW"
               v-if="hasImageVariables"
+              :disabled="!hasTrainingImageVariables"
               class="view-button"
             >
               <i class="fa fa-image"></i>
@@ -29,6 +30,7 @@
             <b-form-radio
               :value="GEO_VIEW"
               v-if="hasGeoVariables"
+              :disabled="!hasTrainingGeoVariables"
               class="view-button"
             >
               <i class="fa fa-globe"></i>
@@ -58,6 +60,7 @@ import {
   LATITUDE_TYPE,
   GEOCOORDINATE_TYPE,
   REMOTE_SENSING_TYPE,
+  GEOBOUNDS_TYPE,
 } from "../util/types";
 
 const TABLE_VIEW = "table";
@@ -76,6 +79,7 @@ export default Vue.extend({
       type: Boolean as () => boolean,
       default: false,
     },
+    trainingVariables: Array as () => Variable[],
   },
 
   data() {
@@ -106,6 +110,13 @@ export default Vue.extend({
         ).length > 0
       );
     },
+    hasTrainingImageVariables(): boolean {
+      return (
+        this.trainingVariables.filter(
+          (v) => v.colType === IMAGE_TYPE || v.colType === REMOTE_SENSING_TYPE
+        ).length > 0
+      );
+    },
     hasGraphVariables(): boolean {
       // TODO: add this in
       return false;
@@ -121,6 +132,23 @@ export default Vue.extend({
         this.variables.filter((v) => v.colType === LONGITUDE_TYPE).length > 0;
       const hasLon =
         this.variables.filter((v) => v.colType === LATITUDE_TYPE).length > 0;
+
+      return (hasLat && hasLon) || hasGeocoord;
+    },
+    hasTrainingGeoVariables(): boolean {
+      const hasGeocoord =
+        this.trainingVariables.filter(
+          (v) =>
+            (v.grouping &&
+              [GEOCOORDINATE_TYPE, GEOBOUNDS_TYPE].includes(v.grouping.type)) ||
+            v.colType === GEOBOUNDS_TYPE
+        ).length > 0;
+      const hasLat =
+        this.trainingVariables.filter((v) => v.colType === LONGITUDE_TYPE)
+          .length > 0;
+      const hasLon =
+        this.trainingVariables.filter((v) => v.colType === LATITUDE_TYPE)
+          .length > 0;
 
       return (hasLat && hasLon) || hasGeocoord;
     },

--- a/public/components/facets/GeocoordinateFacet.vue
+++ b/public/components/facets/GeocoordinateFacet.vue
@@ -85,6 +85,7 @@ import {
   NUMERICAL_SUMMARY,
   RowSelection,
   SummaryMode,
+  TaskTypes,
 } from "../../store/dataset";
 import TypeChangeMenu from "../TypeChangeMenu.vue";
 import FacetNumerical from "./FacetNumerical.vue";

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -546,6 +546,13 @@ export const getters = {
     return task.includes(TaskTypes.REMOTE_SENSING);
   },
 
+  isGeoSpatial(state:Route): boolean {
+    // get tasks in route
+    const task = state.query.training as string;
+    // return if geospatial reside in the route hardcoded for now I dont believe there is an enum for it
+    return !!task && task.includes("__geo_coordinates");
+  },
+
   /* Check if the current task includes Timeseries. */
   isTimeseries(state: Route): boolean {
     // Get the list of task of the route.

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -546,7 +546,7 @@ export const getters = {
     return task.includes(TaskTypes.REMOTE_SENSING);
   },
 
-  isGeoSpatial(state:Route): boolean {
+  isGeoSpatial(state: Route): boolean {
     // get tasks in route
     const task = state.query.training as string;
     // return if geospatial reside in the route hardcoded for now I dont believe there is an enum for it

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -548,7 +548,6 @@ export const getters = {
   },
 
   isGeoSpatial(state: Route, getters: any): boolean {
-    // return if geospatial reside in the route hardcoded for now I dont believe there is an enum for it
     return getters.getTrainingVariables.some(
       (v) => v.colType === GEOBOUNDS_TYPE || v.colType === GEOCOORDINATE_TYPE
     );

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -548,8 +548,6 @@ export const getters = {
   },
 
   isGeoSpatial(state: Route, getters: any): boolean {
-    // get tasks in route
-    const task = state.query.training as string;
     // return if geospatial reside in the route hardcoded for now I dont believe there is an enum for it
     return getters.getTrainingVariables.some(
       (v) => v.colType === GEOBOUNDS_TYPE || v.colType === GEOCOORDINATE_TYPE

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -36,6 +36,7 @@ import { Route } from "vue-router";
 import _ from "lodash";
 import { $enum } from "ts-enum-util";
 import { minimumRouteKey } from "../../util/data";
+import { GEOBOUNDS_TYPE, GEOCOORDINATE_TYPE } from "../../util/types";
 
 export const getters = {
   getRoute(state: Route): Route {
@@ -546,14 +547,17 @@ export const getters = {
     return task.includes(TaskTypes.REMOTE_SENSING);
   },
 
-  isGeoSpatial(state: Route): boolean {
+  isGeoSpatial(state: Route, getters: any): boolean {
     // get tasks in route
     const task = state.query.training as string;
     // return if geospatial reside in the route hardcoded for now I dont believe there is an enum for it
-    return !!task && task.includes("__geo_coordinates");
+    return getters.getTrainingVariables.some(
+      (v) => v.colType === GEOBOUNDS_TYPE || v.colType === GEOCOORDINATE_TYPE
+    );
   },
 
   /* Check if the current task includes Timeseries. */
+
   isTimeseries(state: Route): boolean {
     // Get the list of task of the route.
     const task = state.query.task as string;

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -106,6 +106,7 @@ export const getters = {
   isSingleSolution: read(moduleGetters.isSingleSolution),
   isApplyModel: read(moduleGetters.isApplyModel),
   isRemoteSensing: read(moduleGetters.isRemoteSensing),
+  isGeoSpatial: read(moduleGetters.isGeoSpatial),
   isTimeseries: read(moduleGetters.isTimeseries),
   getBandCombinationId: read(moduleGetters.getBandCombinationId),
   getModelLimit: read(moduleGetters.getModelLimit),


### PR DESCRIPTION
closes #1730 

Added support for disabling view-type-toggles if there is no training data for it to use.
Added a getter for routes that can check if geo_coordinate data is present. "uses training variable from route, should be changed to task variable once the backend supports it"
Remove some old prefix filtering in the filterName for FilterBadges(because we use the displayname now there is no need for filtering and making it look pretty)