### PR TITLE
Parquet Dataset Storage

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -250,30 +250,15 @@ func splitTrainTest(sourceFile string, trainFile string, testFile string, hasHea
 		outputTrain, outputTest = shuffleAndWrite(inputData, groupingCol, numTrainingRows, numTestRows, true, outputTrain, outputTest, trainTestSplit)
 	}
 
-	parquetStorage := serialization.GetStorage(trainFile + ".parquet")
-	csvStorage := serialization.GetStorage(trainFile)
-
-	err = csvStorage.WriteData(trainFile, outputTrain)
+	err = datasetStorage.WriteData(trainFile, outputTrain)
 	if err != nil {
 		return errors.Wrap(err, "unable to output train data")
 	}
 
-	err = csvStorage.WriteData(testFile, outputTest)
+	err = datasetStorage.WriteData(testFile, outputTest)
 	if err != nil {
 		return errors.Wrap(err, "unable to output test data")
 	}
-
-	testParquetFile := fmt.Sprintf("%s.parquet", testFile)
-	err = parquetStorage.WriteData(testParquetFile, outputTest)
-	if err != nil {
-		return errors.Wrap(err, "unable to output test data")
-	}
-
-	pData, err := parquetStorage.ReadData(testParquetFile)
-	if err != nil {
-		return err
-	}
-	log.Infof("DATA: %v", pData)
 
 	return nil
 }

--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -258,20 +258,22 @@ func splitTrainTest(sourceFile string, trainFile string, testFile string, hasHea
 		return errors.Wrap(err, "unable to output train data")
 	}
 
-	err = parquetStorage.WriteData(trainFile+".parquet", outputTrain)
-	if err != nil {
-		return errors.Wrap(err, "unable to output train data")
-	}
-
 	err = csvStorage.WriteData(testFile, outputTest)
 	if err != nil {
 		return errors.Wrap(err, "unable to output test data")
 	}
 
-	err = parquetStorage.WriteData(testFile+".parquet", outputTest)
+	testParquetFile := fmt.Sprintf("%s.parquet", testFile)
+	err = parquetStorage.WriteData(testParquetFile, outputTest)
 	if err != nil {
 		return errors.Wrap(err, "unable to output test data")
 	}
+
+	pData, err := parquetStorage.ReadData(testParquetFile)
+	if err != nil {
+		return err
+	}
+	log.Infof("DATA: %v", pData)
 
 	return nil
 }

--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -250,12 +250,25 @@ func splitTrainTest(sourceFile string, trainFile string, testFile string, hasHea
 		outputTrain, outputTest = shuffleAndWrite(inputData, groupingCol, numTrainingRows, numTestRows, true, outputTrain, outputTest, trainTestSplit)
 	}
 
-	err = datasetStorage.WriteData(trainFile, outputTrain)
+	parquetStorage := serialization.GetStorage(trainFile + ".parquet")
+	csvStorage := serialization.GetStorage(trainFile)
+
+	err = csvStorage.WriteData(trainFile, outputTrain)
 	if err != nil {
 		return errors.Wrap(err, "unable to output train data")
 	}
 
-	err = datasetStorage.WriteData(testFile, outputTest)
+	err = parquetStorage.WriteData(trainFile+".parquet", outputTrain)
+	if err != nil {
+		return errors.Wrap(err, "unable to output train data")
+	}
+
+	err = csvStorage.WriteData(testFile, outputTest)
+	if err != nil {
+		return errors.Wrap(err, "unable to output test data")
+	}
+
+	err = parquetStorage.WriteData(testFile+".parquet", outputTest)
 	if err != nil {
 		return errors.Wrap(err, "unable to output test data")
 	}

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -135,7 +135,7 @@ func (d *Parquet) WriteData(uri string, data [][]string) error {
 		return errors.Wrapf(err, "unable to create parquet file '%s'", uri)
 	}
 
-	pw, err := writer.NewCSVWriter(md, fw, 4)
+	pw, err := writer.NewCSVWriter(md, fw, 1)
 	if err != nil {
 		return errors.Wrap(err, "unable to create parquet writer")
 	}

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -1,0 +1,242 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package serialization
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/xitongsys/parquet-go-source/local"
+	"github.com/xitongsys/parquet-go/reader"
+	"github.com/xitongsys/parquet-go/writer"
+
+	"github.com/pkg/errors"
+	"github.com/uncharted-distil/distil-compute/metadata"
+	"github.com/uncharted-distil/distil-compute/model"
+	api "github.com/uncharted-distil/distil/api/model"
+)
+
+// Parquet represents a dataset storage backed with parquet data and json schema doc.
+type Parquet struct {
+}
+
+type parquetRow struct {
+	data []string `parquet:"name=data, type=SLICE, valuetype=UTF8"`
+}
+
+// NewParquet creates a new parquet backed storage.
+func NewParquet() *Parquet {
+	return &Parquet{}
+}
+
+// ReadDataset reads a raw dataset from the file system, loading the csv
+// data into memory.
+func (d *Parquet) ReadDataset(uri string) (*api.RawDataset, error) {
+	data, err := d.ReadData(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := d.ReadMetadata(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.RawDataset{
+		Data:     data,
+		Metadata: meta,
+	}, nil
+}
+
+// WriteDataset writes the raw dataset to the file system, writing out
+// the data to a csv file.
+func (d *Parquet) WriteDataset(uri string, data *api.RawDataset) error {
+	err := d.WriteData(uri, data.Data)
+	if err != nil {
+		return err
+	}
+
+	err = d.WriteMetadata(uri, data.Metadata, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ReadData reads the data from a csv file.
+func (d *Parquet) ReadData(uri string) ([][]string, error) {
+	fr, err := local.NewLocalFileReader(uri)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to open parquet file")
+	}
+
+	pr, err := reader.NewParquetReader(fr, new(parquetRow), 1)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to open parquet file reader")
+	}
+
+	num := int(pr.GetNumRows())
+	rows := make([]parquetRow, num)
+	err = pr.Read(&rows)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read parquet data")
+	}
+	pr.ReadStop()
+	fr.Close()
+
+	output := make([][]string, len(rows))
+	for i, row := range rows {
+		output[i] = row.data
+	}
+
+	return output, nil
+}
+
+// WriteData writes data to a csv file.
+func (d *Parquet) WriteData(uri string, data [][]string) error {
+	fw, err := local.NewLocalFileWriter(uri)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create parquet file '%s'", uri)
+	}
+
+	//write
+	pw, err := writer.NewParquetWriter(fw, new(parquetRow), 1)
+	if err != nil {
+		return errors.Wrap(err, "unable to create parquet writer")
+	}
+	defer fw.Close()
+
+	for i := 0; i < len(data); i++ {
+		row := &parquetRow{
+			data: data[i],
+		}
+		err = pw.Write(row)
+		if err != nil {
+			return errors.Wrap(err, "error writing data to parquet file")
+		}
+	}
+	err = pw.WriteStop()
+	if err != nil {
+		return errors.Wrap(err, "error ending parquet write")
+	}
+
+	return nil
+}
+
+// ReadMetadata reads the dataset doc from disk.
+func (d *Parquet) ReadMetadata(uri string) (*model.Metadata, error) {
+	meta, err := metadata.LoadMetadataFromOriginalSchema(uri, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return meta, nil
+}
+
+// WriteMetadata writes the dataset doc to disk.
+func (d *Parquet) WriteMetadata(uri string, meta *model.Metadata, extended bool) error {
+	dataResources := make([]interface{}, 0)
+	for _, dr := range meta.DataResources {
+		dataResources = append(dataResources, d.writeDataResource(dr, extended))
+	}
+
+	about := map[string]interface{}{
+		"datasetID":            meta.ID,
+		"datasetName":          meta.Name,
+		"description":          meta.Description,
+		"datasetSchemaVersion": schemaVersion,
+		"license":              license,
+		"redacted":             meta.Redacted,
+	}
+
+	if extended {
+		about["parentDatasetIDs"] = meta.ParentDatasetIDs
+		about["storageName"] = meta.StorageName
+		about["rawData"] = meta.Raw
+		about["mergedSchema"] = "false"
+	}
+
+	output := map[string]interface{}{
+		"about":         about,
+		"dataResources": dataResources,
+	}
+
+	bytes, err := json.MarshalIndent(output, "", "	")
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal merged schema file output")
+	}
+	// write copy to disk
+	err = ioutil.WriteFile(uri, bytes, 0644)
+	if err != nil {
+		return errors.Wrap(err, "failed to write metadata to disk")
+	}
+
+	return nil
+}
+
+func (d *Parquet) writeDataResource(resource *model.DataResource, extended bool) map[string]interface{} {
+	vars := make([]interface{}, 0)
+
+	for _, v := range resource.Variables {
+		vars = append(vars, d.writeVariable(v, extended))
+	}
+
+	output := map[string]interface{}{
+		"resID":        resource.ResID,
+		"resPath":      resource.ResPath,
+		"resType":      resource.ResType,
+		"resFormat":    resource.ResFormat,
+		"isCollection": resource.IsCollection,
+	}
+
+	if len(vars) > 0 {
+		output["columns"] = vars
+	}
+
+	return output
+}
+
+func (d *Parquet) writeVariable(variable *model.Variable, extended bool) interface{} {
+	// col type index doesn't exist for TA2
+	colType := model.MapSchemaType(variable.Type)
+
+	output := map[string]interface{}{
+		model.VarIndexField: variable.Index,
+		model.VarNameField:  variable.DisplayName,
+		model.VarTypeField:  colType,
+		model.VarRoleField:  variable.Role,
+		"refersTo":          variable.RefersTo,
+	}
+
+	if extended {
+		output[model.VarDescriptionField] = variable.Description
+		output[model.VarOriginalTypeField] = variable.OriginalType
+		output[model.VarSelectedRoleField] = variable.SelectedRole
+		output[model.VarDistilRole] = variable.DistilRole
+		output[model.VarOriginalVariableField] = variable.OriginalVariable
+		output[model.VarNameField] = variable.Name
+		output[model.VarDisplayVariableField] = variable.DisplayName
+		output[model.VarImportanceField] = variable.Importance
+		output[model.VarSuggestedTypesField] = variable.SuggestedTypes
+		output[model.VarDeleted] = variable.Deleted
+		output[model.VarGroupingField] = variable.Grouping
+		output[model.VarMinField] = variable.Min
+		output[model.VarMaxField] = variable.Max
+	}
+
+	return output
+}

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -16,6 +16,8 @@
 package serialization
 
 import (
+	"path"
+
 	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
 )
@@ -23,6 +25,11 @@ import (
 const (
 	schemaVersion = "4.0.0"
 	license       = "Unknown"
+)
+
+var (
+	csvStorage     = NewCSV()
+	parquetStorage = NewParquet()
 )
 
 // Storage defines the base functions needed to store datasets to a backing
@@ -34,4 +41,13 @@ type Storage interface {
 	WriteData(uri string, data [][]string) error
 	ReadMetadata(uri string) (*model.Metadata, error)
 	WriteMetadata(uri string, metadata *model.Metadata, extended bool) error
+}
+
+// GetStorage returns the storage to use based on URI.
+func GetStorage(uri string) Storage {
+	if path.Ext(uri) == ".parquet" {
+		return parquetStorage
+	}
+
+	return csvStorage
 }

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48
+	github.com/xitongsys/parquet-go v1.5.3
+	github.com/xitongsys/parquet-go-source v0.0.0-20190524061010-2b72cbee77d5
 	github.com/zenazn/goji v0.9.0
 	goji.io/v3 v3.0.0
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Jeffail/gabs/v2 v2.2.0 h1:7touC+WzbQ7LO5+mwgxT44miyTqAVCOlIWLA6PiIB5w=
 github.com/Jeffail/gabs/v2 v2.2.0/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
+github.com/apache/thrift v0.0.0-20181112125854-24918abba929 h1:ubPe2yRkS6A/X37s0TVGfuN42NV2h0BlzWj0X76RoUw=
+github.com/apache/thrift v0.0.0-20181112125854-24918abba929/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 h1:c4mLfegoDw6OhSJXTd2jUEQgZUQuJWtocudb97Qn9EM=
 github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
 github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
@@ -36,6 +38,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
@@ -101,6 +105,8 @@ github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.10.5 h1:7q6vHIqubShURwQz8cQK6yIe/xC3IF0Vm7TGfqjewrc=
+github.com/klauspost/compress v1.10.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -188,6 +194,10 @@ github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnm
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9/go.mod h1:PrytgQ5GjTc6Z5/pbL5vj1UhD716wDobDeimrd7lRKY=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48 h1:XYef2jcFEKziHl4rv/21jrNeQg6Z3gL345u16fHWVDo=
 github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48/go.mod h1:E/Q5UxH/qEZkOl5P6vKXtsJsQL2b96TF4eKuTbRhpmk=
+github.com/xitongsys/parquet-go v1.5.3 h1:v5X025+wj4FbhA4QdspRKhlUcQjMShsGSVns4b8UGUs=
+github.com/xitongsys/parquet-go v1.5.3/go.mod h1:Tewz0PmVEQyY6iLAoocllGHaKFLnbfkSgj3hVLTwFP0=
+github.com/xitongsys/parquet-go-source v0.0.0-20190524061010-2b72cbee77d5 h1:XmN4NA9133N6OvDEAR6TVVhFq5NgetYTyeKl1EMNazs=
+github.com/xitongsys/parquet-go-source v0.0.0-20190524061010-2b72cbee77d5/go.mod h1:xxCx7Wpym/3QCo6JhujJX51dzSXrwmb0oH6FQb39SEA=
 github.com/zenazn/goji v0.9.0 h1:RSQQAbXGArQ0dIDEq+PI6WqN6if+5KHu6x2Cx/GXLTQ=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
Added simple implementation of parquet backed storage. It currently writes out strings (basically a CSV stored in parquet) and reads typed data. Reading currently translates typed data to strings since distil expects string data everywhere currently.

No integration of the parquet storage is currently done in distil. There is now a simple function that uses the filename extension to determine if it is parquet or csv, but it is not being called yet.