### PR TITLE
Store split parquet

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -47,10 +47,6 @@ const (
 	testFilenamePrefix  = "test"
 )
 
-var (
-	datasetStorage serialization.Storage
-)
-
 // FilteredDataProvider defines a function that will fetch data from a back end source given
 // a set of filter parameters.
 type FilteredDataProvider func(dataset string, index string, filters *api.FilterParams) (*api.FilteredData, error)
@@ -103,11 +99,6 @@ type DataReference struct {
 	ResObject string `json:"resObject"`
 }
 
-// SetDatasetStorage sets the storage interface to use for accessing datasets.
-func SetDatasetStorage(ds serialization.Storage) {
-	datasetStorage = ds
-}
-
 // Hash the filter set
 func getFilteredDatasetHash(dataset string, target string, filterParams *api.FilterParams, isTrain bool) (uint64, error) {
 	hash, err := hashstructure.Hash([]interface{}{dataset, target, *filterParams, isTrain}, nil)
@@ -139,6 +130,7 @@ func splitTrainTestTimeseries(sourceFile string, trainFile string, testFile stri
 	outputTest := [][]string{}
 
 	// read the data
+	datasetStorage := serialization.GetStorage(sourceFile)
 	inputData, err := datasetStorage.ReadData(sourceFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to open source file")
@@ -214,6 +206,7 @@ func splitTrainTest(sourceFile string, trainFile string, testFile string, hasHea
 	outputTest := [][]string{}
 
 	// read the data
+	datasetStorage := serialization.GetStorage(sourceFile)
 	inputData, err := datasetStorage.ReadData(sourceFile)
 	if err != nil {
 		return errors.Wrap(err, "failed to read source file")

--- a/api/compute/dataset_persist_test.go
+++ b/api/compute/dataset_persist_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil/api/env"
-	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 )
 
@@ -153,7 +152,6 @@ func TestLimitChange(t *testing.T) {
 }
 
 func createTestParams(stratify bool, quality string) *persistedDataParams {
-	datasetStorage = serialization.NewCSV()
 	return &persistedDataParams{
 		DatasetName:        "test_dataset",
 		SchemaFile:         compute.D3MDataSchema,

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -36,15 +36,6 @@ const (
 	confidenceName           = "confidence"
 )
 
-var (
-	datasetStorage serialization.Storage
-)
-
-// SetDatasetStorage sets the storage interface to use for accessing datasets.
-func SetDatasetStorage(ds serialization.Storage) {
-	datasetStorage = ds
-}
-
 func (s *Storage) getResultTable(storageName string) string {
 	return fmt.Sprintf("%s%s", storageName, resultTableSuffix)
 }
@@ -153,6 +144,7 @@ func (s *Storage) PersistSolutionFeatureWeight(dataset string, storageName strin
 // PersistResult stores the solution result to Postgres.
 func (s *Storage) PersistResult(dataset string, storageName string, resultURI string, target string, confidenceValues *api.SolutionExplainResult) error {
 	// Read the results file.
+	datasetStorage := serialization.GetStorage(resultURI)
 	records, err := datasetStorage.ReadData(resultURI)
 	if err != nil {
 		return err

--- a/api/serialization/csv.go
+++ b/api/serialization/csv.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	api "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/util"
 	log "github.com/unchartedsoftware/plog"
@@ -98,6 +99,11 @@ func (d *CSV) WriteData(uri string, data [][]string) error {
 	return nil
 }
 
+// ReadRawVariables reads the csv header file to get a list of variables in the file.
+func (d *CSV) ReadRawVariables(uri string) ([]string, error) {
+	return util.ReadCSVHeader(uri)
+}
+
 // ReadMetadata reads the dataset doc from disk.
 func (d *CSV) ReadMetadata(uri string) (*model.Metadata, error) {
 	meta, err := metadata.LoadMetadataFromOriginalSchema(uri, true)
@@ -160,7 +166,7 @@ func (d *CSV) writeDataResource(resource *model.DataResource, extended bool) map
 		"resID":        resource.ResID,
 		"resPath":      resource.ResPath,
 		"resType":      resource.ResType,
-		"resFormat":    resource.ResFormat,
+		"resFormat":    map[string][]string{compute.D3MResourceFormat: {"csv"}},
 		"isCollection": resource.IsCollection,
 	}
 

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
-	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	api "github.com/uncharted-distil/distil/api/model"
 )
 
@@ -267,7 +266,7 @@ func (d *Parquet) writeDataResource(resource *model.DataResource, extended bool)
 		"resID":        resource.ResID,
 		"resPath":      resource.ResPath,
 		"resType":      resource.ResType,
-		"resFormat":    map[string][]string{compute.D3MResourceFormat: {"csv"}},
+		"resFormat":    map[string][]string{"application/parquet": {"parquet"}},
 		"isCollection": resource.IsCollection,
 	}
 

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -41,6 +41,7 @@ type Storage interface {
 	WriteData(uri string, data [][]string) error
 	ReadMetadata(uri string) (*model.Metadata, error)
 	WriteMetadata(uri string, metadata *model.Metadata, extended bool) error
+	ReadRawVariables(uri string) ([]string, error)
 }
 
 // GetStorage returns the storage to use based on URI.

--- a/api/task/cleaning.go
+++ b/api/task/cleaning.go
@@ -22,6 +22,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 )
 
@@ -70,6 +71,7 @@ func Clean(schemaFile string, dataset string, config *IngestTaskConfig) (string,
 	output = append(output, csvData...)
 
 	// output the data
+	datasetStorage := serialization.GetStorage(outputPath.outputData)
 	err = datasetStorage.WriteData(outputPath.outputData, output)
 	if err != nil {
 		return "", errors.Wrap(err, "error writing clustered output")

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 )
 
@@ -91,6 +92,7 @@ func ClusterDataset(schemaFile string, dataset string, config *IngestTaskConfig)
 	output = append(output, header)
 	output = append(output, lines...)
 
+	datasetStorage := serialization.GetStorage(outputPath.outputData)
 	err = datasetStorage.WriteData(outputPath.outputData, output)
 	if err != nil {
 		return "", errors.Wrap(err, "error writing clustered output")

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -43,14 +43,7 @@ var (
 		"jpeg": "jpeg",
 		"jpg":  "jpeg",
 	}
-
-	datasetStorage serialization.Storage
 )
-
-// SetDatasetStorage sets the storage interface to use for accessing datasets.
-func SetDatasetStorage(ds serialization.Storage) {
-	datasetStorage = ds
-}
 
 // DatasetConstructor is used to build a dataset.
 type DatasetConstructor interface {
@@ -82,6 +75,7 @@ func CreateDataset(dataset string, datasetCtor DatasetConstructor, outputPath st
 		return "", "", err
 	}
 
+	datasetStorage := serialization.GetStorage(dataPath)
 	err = datasetStorage.WriteData(dataPath, ds.Data)
 	if err != nil {
 		return "", "", err
@@ -138,6 +132,7 @@ func writeDataset(meta *model.Metadata, csvData []byte, outputPath string, confi
 	}
 
 	schemaPath := path.Join(outputDatasetPath, compute.D3MDataSchema)
+	datasetStorage := serialization.GetStorage(dataPath)
 	err = datasetStorage.WriteMetadata(schemaPath, meta, true)
 	if err != nil {
 		return "", err

--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 	"github.com/uncharted-distil/distil/api/util/json"
 )
@@ -101,6 +102,7 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 	mainDR.Variables = vars
 
 	schemaOutputPath := path.Join(featurizedOutputPath, compute.D3MDataSchema)
+	datasetStorage := serialization.GetStorage(dataOutputPath)
 	err = datasetStorage.WriteMetadata(schemaOutputPath, meta, true)
 	if err != nil {
 		return "", "", err

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -23,6 +23,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
 
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 )
 
@@ -76,6 +77,7 @@ func outputDataset(paths *datasetCopyPath, meta *model.Metadata, lines [][]strin
 	output = append(output, lines...)
 
 	// output the data with the new feature
+	datasetStorage := serialization.GetStorage(paths.outputData)
 	err := datasetStorage.WriteData(paths.outputData, output)
 	if err != nil {
 		return errors.Wrap(err, "error writing output")

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/uncharted-distil/distil-compute/metadata"
 
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 )
 
@@ -119,6 +120,7 @@ func GeocodeForwardDataset(schemaFile string, dataset string, config *IngestTask
 	output = append(output, lines...)
 
 	// output the data with the new feature
+	datasetStorage := serialization.GetStorage(outputPath.outputData)
 	err = datasetStorage.WriteData(outputPath.outputData, output)
 	if err != nil {
 		return "", errors.Wrap(err, "error writing feature output")

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/postgres"
+	"github.com/uncharted-distil/distil/api/serialization"
 )
 
 const (
@@ -323,6 +324,7 @@ func Ingest(originalSchemaFile string, schemaFile string, data api.DataStorage, 
 			log.Infof("storing (extended: %v) metadata with new name to %s (new: '%s', old: '%s')", extendedOutput, originalSchemaFile, uniqueName, meta.Name)
 			meta.Name = uniqueName
 			meta.ID = model.NormalizeDatasetID(uniqueName)
+			datasetStorage := serialization.GetStorage(originalSchemaFile)
 			err = datasetStorage.WriteMetadata(originalSchemaFile, meta, extendedOutput)
 			if err != nil {
 				return "", errors.Wrap(err, "unable to store updated metadata")
@@ -395,6 +397,7 @@ func IngestMetadata(originalSchemaFile string, schemaFile string, data api.DataS
 		if meta.StorageName != storageName {
 			log.Infof("updating storage name in metadata from %s to %s", meta.StorageName, storageName)
 			meta.StorageName = storageName
+			datasetStorage := serialization.GetStorage(schemaFile)
 			err = datasetStorage.WriteMetadata(schemaFile, meta, true)
 			if err != nil {
 				return "", err
@@ -475,6 +478,7 @@ func IngestPostgres(originalSchemaFile string, schemaFile string, source metadat
 
 	// Load the data.
 	log.Infof("inserting rows into database based on data found in %s", dataDir)
+	datasetStorage := serialization.GetStorage(dataDir)
 	data, err := datasetStorage.ReadData(dataDir)
 	if err != nil {
 		return errors.Wrap(err, "unable to read input data")
@@ -540,6 +544,7 @@ func loadMetadataForIngest(originalSchemaFile string, schemaFile string, source 
 		if updated {
 			extendedOutput := source == metadata.Augmented
 			log.Infof("storing updated (extended: %v) metadata to %s", extendedOutput, originalSchemaFile)
+			datasetStorage := serialization.GetStorage(originalSchemaFile)
 			err = datasetStorage.WriteMetadata(originalSchemaFile, meta, extendedOutput)
 			if err != nil {
 				return "", nil, errors.Wrap(err, "unable to store updated metadata")

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil/api/env"
 	apiModel "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/serialization"
 	log "github.com/unchartedsoftware/plog"
 )
 
@@ -157,6 +158,7 @@ func createMergedVariables(varNames []string, leftVarsMap map[string]*model.Vari
 func createDatasetFromCSV(config *env.Config, csvFile string, datasetName string, storageName string,
 	leftVarsMap map[string]*model.Variable, rightVarsMap map[string]*model.Variable) ([]*model.Variable, error) {
 
+	datasetStorage := serialization.GetStorage(csvFile)
 	inputData, err := datasetStorage.ReadData(csvFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read data")
@@ -213,6 +215,7 @@ func createDatasetFromCSV(config *env.Config, csvFile string, datasetName string
 }
 
 func createFilteredData(csvFile string, variables []*model.Variable, lineCount int) (*apiModel.FilteredData, error) {
+	datasetStorage := serialization.GetStorage(csvFile)
 	inputData, err := datasetStorage.ReadData(csvFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read joined data")

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil/api/env"
 	apiModel "github.com/uncharted-distil/distil/api/model"
-	"github.com/uncharted-distil/distil/api/serialization"
 )
 
 type testSubmitter struct{}
@@ -36,8 +35,6 @@ func (testSubmitter) submit(datasetURIs []string, pipelineDesc *description.Full
 }
 
 func TestJoin(t *testing.T) {
-
-	datasetStorage = serialization.NewCSV()
 
 	varsLeft := []*model.Variable{
 		{

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -24,6 +24,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/model"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 )
 
@@ -97,6 +98,7 @@ func Merge(schemaFile string, dataset string, config *IngestTaskConfig) (string,
 	output = append(output, csvData[1:]...)
 
 	// output the data
+	datasetStorage := serialization.GetStorage(outputPath.outputData)
 	err = datasetStorage.WriteData(outputPath.outputData, output)
 	if err != nil {
 		return "", errors.Wrap(err, "error writing merged output")

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -28,6 +28,7 @@ import (
 	comp "github.com/uncharted-distil/distil/api/compute"
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 	log "github.com/unchartedsoftware/plog"
 )
@@ -221,6 +222,7 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 		meta.StorageName = model.NormalizeDatasetID(datasetName)
 		meta.DatasetFolder = path.Base(datasetPath)
 		schemaPath = path.Join(datasetPath, compute.D3MDataSchema)
+		datasetStorage := serialization.GetStorage(rawDataPath)
 		err = datasetStorage.WriteMetadata(schemaPath, meta, true)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to update dataset doc")
@@ -277,6 +279,7 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 		return nil, errors.Wrap(err, "unable to read latest dataset doc")
 	}
 	meta.ID = sourceDatasetID
+	datasetStorage := serialization.GetStorage(schemaPath)
 	err = datasetStorage.WriteMetadata(schemaPath, meta, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to update dataset doc")

--- a/api/task/sample.go
+++ b/api/task/sample.go
@@ -25,6 +25,7 @@ import (
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
 	"github.com/uncharted-distil/distil/api/compute"
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 )
 
@@ -59,6 +60,7 @@ func Sample(originalSchemaFile string, schemaFile string, dataset string, config
 	}
 
 	// output to the expected location (learningData.csv)
+	datasetStorage := serialization.GetStorage(csvFilePath)
 	err = datasetStorage.WriteData(csvFilePath, sampledData)
 	if err != nil {
 		return "", false, 0, err

--- a/main.go
+++ b/main.go
@@ -43,7 +43,6 @@ import (
 	"github.com/uncharted-distil/distil/api/postgres"
 	"github.com/uncharted-distil/distil/api/rest"
 	"github.com/uncharted-distil/distil/api/routes"
-	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/service"
 	"github.com/uncharted-distil/distil/api/task"
 	"github.com/uncharted-distil/distil/api/util"
@@ -195,12 +194,6 @@ func main() {
 		datamartCtors[dm.ProvenanceISI] = dm.NewISIMetadataStorage(config.DatamartImportFolder, &config, ingestConfig, isiDatamartClientCtor)
 	}
 	datamartCtors[es.Provenance] = esMetadataStorageCtor
-
-	// set the data reader and writer
-	datasetStorage := serialization.NewCSV()
-	task.SetDatasetStorage(datasetStorage)
-	pg.SetDatasetStorage(datasetStorage)
-	api.SetDatasetStorage(datasetStorage)
 
 	// set extremas
 	//esStorage, err := esMetadataStorageCtor()


### PR DESCRIPTION
Parquet storage now used if a referenced URI end in `.parquet`. Also updated parquet storage to not write out the header, and to read variables from the metadata. The resFormat in the metadata gets output based on the serialization used.