### PR TITLE
added sort function based on rank

### DIFF
--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -24,7 +24,7 @@
         <div class="col-12 flex-column variable-facets-container">
           <div
             class="variable-facets-item"
-            v-for="summary in sortedVariableSummaries()"
+            v-for="summary in summaries"
             :key="summary.key"
           >
             <template v-if="summary.pending">
@@ -166,7 +166,7 @@ import { overlayRouteEntry, getRouteFacetPage } from "../../util/routes";
 import { Dictionary } from "../../util/dict";
 import {
   getVariableRanking,
-  getSolutionVariableRanking,
+  getResultVariableRanking,
   NUM_PER_PAGE,
 } from "../../util/data";
 import {
@@ -270,7 +270,7 @@ export default Vue.extend({
       const ranking: Dictionary<number> = {};
       this.variables.forEach((variable) => {
         ranking[variable.colName] = this.isResultFeatures
-          ? getSolutionVariableRanking(
+          ? getResultVariableRanking(
               variable,
               routeGetters.getRouteSolutionId(this.$store)
             )
@@ -394,17 +394,6 @@ export default Vue.extend({
 
     isImage(type: string): boolean {
       return isImageType(type);
-    },
-    sortedVariableSummaries(): VariableSummary[] {
-      const ranking = this.ranking;
-      if (ranking === {}) {
-        return this.summaries;
-      }
-      this.summaries.sort((a, b) => {
-        return ranking[b.key] - ranking[a.key];
-      });
-
-      return this.summaries;
     },
   },
   beforeMount() {

--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -166,7 +166,7 @@ import { overlayRouteEntry, getRouteFacetPage } from "../../util/routes";
 import { Dictionary } from "../../util/dict";
 import {
   getVariableRanking,
-  getResultVariableRanking,
+  getSolutionVariableRanking,
   NUM_PER_PAGE,
 } from "../../util/data";
 import {
@@ -270,7 +270,7 @@ export default Vue.extend({
       const ranking: Dictionary<number> = {};
       this.variables.forEach((variable) => {
         ranking[variable.colName] = this.isResultFeatures
-          ? getResultVariableRanking(
+          ? getSolutionVariableRanking(
               variable,
               routeGetters.getRouteSolutionId(this.$store)
             )

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -1,52 +1,52 @@
-import _ from "lodash";
 import axios from "axios";
-import Vue from "vue";
 import sha1 from "crypto-js/sha1";
+import _ from "lodash";
+import Vue from "vue";
 import {
-  Variable,
-  VariableSummary,
-  TableData,
-  TableRow,
-  TableColumn,
-  TimeseriesGrouping,
   D3M_INDEX_FIELD,
   SummaryMode,
+  TableColumn,
+  TableData,
+  TableRow,
+  TimeseriesGrouping,
+  Variable,
+  VariableSummary,
 } from "../store/dataset/index";
 import {
-  Solution,
-  SOLUTION_COMPLETED,
+  actions as datasetActions,
+  getters as datasetGetters,
+} from "../store/dataset/module";
+import { PredictionContext } from "../store/predictions/actions";
+import {
   Predictions,
   PREDICT_COMPLETED,
+  Solution,
+  SOLUTION_COMPLETED,
 } from "../store/requests/index";
-import { Dictionary } from "./dict";
-import { FilterParams } from "./filters";
-import store from "../store/store";
+import { getters as requestGetters } from "../store/requests/module";
+import { ResultsContext } from "../store/results/actions";
 import {
   actions as resultsActions,
   getters as resultsGetters,
 } from "../store/results/module";
-import { ResultsContext } from "../store/results/actions";
-import { PredictionContext } from "../store/predictions/actions";
-import {
-  getters as datasetGetters,
-  actions as datasetActions,
-} from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
-import { getters as requestGetters } from "../store/requests/module";
+import store from "../store/store";
 import {
   formatValue,
-  isIntegerType,
-  isTimeType,
-  isListType,
   hasComputedVarPrefix,
   IMAGE_TYPE,
+  isIntegerType,
+  isLatitudeGroupType,
+  isListType,
+  isLongitudeGroupType,
+  isTimeGroupType,
+  isTimeType,
+  isValueGroupType,
   REMOTE_SENSING_TYPE,
   TIMESERIES_TYPE,
-  isLatitudeGroupType,
-  isLongitudeGroupType,
-  isValueGroupType,
-  isTimeGroupType,
 } from "../util/types";
+import { Dictionary } from "./dict";
+import { FilterParams } from "./filters";
 
 // Postfixes for special variable names
 export const PREDICTED_SUFFIX = "_predicted";
@@ -618,7 +618,7 @@ export function sortSummariesByImportance(
   return summaries;
 }
 
-export function sortSolutionSummariesByImportance(
+export function sortResultSummariesByImportance(
   summaries: VariableSummary[],
   variables: Variable[],
   solutionID: string

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -618,7 +618,7 @@ export function sortSummariesByImportance(
   return summaries;
 }
 
-export function sortResultSummariesByImportance(
+export function sortSolutionSummariesByImportance(
   summaries: VariableSummary[],
   variables: Variable[],
   solutionID: string

--- a/public/views/Predictions.vue
+++ b/public/views/Predictions.vue
@@ -22,7 +22,7 @@
             :log-activity="logActivity"
             model-selection
             :pagination="trainingVariables.length > rowsPerPage"
-            :summaries="trainingSummaries"
+            :summaries="trainingSummariesByImportance"
           >
           </variable-facets>
         </div>
@@ -48,20 +48,17 @@ import StatusPanel from "../components/StatusPanel";
 import StatusSidebar from "../components/StatusSidebar";
 import { VariableSummary, Variable } from "../store/dataset/index";
 import { actions as viewActions } from "../store/view/module";
-import {
-  getters as datasetGetters,
-  actions as datasetActions,
-} from "../store/dataset/module";
+import { actions as datasetActions } from "../store/dataset/module";
 import { getters as predictionGetters } from "../store/predictions/module";
 import { getters as requestGetters } from "../store/requests/module";
-import { getters as resultGetters } from "../store/results/module";
 import { getters as routeGetters } from "../store/route/module";
 import {
   NUM_PER_PAGE,
   getVariableSummariesByState,
   searchVariables,
+  sortSolutionSummariesByImportance,
 } from "../util/data";
-import { Feature, Activity } from "../util/userEvents";
+import { Activity } from "../util/userEvents";
 
 export default Vue.extend({
   name: "predictions-view",
@@ -103,6 +100,13 @@ export default Vue.extend({
         this.rowsPerPage,
         this.trainingVariables,
         summaryDictionary
+      );
+    },
+    trainingSummariesByImportance(): VariableSummary[] {
+      return sortSolutionSummariesByImportance(
+        this.trainingSummaries,
+        this.trainingVariables,
+        this.solutionId
       );
     },
     solutionId(): string {

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -49,11 +49,11 @@ import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as resultGetters } from "../store/results/module";
 import { getters as routeGetters } from "../store/route/module";
 import { getters as requestGetters } from "../store/requests/module";
-import { sortResultSummariesByImportance } from "../util/data";
 import {
   NUM_PER_PAGE,
   getVariableSummariesByState,
   searchVariables,
+  sortSolutionSummariesByImportance,
 } from "../util/data";
 import { Feature, Activity } from "../util/userEvents";
 
@@ -118,7 +118,7 @@ export default Vue.extend({
       );
     },
     trainingSummariesByImportance(): VariableSummary[] {
-      return sortResultSummariesByImportance(
+      return sortSolutionSummariesByImportance(
         this.trainingSummaries,
         this.trainingVariables,
         this.solutionId

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -22,7 +22,7 @@
           :log-activity="logActivity"
           model-selection
           :pagination="trainingVariables.length > rowsPerPage"
-          :summaries="trainingSummaries"
+          :summaries="trainingSummariesByImportance"
         >
         </variable-facets>
       </div>
@@ -49,6 +49,7 @@ import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as resultGetters } from "../store/results/module";
 import { getters as routeGetters } from "../store/route/module";
 import { getters as requestGetters } from "../store/requests/module";
+import { sortResultSummariesByImportance } from "../util/data";
 import {
   NUM_PER_PAGE,
   getVariableSummariesByState,
@@ -114,6 +115,13 @@ export default Vue.extend({
         this.rowsPerPage,
         this.trainingVariables,
         summaryDictionary
+      );
+    },
+    trainingSummariesByImportance(): VariableSummary[] {
+      return sortResultSummariesByImportance(
+        this.trainingSummaries,
+        this.trainingVariables,
+        this.solutionId
       );
     },
     solutionId(): string {


### PR DESCRIPTION
added sortedVariableSummaries function. Sorts the variable summaries based on ranking if ranking is available.
This function sorts once on render.
Tried using watch to only sort when the summaries were updated but surprisingly this was being called consistently.
Removed a bunch of unused imports and some unused lines of code.

closes #1930 