### PR TITLE
1751 ranking clean up

### DIFF
--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -102,7 +102,7 @@ import ErrorModal from "../components/ErrorModal";
 import { createRouteEntry } from "../util/routes";
 import { formatBytes } from "../util/bytes";
 import {
-  sortVariablesByImportance,
+  sortVariablesByPCARanking,
   isDatamartProvenance,
   filterVariablesByFeature,
 } from "../util/data";
@@ -140,7 +140,7 @@ export default Vue.extend({
       );
     },
     topVariables(): Variable[] {
-      return sortVariablesByImportance(
+      return sortVariablesByPCARanking(
         filterVariablesByFeature(this.dataset.variables).slice(0)
       ).slice(0, NUM_TOP_FEATURES);
     },

--- a/public/components/DatasetPreviewCard.vue
+++ b/public/components/DatasetPreviewCard.vue
@@ -37,7 +37,7 @@
 import _ from "lodash";
 import Vue from "vue";
 import {
-  sortVariablesByImportance,
+  sortVariablesByPCARanking,
   filterVariablesByFeature,
 } from "../util/data";
 import { formatBytes } from "../util/bytes";
@@ -54,13 +54,12 @@ export default Vue.extend({
 
   computed: {
     topVariables(): Variable[] {
-      return sortVariablesByImportance(this.dataset.variables.slice(0)).slice(
+      return sortVariablesByPCARanking(this.dataset.variables.slice(0)).slice(
         0,
         NUM_TOP_FEATURES
       );
     },
   },
-
   methods: {
     formatBytes(n: number): string {
       return formatBytes(n);

--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -166,7 +166,7 @@ import { overlayRouteEntry, getRouteFacetPage } from "../../util/routes";
 import { Dictionary } from "../../util/dict";
 import {
   getVariableRanking,
-  getSolutionVariableRanking,
+  getSolutionFeatureImportance,
   NUM_PER_PAGE,
 } from "../../util/data";
 import {
@@ -270,7 +270,7 @@ export default Vue.extend({
       const ranking: Dictionary<number> = {};
       this.variables.forEach((variable) => {
         ranking[variable.colName] = this.isResultFeatures
-          ? getSolutionVariableRanking(
+          ? getSolutionFeatureImportance(
               variable,
               routeGetters.getRouteSolutionId(this.$store)
             )

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1,52 +1,52 @@
-import _ from "lodash";
 import axios, { AxiosResponse } from "axios";
-import { Dictionary } from "../../util/dict";
+import _ from "lodash";
 import { ActionContext } from "vuex";
 import {
-  Dataset,
-  DatasetOrigin,
-  DatasetState,
-  Variable,
-  Grouping,
-  DatasetPendingRequestType,
-  DatasetPendingRequestStatus,
-  VariableRankingPendingRequest,
-  JoinSuggestionPendingRequest,
-  JoinDatasetImportPendingRequest,
-  Task,
-  ClusteringPendingRequest,
-  SummaryMode,
-  DataMode,
-  BandCombinations,
-  BandID,
-  isClusteredGrouping,
-  TimeSeriesValue,
-} from "./index";
-import { mutations, getters } from "./module";
-import store, { DistilState } from "../store";
-import { Highlight } from "../dataset/index";
-import { FilterParams } from "../../util/filters";
-import {
-  createPendingSummary,
-  createErrorSummary,
   createEmptyTableData,
+  createErrorSummary,
+  createPendingSummary,
   fetchSummaryExemplars,
-  validateArgs,
   minimumRouteKey,
+  validateArgs,
 } from "../../util/data";
+import { Dictionary } from "../../util/dict";
+import { FilterParams } from "../../util/filters";
 import { addHighlightToFilterParams } from "../../util/highlights";
 import { loadImage } from "../../util/image";
 import {
+  GEOCODED_LAT_PREFIX,
+  GEOCODED_LON_PREFIX,
   getVarType,
   IMAGE_TYPE,
-  GEOCODED_LON_PREFIX,
-  GEOCODED_LAT_PREFIX,
+  isImageType,
   isRankableVariableType,
   REMOTE_SENSING_TYPE,
-  isImageType,
   UNKNOWN_TYPE,
 } from "../../util/types";
+import { Highlight } from "../dataset/index";
 import { getters as routeGetters } from "../route/module";
+import store, { DistilState } from "../store";
+import {
+  BandCombinations,
+  BandID,
+  ClusteringPendingRequest,
+  DataMode,
+  Dataset,
+  DatasetOrigin,
+  DatasetPendingRequestStatus,
+  DatasetPendingRequestType,
+  DatasetState,
+  Grouping,
+  isClusteredGrouping,
+  JoinDatasetImportPendingRequest,
+  JoinSuggestionPendingRequest,
+  SummaryMode,
+  Task,
+  TimeSeriesValue,
+  Variable,
+  VariableRankingPendingRequest,
+} from "./index";
+import { getters, mutations } from "./module";
 
 // fetches variables and add dataset name to each variable
 async function getVariables(dataset: string): Promise<Variable[]> {
@@ -912,7 +912,6 @@ export const actions = {
         // If the request has already been reviewed, we apply the rankings.
         if (routeGetters.getRouteIsTrainingVariablesRanked(store)) {
           mutations.setVariableRankings(context, { dataset, rankings });
-          mutations.updateVariableRankings(context, rankings);
         } else {
           status = DatasetPendingRequestStatus.RESOLVED;
         }

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -5,7 +5,6 @@ import { actions as moduleActions } from "./actions";
 import { mutations as moduleMutations } from "./mutations";
 import { DistilState } from "../store";
 import { getStoreAccessors } from "vuex-typescript";
-import { radialArea } from "d3";
 
 export const datasetModule: Module<DatasetState, DistilState> = {
   getters: moduleGetters,

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -1,34 +1,33 @@
 import axios from "axios";
+import { ActionContext } from "vuex";
+import { validateArgs } from "../../util/data";
+import { FilterParams } from "../../util/filters";
+import { getStreamById, getWebSocketConnection } from "../../util/ws";
+import { SummaryMode, TaskTypes } from "../dataset";
+import { actions as predictActions } from "../predictions/module";
+import { actions as resultsActions } from "../results/module";
+import { getters as routeGetters } from "../route/module";
+import store, { DistilState } from "../store";
 import {
-  RequestState,
-  SOLUTION_PENDING,
-  SOLUTION_COMPLETED,
-  SOLUTION_ERRORED,
-  SOLUTION_REQUEST_PENDING,
-  SOLUTION_REQUEST_RUNNING,
-  SOLUTION_REQUEST_COMPLETED,
-  SOLUTION_REQUEST_ERRORED,
-  SOLUTION_FITTING,
-  SOLUTION_PRODUCING,
-  SOLUTION_SCORING,
-  SolutionRequest,
-  Solution,
+  ModelQuality,
+  Predictions,
   PREDICT_COMPLETED,
   PREDICT_ERRORED,
-  Predictions,
-  ModelQuality,
+  RequestState,
+  Solution,
+  SolutionRequest,
+  SOLUTION_COMPLETED,
+  SOLUTION_ERRORED,
+  SOLUTION_FITTING,
+  SOLUTION_PENDING,
+  SOLUTION_PRODUCING,
+  SOLUTION_REQUEST_COMPLETED,
+  SOLUTION_REQUEST_ERRORED,
+  SOLUTION_REQUEST_PENDING,
+  SOLUTION_REQUEST_RUNNING,
+  SOLUTION_SCORING,
 } from "./index";
-import { ActionContext } from "vuex";
-import store, { DistilState } from "../store";
 import { mutations } from "./module";
-import { getWebSocketConnection, getStreamById } from "../../util/ws";
-import { FilterParams } from "../../util/filters";
-import { actions as resultsActions } from "../results/module";
-import { actions as predictActions } from "../predictions/module";
-import { getters as routeGetters } from "../route/module";
-import { TaskTypes, SummaryMode } from "../dataset";
-import { validateArgs } from "../../util/data";
-import { Model } from "../model";
 
 const CREATE_SOLUTIONS = "CREATE_SOLUTIONS";
 const STOP_SOLUTIONS = "STOP_SOLUTIONS";
@@ -106,6 +105,9 @@ function updateCurrentSolutionResults(
     highlight: context.getters.getDecodedHighlight,
     dataMode: dataMode,
     size,
+  });
+  resultsActions.fetchFeatureImportanceRanking(store, {
+    solutionID: res.solutionId,
   });
   resultsActions.fetchPredictedSummary(store, {
     dataset: req.dataset,

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -780,7 +780,7 @@ export const actions = {
 
   // Fetch variable rankings associated with a computed solution.  If the solution results are
   // available, then the rankings will have been computed.
-  async fetchVariableRankings(
+  async fetchFeatureImportanceRanking(
     context: ResultsContext,
     args: { solutionID: string }
   ) {

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -1,34 +1,28 @@
 import axios from "axios";
 import _ from "lodash";
+import { Dictionary } from "vue-router/types/router";
 import { ActionContext } from "vuex";
-import store, { DistilState } from "../store";
-import { EXCLUDE_FILTER, FilterParams } from "../../util/filters";
+import {
+  createEmptyTableData,
+  createErrorSummary,
+  createPendingSummary,
+  fetchSolutionResultSummary,
+  fetchSummaryExemplars,
+  minimumRouteKey,
+  validateArgs,
+} from "../../util/data";
+import { EXCLUDE_FILTER } from "../../util/filters";
+import { addHighlightToFilterParams } from "../../util/highlights";
 import {
   getSolutionById,
   getSolutionsBySolutionRequestIds,
 } from "../../util/solutions";
-import {
-  Variable,
-  Highlight,
-  SummaryMode,
-  DataMode,
-  VariableSummary,
-} from "../dataset/index";
-import { mutations } from "./module";
-import { ResultsState } from "./index";
-import { addHighlightToFilterParams } from "../../util/highlights";
-import {
-  fetchSolutionResultSummary,
-  createPendingSummary,
-  createErrorSummary,
-  createEmptyTableData,
-  fetchSummaryExemplars,
-  validateArgs,
-  minimumRouteKey,
-} from "../../util/data";
-import { getters as resultGetters } from "../results/module";
+import { DataMode, Highlight, SummaryMode, Variable } from "../dataset/index";
 import { getters as dataGetters } from "../dataset/module";
-import { Dictionary } from "vue-router/types/router";
+import { getters as resultGetters } from "../results/module";
+import store, { DistilState } from "../store";
+import { ResultsState } from "./index";
+import { mutations } from "./module";
 
 export type ResultsContext = ActionContext<ResultsState, DistilState>;
 
@@ -794,7 +788,7 @@ export const actions = {
       `/distil/solution-variable-rankings/${args.solutionID}`
     );
     const rankings = <Dictionary<number>>response.data;
-    mutations.setVariableRankings(store, {
+    mutations.setFeatureImportanceRanking(store, {
       solutionID: args.solutionID,
       rankings: _.pickBy(rankings, (ranking) => ranking !== null),
     });

--- a/public/store/results/getters.ts
+++ b/public/store/results/getters.ts
@@ -1,17 +1,17 @@
 import {
-  VariableSummary,
-  Extrema,
-  TableData,
-  TableRow,
-  TableColumn,
-} from "../dataset/index";
-import { ResultsState, Forecast, TimeSeries } from "./index";
-import {
-  getTableDataItems,
   getTableDataFields,
+  getTableDataItems,
   minimumRouteKey,
 } from "../../util/data";
 import { Dictionary } from "../../util/dict";
+import {
+  Extrema,
+  TableColumn,
+  TableData,
+  TableRow,
+  VariableSummary,
+} from "../dataset/index";
+import { Forecast, ResultsState, TimeSeries } from "./index";
 
 export const getters = {
   // results
@@ -155,7 +155,9 @@ export const getters = {
 
   // variable rankings
 
-  getVariableRankings(state: ResultsState): Dictionary<Dictionary<number>> {
-    return state.variableRankings;
+  getFeatureImportanceRanking(
+    state: ResultsState
+  ): Dictionary<Dictionary<number>> {
+    return state.featureImportanceRanking;
   },
 };

--- a/public/store/results/index.ts
+++ b/public/store/results/index.ts
@@ -1,9 +1,9 @@
 import { Dictionary } from "../../util/dict";
 import {
-  VariableSummary,
   Extrema,
   TableData,
   TimeSeriesValue,
+  VariableSummary,
 } from "../dataset/index";
 
 export interface TimeSeries {
@@ -40,7 +40,7 @@ export interface ResultsState {
   fittedSolutionId: string;
   produceRequestId: string;
   // variable rankings - maps {solutionID, {featureName: rank value}}
-  variableRankings: Dictionary<Dictionary<number>>;
+  featureImportanceRanking: Dictionary<Dictionary<number>>;
 }
 
 export const state: ResultsState = {
@@ -64,5 +64,5 @@ export const state: ResultsState = {
   fittedSolutionId: null,
   produceRequestId: null,
   // variable rankings
-  variableRankings: {},
+  featureImportanceRanking: {},
 };

--- a/public/store/results/module.ts
+++ b/public/store/results/module.ts
@@ -97,7 +97,9 @@ export const actions = {
   // forecast
   fetchForecastedTimeseries: dispatch(moduleActions.fetchForecastedTimeseries),
   // variable rankings
-  fetchVariableRankings: dispatch(moduleActions.fetchVariableRankings),
+  fetchFeatureImportanceRanking: dispatch(
+    moduleActions.fetchFeatureImportanceRanking
+  ),
 };
 
 // Typed mutations

--- a/public/store/results/module.ts
+++ b/public/store/results/module.ts
@@ -1,10 +1,10 @@
 import { Module } from "vuex";
-import { state, ResultsState } from "./index";
-import { getters as moduleGetters } from "./getters";
-import { actions as moduleActions } from "./actions";
-import { mutations as moduleMutations } from "./mutations";
-import { DistilState } from "../store";
 import { getStoreAccessors } from "vuex-typescript";
+import { DistilState } from "../store";
+import { actions as moduleActions } from "./actions";
+import { getters as moduleGetters } from "./getters";
+import { ResultsState, state } from "./index";
+import { mutations as moduleMutations } from "./mutations";
 
 export const resultsModule: Module<ResultsState, DistilState> = {
   getters: moduleGetters,
@@ -68,7 +68,7 @@ export const getters = {
   getPredictedTimeseries: read(moduleGetters.getPredictedTimeseries),
   getPredictedForecasts: read(moduleGetters.getPredictedForecasts),
   // rankings
-  getVariableRankings: read(moduleGetters.getVariableRankings),
+  getFeatureImportanceRanking: read(moduleGetters.getFeatureImportanceRanking),
 };
 
 // Typed actions
@@ -129,5 +129,7 @@ export const mutations = {
   updatePredictedTimeseries: commit(moduleMutations.updatePredictedTimeseries),
   updatePredictedForecast: commit(moduleMutations.updatePredictedForecast),
   // variable rankings
-  setVariableRankings: commit(moduleMutations.setVariableRankings),
+  setFeatureImportanceRanking: commit(
+    moduleMutations.setFeatureImportanceRanking
+  ),
 };

--- a/public/store/results/mutations.ts
+++ b/public/store/results/mutations.ts
@@ -1,14 +1,13 @@
 import Vue from "vue";
-import _ from "lodash";
-import { ResultsState } from "./index";
+import { Dictionary } from "vue-router/types/router";
+import { updateSummaries, updateSummariesPerVariable } from "../../util/data";
 import {
-  VariableSummary,
   Extrema,
   TableData,
   TimeSeriesValue,
+  VariableSummary,
 } from "../dataset/index";
-import { updateSummaries, updateSummariesPerVariable } from "../../util/data";
-import { Dictionary } from "vue-router/types/router";
+import { ResultsState } from "./index";
 
 export const mutations = {
   // training / target
@@ -158,10 +157,10 @@ export const mutations = {
     );
   },
 
-  setVariableRankings(
+  setFeatureImportanceRanking(
     state: ResultsState,
     args: { solutionID: string; rankings: Dictionary<number> }
   ) {
-    Vue.set(state.variableRankings, args.solutionID, args.rankings);
+    Vue.set(state.featureImportanceRanking, args.solutionID, args.rankings);
   },
 };

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -1,47 +1,47 @@
 import _ from "lodash";
-import { ViewState } from "./index";
 import { ActionContext } from "vuex";
-import store, { DistilState } from "../store";
-import { mutations as viewMutations, getters as viewGetters } from "./module";
+import {
+  filterArrayByPage,
+  NUM_PER_PAGE,
+  NUM_PER_TARGET_PAGE,
+  searchVariables,
+  sortVariablesByImportance,
+} from "../../util/data";
 import { Dictionary } from "../../util/dict";
+import { getPredictionsById } from "../../util/predictions";
+import {
+  DataMode,
+  Highlight,
+  SummaryMode,
+  TaskTypes,
+  Variable,
+} from "../dataset";
 import {
   actions as datasetActions,
   mutations as datasetMutations,
 } from "../dataset/module";
 import {
-  actions as requestActions,
-  mutations as requestMutations,
-  getters as requestGetters,
-} from "../requests/module";
-import {
-  actions as resultActions,
-  mutations as resultMutations,
-} from "../results/module";
+  actions as modelActions,
+  mutations as modelMutations,
+} from "../model/module";
 import {
   actions as predictionActions,
   mutations as predictionMutations,
 } from "../predictions/module";
 import {
-  actions as modelActions,
-  mutations as modelMutations,
-} from "../model/module";
-import { getters as routeGetters } from "../route/module";
+  actions as requestActions,
+  getters as requestGetters,
+  mutations as requestMutations,
+} from "../requests/module";
 import {
-  TaskTypes,
-  SummaryMode,
-  DataMode,
-  Variable,
-  Highlight,
-} from "../dataset";
-import { getPredictionsById } from "../../util/predictions";
-import {
-  NUM_PER_PAGE,
-  NUM_PER_TARGET_PAGE,
-  sortVariablesByImportance,
-  filterArrayByPage,
-  searchVariables,
-} from "../../util/data";
+  actions as resultActions,
+  mutations as resultMutations,
+} from "../results/module";
 import { SELECT_TARGET_ROUTE } from "../route";
+import { getters as routeGetters } from "../route/module";
+import store, { DistilState } from "../store";
+import { ViewState } from "./index";
+import { getters as viewGetters, mutations as viewMutations } from "./module";
 
 enum ParamCacheKey {
   VARIABLES = "VARIABLES",
@@ -203,7 +203,9 @@ const fetchVariableRankings = createCacheable(
 const fetchSolutionVariableRankings = createCacheable(
   ParamCacheKey.SOLUTION_VARIABLE_RANKINGS,
   (context, args) => {
-    resultActions.fetchVariableRankings(store, { solutionID: args.solutionID });
+    resultActions.fetchFeatureImportanceRanking(store, {
+      solutionID: args.solutionID,
+    });
   }
 );
 
@@ -562,7 +564,9 @@ export const actions = {
       dataMode: dataMode,
       varModes: varModes,
     });
-    resultActions.fetchVariableRankings(store, { solutionID: solutionId });
+    resultActions.fetchFeatureImportanceRanking(store, {
+      solutionID: solutionId,
+    });
 
     const task = routeGetters.getRouteTask(store);
 

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -609,6 +609,13 @@ export function getSolutionFeatureImportance(
   return null;
 }
 
+export function sortVariablesByImportance(variables: Variable[]): Variable[] {
+  variables.sort((a, b) => {
+    return getVariableImportance(b) - getVariableImportance(a);
+  });
+  return variables;
+}
+
 export function sortSummariesByImportance(
   summaries: VariableSummary[],
   variables: Variable[]

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -584,11 +584,13 @@ export function getVariableRanking(v: Variable): number {
   return v.ranking !== undefined ? v.ranking : 0;
 }
 
-export function getSolutionVariableRanking(
+export function getSolutionFeatureImportance(
   v: Variable,
   solutionID: string
 ): number {
-  const solutionRanks = resultsGetters.getVariableRankings(store)[solutionID];
+  const solutionRanks = resultsGetters.getFeatureImportanceRanking(store)[
+    solutionID
+  ];
   if (solutionRanks) {
     return solutionRanks[v.colName];
   }
@@ -626,7 +628,7 @@ export function sortSolutionSummariesByImportance(
   // create importance lookup map
   const importance: Dictionary<number> = {};
   variables.forEach((variable) => {
-    importance[variable.colName] = getSolutionVariableRanking(
+    importance[variable.colName] = getSolutionFeatureImportance(
       variable,
       solutionID
     );

--- a/public/views/Predictions.vue
+++ b/public/views/Predictions.vue
@@ -105,7 +105,6 @@ export default Vue.extend({
     trainingSummariesByImportance(): VariableSummary[] {
       return sortSolutionSummariesByImportance(
         this.trainingSummaries,
-        this.trainingVariables,
         this.solutionId
       );
     },

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -54,6 +54,7 @@ import {
   getVariableSummariesByState,
   searchVariables,
   sortSolutionSummariesByImportance,
+  filterArrayByPage,
 } from "../util/data";
 import { Feature, Activity } from "../util/userEvents";
 
@@ -118,10 +119,23 @@ export default Vue.extend({
       );
     },
     trainingSummariesByImportance(): VariableSummary[] {
-      return sortSolutionSummariesByImportance(
-        this.trainingSummaries,
+      const summaryDictionary = resultGetters.getTrainingSummariesDictionary(
+        this.$store
+      );
+      const trainingSummaries = getVariableSummariesByState(
+        this.resultTrainingVarsPage,
+        this.trainingVariables.length,
         this.trainingVariables,
-        this.solutionId
+        summaryDictionary
+      );
+      return filterArrayByPage(
+        this.resultTrainingVarsPage,
+        this.rowsPerPage,
+        sortSolutionSummariesByImportance(
+          trainingSummaries,
+          this.trainingVariables,
+          this.solutionId
+        )
       );
     },
     solutionId(): string {

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -131,11 +131,7 @@ export default Vue.extend({
       return filterArrayByPage(
         this.resultTrainingVarsPage,
         this.rowsPerPage,
-        sortSolutionSummariesByImportance(
-          trainingSummaries,
-          this.trainingVariables,
-          this.solutionId
-        )
+        sortSolutionSummariesByImportance(trainingSummaries, this.solutionId)
       );
     },
     solutionId(): string {


### PR DESCRIPTION
Clean up surrounding the ranking code.
There is three rankings PCA, MI, and FI.
Moved the rankings from the variable and into a map.
Changed a lot of the helper functions in data.ts to reflect the above.
Fixed a bug where we would fetch FI too early and we would never display FI. 
Added Ranking fix in result.
closes #1751 