### PR TITLE
Update variable.go

### DIFF
--- a/api/model/storage/elastic/variable.go
+++ b/api/model/storage/elastic/variable.go
@@ -47,7 +47,7 @@ func (s *Storage) parseRawVariable(child map[string]interface{}) (*model.Variabl
 	if !ok {
 		description = ""
 	}
-	importance, ok := json.Int(child, model.VarImportanceField)
+	importance, ok := json.Float(child, model.VarImportanceField)
 	if !ok {
 		importance = 0
 	}

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20200924154433-5b93533570f9
+	github.com/uncharted-distil/distil-compute v0.0.0-20200929184457-3c6f1818fb91
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/uncharted-distil/distil-compute v0.0.0-20200924154433-5b93533570f9 h1:pLQ2Isx3prNt+/XcEKO8mWFmwIgVvjAVYNJ4FC4GeDc=
 github.com/uncharted-distil/distil-compute v0.0.0-20200924154433-5b93533570f9/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
+github.com/uncharted-distil/distil-compute v0.0.0-20200929184457-3c6f1818fb91 h1:+iPreUC+F3m5prpbk/BvVRb0Hx3802EQLfm8Ve4aP6o=
+github.com/uncharted-distil/distil-compute v0.0.0-20200929184457-3c6f1818fb91/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=


### PR DESCRIPTION
changed importance from int parse to float. This change is contingent on the changes from the distil-compute repo.
contingent on ->https://github.com/uncharted-distil/distil-compute/pull/145
closes #1933 