### PR TITLE
#1879 - Model Explanation Badge

### DIFF
--- a/api/model/variable_summary.go
+++ b/api/model/variable_summary.go
@@ -62,6 +62,7 @@ type VariableSummary struct {
 	Timeline         *Histogram `json:"timeline"`
 	TimelineBaseline *Histogram `json:"timelineBaseline"`
 	TimelineType     string     `json:"timelineType"`
+	Weighted         bool       `json:"weighted"`
 }
 
 // SummaryMode defines the summary display modes.

--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -332,7 +332,7 @@ export default Vue.extend({
 
     hasExplanations(): boolean {
       // waiting for explanation enum to be added to results summaries
-      return false;
+      return this.predictedSummary?.weighted;
     },
   },
 

--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -332,7 +332,7 @@ export default Vue.extend({
 
     hasExplanations(): boolean {
       // waiting for explanation enum to be added to results summaries
-      return this.predictedSummary?.weighted;
+      return !!this.predictedSummary?.weighted;
     },
   },
 

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -157,6 +157,7 @@ export interface VariableSummary {
   timelineType?: string;
   selected?: Histogram;
   err?: string;
+  weighted?: boolean;
   pending?: boolean;
 }
 


### PR DESCRIPTION
Closes #1879  - Added boolean weighted field to the return for predicted summaries with helper SQL query that checks if we return even one weighted row back, then read that field off to set hasExplanations computed in the result group component, with updates to the variable summary inferfaces in go and typescript to support the weighted field.