### PR TITLE
Image mosaic changes

### DIFF
--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"path"
 
+	"github.com/disintegration/imaging"
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
@@ -48,12 +49,13 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor) func(http.ResponseWrite
 		sourcePath := env.ResolvePath(res.Source, res.Folder)
 		sourcePath = path.Join(sourcePath, imageFolder)
 
-		image, err := util.ImageFromCombination(sourcePath, imageID, util.BandCombinationID(bandCombo))
+		img, err := util.ImageFromCombination(sourcePath, imageID, util.BandCombinationID(bandCombo))
 		if err != nil {
 			handleError(w, err)
 			return
 		}
-		imageBytes, err := util.ImageToJPEG(image)
+		thumbnailImg := imaging.Resize(img, 125, 0, imaging.Lanczos)
+		imageBytes, err := util.ImageToJPEG(thumbnailImg)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -16,14 +16,14 @@
 package routes
 
 import (
-	"strconv"
-	"net/http"
-	"path"
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/util"
 	"goji.io/v3/pat"
+	"net/http"
+	"path"
+	"strconv"
 )
 
 // MultiBandImageHandler fetches individual band images and combines them into a single RGB image using the supplied mapping.
@@ -34,7 +34,7 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor) func(http.ResponseWrite
 		bandCombo := pat.Param(r, "band-combination")
 		isThumbnail, err := strconv.ParseBool(pat.Param(r, "is-thumbnail"))
 		//assuming square
-		thumbnailDimension:=125
+		thumbnailDimension := 125
 		imageScale := util.ImageScale{}
 		if err != nil {
 			handleError(w, err)
@@ -54,8 +54,8 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor) func(http.ResponseWrite
 		}
 		sourcePath := env.ResolvePath(res.Source, res.Folder)
 		sourcePath = path.Join(sourcePath, imageFolder)
-		if isThumbnail{
-			imageScale = util.ImageScale{Width:thumbnailDimension, Height:thumbnailDimension}
+		if isThumbnail {
+			imageScale = util.ImageScale{Width: thumbnailDimension, Height: thumbnailDimension}
 		}
 		img, err := util.ImageFromCombination(sourcePath, imageID, util.BandCombinationID(bandCombo), imageScale)
 		if err != nil {

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -25,7 +25,10 @@ import (
 	"path"
 	"strconv"
 )
-
+const (
+	// ThumbnailDimensions is hard coded thumbnail dimension -- could be refactored to be default if we want client to dictate size.
+	ThumbnailDimensions = 125
+)
 // MultiBandImageHandler fetches individual band images and combines them into a single RGB image using the supplied mapping.
 func MultiBandImageHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -33,8 +36,6 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor) func(http.ResponseWrite
 		imageID := pat.Param(r, "image-id")
 		bandCombo := pat.Param(r, "band-combination")
 		isThumbnail, err := strconv.ParseBool(pat.Param(r, "is-thumbnail"))
-		//assuming square
-		thumbnailDimension := 125
 		imageScale := util.ImageScale{}
 		if err != nil {
 			handleError(w, err)
@@ -55,7 +56,7 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor) func(http.ResponseWrite
 		sourcePath := env.ResolvePath(res.Source, res.Folder)
 		sourcePath = path.Join(sourcePath, imageFolder)
 		if isThumbnail {
-			imageScale = util.ImageScale{Width: thumbnailDimension, Height: thumbnailDimension}
+			imageScale = util.ImageScale{Width: ThumbnailDimensions, Height: ThumbnailDimensions}
 		}
 		img, err := util.ImageFromCombination(sourcePath, imageID, util.BandCombinationID(bandCombo), imageScale)
 		if err != nil {

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -200,7 +200,7 @@ func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) floa
 		maxXSize = imageScale.Width
 		maxYSize = imageScale.Height
 		width, height := getMaxDimensions(&bandImages)
-		aspectRatio := float64(height)/float64(width)
+		aspectRatio := float64(height) / float64(width)
 		maxYSize = int(float64(maxXSize) * aspectRatio)
 	} else {
 		maxXSize, maxYSize = getMaxDimensions(&bandImages)
@@ -221,10 +221,11 @@ func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) floa
 	}
 	return createRGBAFromRamp(maxXSize, maxYSize, bandImages, transform, ramp), nil
 }
+
 // getMaxDimensions return max from array. Return order width, height
-func getMaxDimensions(bandImages *[]*image.Gray16) (int,int) {
-	width:=0
-	height:=0
+func getMaxDimensions(bandImages *[]*image.Gray16) (int, int) {
+	width := 0
+	height := 0
 	for _, bandImage := range *bandImages {
 		// extract input raster size and update max x,y
 		xSize := bandImage.Bounds().Dx()
@@ -236,7 +237,7 @@ func getMaxDimensions(bandImages *[]*image.Gray16) (int,int) {
 			height = ySize
 		}
 	}
-return width, height
+	return width, height
 }
 
 func loadAsGray16(filePath string) (*image.Gray16, error) {

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -390,7 +390,7 @@ func SavePNGImage(image *image.RGBA, filename string) error {
 
 // ImageToJPEG encodes an RGBA image as a JPEG byte array for further processing or
 // network transmission.
-func ImageToJPEG(image image.Image) ([]byte, error) {
+func ImageToJPEG(image *image.RGBA) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	if err := jpeg.Encode(buf, image, nil); err != nil {
 		return nil, errors.Wrap(err, "failed so encode png file")

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -366,7 +366,7 @@ func SavePNGImage(image *image.RGBA, filename string) error {
 
 // ImageToJPEG encodes an RGBA image as a JPEG byte array for further processing or
 // network transmission.
-func ImageToJPEG(image *image.RGBA) ([]byte, error) {
+func ImageToJPEG(image image.Image) ([]byte, error) {
 	buf := new(bytes.Buffer)
 	if err := jpeg.Encode(buf, image, nil); err != nil {
 		return nil, errors.Wrap(err, "failed so encode png file")

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -18,6 +18,11 @@ package util
 import (
 	"bytes"
 	"fmt"
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/nfnt/resize"
+	"github.com/pkg/errors"
+	"github.com/uncharted-distil/gdal"
+	log "github.com/unchartedsoftware/plog"
 	"image"
 	"image/jpeg"
 	"image/png"
@@ -26,12 +31,6 @@ import (
 	"os"
 	"path"
 	"strings"
-
-	lru "github.com/hashicorp/golang-lru"
-	"github.com/nfnt/resize"
-	"github.com/pkg/errors"
-	"github.com/uncharted-distil/gdal"
-	log "github.com/unchartedsoftware/plog"
 )
 
 const (
@@ -95,6 +94,16 @@ type BandCombination struct {
 	Transform   func(...uint16) float64
 }
 
+// ImageScale defines what to scale the image size to. If one property is defined aspect ratio will be kept. If nil for both the func will determine the size.
+type ImageScale struct {
+	Width  int
+	Height int
+}
+
+func (imageScale *ImageScale) shouldScale() bool {
+	return imageScale.Width != 0 && imageScale.Height != 0
+}
+
 // ClampedNormalizingTransform transforms to a range of (-1, 1) and then clamps to (0, 1)
 func ClampedNormalizingTransform(bandValues ...uint16) float64 {
 	return math.Max(0, float64(int32(bandValues[0])-int32(bandValues[1]))/float64(int32(bandValues[0])+int32(bandValues[1])))
@@ -141,7 +150,7 @@ func init() {
 
 // ImageFromCombination takes a base datsaet directory, fileID and a band combination label and
 // returns a composed image.  NOTE: Currently a bit hardcoded for sentinel-2 data.
-func ImageFromCombination(datasetDir string, fileID string, bandCombination BandCombinationID) (*image.RGBA, error) {
+func ImageFromCombination(datasetDir string, fileID string, bandCombination BandCombinationID, imageScale ImageScale) (*image.RGBA, error) {
 	// attempt to get the folder file type for the supplied dataset dir from the cache, if
 	// not do the look up
 	var fileType string
@@ -164,7 +173,7 @@ func ImageFromCombination(datasetDir string, fileID string, bandCombination Band
 			filePath := getFilePath(datasetDir, fileID, bandLabel, fileType)
 			filePaths = append(filePaths, filePath)
 		}
-		return ImageFromBands(filePaths, bandCombo.Ramp, bandCombo.Transform)
+		return ImageFromBands(filePaths, bandCombo.Ramp, bandCombo.Transform, imageScale)
 	}
 
 	return nil, errors.Errorf("unhandled band combination %s", bandCombination)
@@ -174,12 +183,11 @@ func ImageFromCombination(datasetDir string, fileID string, bandCombination Band
 // where the file names map to R,G,B in order.  The results are returned as a JPEG
 // encoded byte stream. If errors are encountered processing a band an attempt will
 // be made to create the image from the remaining bands, while logging an error.
-func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) float64) (*image.RGBA, error) {
+func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) float64, imageScale ImageScale) (*image.RGBA, error) {
 	bandImages := []*image.Gray16{}
 	maxXSize := 0
 	maxYSize := 0
 
-	// Load each of the datasets as a Gray16 image
 	for _, filePath := range paths {
 		bandImage, err := loadAsGray16(filePath)
 		bandImages = append(bandImages, bandImage)
@@ -187,21 +195,19 @@ func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) floa
 			log.Error(err, "band file not loaded")
 			continue
 		}
-
-		// extract input raster size and update max x,y
-		xSize := bandImage.Bounds().Dx()
-		ySize := bandImage.Bounds().Dy()
-		if xSize > maxXSize {
-			maxXSize = xSize
-		}
-		if ySize > maxYSize {
-			maxYSize = ySize
-		}
 	}
-
+	if imageScale.shouldScale() {
+		maxXSize = imageScale.Width
+		maxYSize = imageScale.Height
+		width, height := getMaxDimensions(&bandImages)
+		aspectRatio := float64(height)/float64(width)
+		maxYSize = int(float64(maxXSize) * aspectRatio)
+	} else {
+		maxXSize, maxYSize = getMaxDimensions(&bandImages)
+	}
 	// Resize any images that are below the max size
 	for i, bandImage := range bandImages {
-		if bandImage != nil && (bandImage.Bounds().Dx() < maxXSize || bandImage.Bounds().Dy() < maxYSize) {
+		if bandImage != nil && (imageScale.shouldScale() || bandImage.Bounds().Dx() < maxXSize || bandImage.Bounds().Dy() < maxYSize) {
 			// no need to check type assertion - guaranteed to be what as passed in by api
 			bandImages[i] = resize.Resize(uint(maxXSize), uint(maxYSize), bandImage, resize.NearestNeighbor).(*image.Gray16)
 		}
@@ -214,6 +220,23 @@ func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) floa
 		return createRGBAFromBands(maxXSize, maxYSize, bandImages), nil
 	}
 	return createRGBAFromRamp(maxXSize, maxYSize, bandImages, transform, ramp), nil
+}
+// getMaxDimensions return max from array. Return order width, height
+func getMaxDimensions(bandImages *[]*image.Gray16) (int,int) {
+	width:=0
+	height:=0
+	for _, bandImage := range *bandImages {
+		// extract input raster size and update max x,y
+		xSize := bandImage.Bounds().Dx()
+		ySize := bandImage.Bounds().Dy()
+		if xSize > width {
+			width = xSize
+		}
+		if ySize > height {
+			height = ySize
+		}
+	}
+return width, height
 }
 
 func loadAsGray16(filePath string) (*image.Gray16, error) {

--- a/api/util/imagery_test.go
+++ b/api/util/imagery_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestImageFromCombination(t *testing.T) {
-	composedImage, err := ImageFromCombination("test/bigearthnet", "S2A_MSIL2A_20171121T112351_79_21", NaturalColors)
+	composedImage, err := ImageFromCombination("test/bigearthnet", "S2A_MSIL2A_20171121T112351_79_21", NaturalColors, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -43,7 +43,7 @@ func TestImageFromBandsTrueColor(t *testing.T) {
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B03.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B02.tif",
-	}, nil, nil)
+	}, nil, nil, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -63,7 +63,7 @@ func TestImageFromBandsResize(t *testing.T) {
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil)
+	}, nil, nil,ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -82,7 +82,7 @@ func TestImageFromRamp(t *testing.T) {
 	composedImage, err := ImageFromBands([]string{
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B11.tif",
-	}, BlueYellowBrownRamp, NormalizingTransform)
+	}, BlueYellowBrownRamp, NormalizingTransform, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -101,7 +101,7 @@ func TestImageFromRampClamped(t *testing.T) {
 	composedImage, err := ImageFromBands([]string{
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, RedYellowGreenRamp, ClampedNormalizingTransform)
+	}, RedYellowGreenRamp, ClampedNormalizingTransform, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -121,7 +121,7 @@ func TestImageFromBandsMissing(t *testing.T) {
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B120.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil)
+	}, nil, nil, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)

--- a/api/util/imagery_test.go
+++ b/api/util/imagery_test.go
@@ -118,7 +118,7 @@ func TestImageFromBandsMissing(t *testing.T) {
 	// Tests handling the case where one of the bands contains bad data.  The missing
 	// band will be mapped to grey.
 	composedImage, err := ImageFromBands([]string{
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B120.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 	}, nil, nil, ImageScale{})
@@ -127,7 +127,7 @@ func TestImageFromBandsMissing(t *testing.T) {
 	assert.True(t, len(composedImage.Pix) > 0)
 
 	// compare to gold standard image
-	testImage, err := LoadPNGImage("test/120_8_4.png")
+	testImage, err := LoadPNGImage("test/12_8_4.png")
 	if err != nil {
 		log.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/davecgh/go-spew v1.1.1
+	github.com/disintegration/imaging v1.6.2
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/websocket v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
+github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -227,6 +229,8 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
+golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/main.go
+++ b/main.go
@@ -257,7 +257,7 @@ func main() {
 	registerRoute(mux, "/distil/export/:solution-id", routes.ExportHandler(solutionClient, config.D3MOutputDir, discoveryLogger))
 	registerRoute(mux, "/distil/config", routes.ConfigHandler(config, version, timestamp, problemPath, datasetDocPath, ta2Version))
 	registerRoute(mux, "/distil/task/:dataset/:target/:variables", routes.TaskHandler(pgDataStorageCtor, esMetadataStorageCtor))
-	registerRoute(mux, "/distil/multiband-image/:dataset/:image-id/:band-combination", routes.MultiBandImageHandler(esMetadataStorageCtor))
+	registerRoute(mux, "/distil/multiband-image/:dataset/:image-id/:band-combination/:is-thumbnail", routes.MultiBandImageHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/distil/multiband-combinations/:dataset", routes.MultiBandCombinationsHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/distil/load/:solution-id/:fitted", routes.LoadHandler(esExportedModelStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/distil/solution-variable-rankings/:solution-id", routes.SolutionVariableRankingHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))

--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -24,7 +24,7 @@
 <script lang="ts">
 import Vue from "vue";
 import ImageLabel from "./ImageLabel";
-import { BandCombination, TableColumn, TableRow } from "../store/dataset/index";
+import { TableColumn, TableRow } from "../store/dataset/index";
 import {
   getters as datasetGetters,
   actions as datasetActions,
@@ -136,6 +136,7 @@ export default Vue.extend({
           dataset: this.dataset,
           imageId: imageId(this.imageUrl),
           bandCombination: this.band,
+          isThumbnail: false,
         });
       } else {
         await datasetActions.fetchImage(this.$store, {

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -231,6 +231,7 @@ export default Vue.extend({
           dataset: this.dataset,
           imageId: this.imageId,
           bandCombination: routeGetters.getBandCombinationId(this.$store),
+          isThumbnail: true,
         });
         if (this.isVisible) {
           this.injectImage();

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1074,7 +1074,7 @@ export const actions = {
 
     try {
       const response = await loadImage(
-        `distil/multiband-image/${args.dataset}/${args.imageId}/${args.bandCombination}`
+        `distil/multiband-image/${args.dataset}/${args.imageId}/${args.bandCombination}/true`
       );
       mutations.updateFile(context, { url: args.imageId, file: response });
     } catch (error) {

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -980,6 +980,7 @@ export const actions = {
             dataset: args.dataset,
             imageId: url,
             bandCombination: BandID.NATURAL_COLORS,
+            isThumbnail: true,
           });
         }
         if (type === "graph") {
@@ -1066,6 +1067,7 @@ export const actions = {
       dataset: string;
       imageId: string;
       bandCombination: string;
+      isThumbnail: boolean;
     }
   ) {
     if (!validateArgs(args, ["dataset", "imageId", "bandCombination"])) {
@@ -1074,7 +1076,7 @@ export const actions = {
 
     try {
       const response = await loadImage(
-        `distil/multiband-image/${args.dataset}/${args.imageId}/${args.bandCombination}/true`
+        `distil/multiband-image/${args.dataset}/${args.imageId}/${args.bandCombination}/${args.isThumbnail}`
       );
       mutations.updateFile(context, { url: args.imageId, file: response });
     } catch (error) {


### PR DESCRIPTION
Adds thumbnail generation to the multi-band image api call.
Adds client store support for fetching thumbnail vs full resolution multi-band images.
TODO mosaic rework to not keep images in client memory if they are not visible.
