### PR TITLE
#1883 "<None>" Exclude Fix

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -171,7 +171,11 @@ func (s *Storage) buildIncludeFilter(dataset string, wheres []string, params []i
 		offset := len(params) + 1
 		for i, category := range filter.Categories {
 			categories = append(categories, fmt.Sprintf("$%d", offset+i))
-			params = append(params, category)
+			if category != "<none>" {
+				params = append(params, category)
+			} else {
+				params = append(params, "")
+			}
 		}
 		where := fmt.Sprintf("%s IN (%s)", name, strings.Join(categories, ", "))
 		wheres = append(wheres, where)

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -25,10 +25,12 @@ import (
 	"path"
 	"strconv"
 )
+
 const (
 	// ThumbnailDimensions is hard coded thumbnail dimension -- could be refactored to be default if we want client to dictate size.
 	ThumbnailDimensions = 125
 )
+
 // MultiBandImageHandler fetches individual band images and combines them into a single RGB image using the supplied mapping.
 func MultiBandImageHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/api/util/imagery_test.go
+++ b/api/util/imagery_test.go
@@ -63,7 +63,7 @@ func TestImageFromBandsResize(t *testing.T) {
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil,ImageScale{})
+	}, nil, nil, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)


### PR DESCRIPTION
Closes #1883 - Besides formatting clean up, added a simple catch to handle the specific "<none>" case of a filter, which is a result of filling that blank in server side in the API return in the first place. There's a possibility that someone names something "<none>" in a dataset that'll break this, but for now this should be sufficient.