### PR TITLE
Added route watcher to selectTraining view for cluster persistence. C…

### DIFF
--- a/public/App.vue
+++ b/public/App.vue
@@ -12,10 +12,7 @@ import VueObserveVisibility from "vue-observe-visibility";
 import BootstrapVue from "bootstrap-vue";
 import NavBar from "./components/NavBar.vue";
 import store from "./store/store";
-import {
-  getters as appGetters,
-  actions as appActions,
-} from "./store/app/module";
+import { actions as appActions } from "./store/app/module";
 import router from "./router/router";
 
 import "font-awesome/css/font-awesome.css";
@@ -25,7 +22,6 @@ import "./styles/main.css";
 
 // DEBUG: this is a mocked graph until we support actual graph data
 import "./assets/graphs/G1.gml";
-import { TaskTypes } from "./store/dataset";
 
 Vue.use(BootstrapVue);
 Vue.use(VueObserveVisibility);

--- a/public/components/StatusSidebar.vue
+++ b/public/components/StatusSidebar.vue
@@ -33,7 +33,7 @@
       <div class="status-icon-wrapper" @click="onStatusIconClick(2)">
         <i class="status-icon fa fa-2x fa-share-alt" aria-hidden="true"></i>
         <i
-          v-if="isNew(clusterStatus)"
+          v-if="isNew(clusterStatus) && !isClustered"
           class="new-update-notification fa fa-circle"
         ></i>
         <i
@@ -83,6 +83,7 @@ import {
   JoinSuggestionPendingRequest,
   JoinDatasetImportPendingRequest,
   ClusteringPendingRequest,
+  DataMode,
 } from "../store/dataset/index";
 import { Feature, Activity } from "../util/userEvents";
 import { Dictionary } from "vue-router/types/router";
@@ -108,7 +109,9 @@ export default Vue.extend({
         .filter((update) => update.dataset === this.dataset);
       return updates;
     },
-
+    isClustered(): boolean {
+      return routeGetters.getDataMode(this.$store) === DataMode.Cluster;
+    },
     variableRankingRequestData(): VariableRankingPendingRequest {
       return <VariableRankingPendingRequest>(
         this.pendingRequests.find(

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -829,23 +829,25 @@ export const actions = {
     if (!validateArgs(args, ["dataset", "variable"])) {
       return null;
     }
-
     const filterParams = addHighlightToFilterParams(
       args.filterParams,
       args.highlight
     );
+    const decodedVarModes = routeGetters.getDecodedVarModes(store);
     const mutator = args.include
       ? mutations.updateIncludedVariableSummaries
       : mutations.updateExcludedVariableSummaries;
-
-    const dataModeDefault = args.dataMode ? args.dataMode : DataMode.Default;
+    const varMode = decodedVarModes.get(args.variable)
+      ? decodedVarModes.get(args.variable)
+      : args.mode;
+    const dataModeDefault = routeGetters.getDataMode(store);
     filterParams.dataMode = dataModeDefault;
 
     try {
       const response = await axios.post(
         `/distil/variable-summary/${args.dataset}/${
           args.variable
-        }/${!args.include}/${args.mode}`,
+        }/${!args.include}/${varMode}`,
         filterParams
       );
       const summary = response.data.summary;

--- a/public/views/SelectTraining.vue
+++ b/public/views/SelectTraining.vue
@@ -57,12 +57,11 @@ import AvailableTrainingVariables from "../components/AvailableTrainingVariables
 import TrainingVariables from "../components/TrainingVariables";
 import TargetVariable from "../components/TargetVariable";
 import TypeChangeMenu from "../components/TypeChangeMenu";
-import { overlayRouteEntry } from "../util/routes";
 import { actions as viewActions } from "../store/view/module";
 import { getters as routeGetters } from "../store/route/module";
-import { getters as datasetGetters } from "../store/dataset/module";
-import { Variable } from "../store/dataset/index";
-
+import { DataMode } from "../store/dataset";
+import { overlayRouteEntry } from "../util/routes";
+import { Route } from "vue-router";
 export default Vue.extend({
   name: "select-training-view",
   components: {
@@ -162,6 +161,19 @@ export default Vue.extend({
     },
     ranking() {
       viewActions.updateSelectTrainingData(this.$store);
+    },
+    $route(to: Route, from: Route) {
+      const dataModeOld = from.query.dataMode as string;
+      if (
+        routeGetters.getDataMode(this.$store) === DataMode.Cluster &&
+        dataModeOld !== DataMode.Cluster
+      ) {
+        const clusterEntry = overlayRouteEntry(this.$route, {
+          clustering: "1",
+        });
+        viewActions.updateSelectTrainingData(this.$store);
+        this.$router.push(clusterEntry);
+      }
     },
   },
   beforeMount() {


### PR DESCRIPTION
-Removed some unused imports from App.vue.
-Added route watch in SelectTraining view. (Used to update variables if clustering was added through browser navigation)
-Updated FetchVariableSummary to prioritize URL params over given function params if available.
-Added check to SideBar to only present red dot if data has not been clustered.
closes #1958