### PR TITLE
Ingest Remove Copies

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -484,8 +484,7 @@ func persistOriginalData(params *persistedDataParams) (string, string, error) {
 	mainDR := meta.GetMainDataResource()
 
 	// split the source data into train & test
-
-	dataPath := path.Join(params.SourceDataFolder, mainDR.ResPath)
+	dataPath := model.GetResourcePath(schemaFilename, mainDR)
 	trainDataFile := path.Join(trainFolder, mainDR.ResPath)
 	testDataFile := path.Join(testFolder, mainDR.ResPath)
 

--- a/api/dataset/media.go
+++ b/api/dataset/media.go
@@ -102,7 +102,7 @@ func (m *Media) CreateDataset(rootDataPath string, datasetName string, config *e
 		datasetName = m.Dataset
 	}
 	outputDatasetPath := rootDataPath
-	dataFilePath := path.Join(compute.D3MDataFolder, compute.D3MLearningData)
+	dataFilePath := path.Join(outputDatasetPath, compute.D3MDataFolder, compute.D3MLearningData)
 
 	labelFolders, err := getLabelFolders(m.ExtractedFilePath)
 	if err != nil {

--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -147,7 +147,7 @@ func (s *Satellite) CreateDataset(rootDataPath string, datasetName string, confi
 		datasetName = s.Dataset
 	}
 	outputDatasetPath := rootDataPath
-	dataFilePath := path.Join(compute.D3MDataFolder, compute.D3MLearningData)
+	dataFilePath := path.Join(outputDatasetPath, compute.D3MDataFolder, compute.D3MLearningData)
 
 	imageFolders, err := getLabelFolders(s.ExtractedFilePath)
 	if err != nil {

--- a/api/dataset/table.go
+++ b/api/dataset/table.go
@@ -54,7 +54,7 @@ func (t *Table) CreateDataset(rootDataPath string, datasetName string, config *e
 	if datasetName == "" {
 		datasetName = t.Dataset
 	}
-	dataFilePath := path.Join(compute.D3MDataFolder, compute.D3MLearningData)
+	dataFilePath := path.Join(rootDataPath, compute.D3MDataFolder, compute.D3MLearningData)
 
 	// create the raw dataset schema doc
 	datasetID := model.NormalizeDatasetID(datasetName)

--- a/api/serialization/csv.go
+++ b/api/serialization/csv.go
@@ -125,7 +125,7 @@ func (d *CSV) WriteMetadata(uri string, meta *model.Metadata, extended bool, upd
 	mainDR := meta.GetMainDataResource()
 	if mainDR.ResFormat[compute.D3MResourceFormat] == nil {
 		if !update {
-			return errors.Errorf("main data resource not set to parquet format")
+			return errors.Errorf("main data resource not set to csv format")
 		}
 		mainDR.ResFormat = map[string][]string{compute.D3MResourceFormat: {"csv"}}
 		mainDR.ResPath = fmt.Sprintf("%s.csv", strings.TrimSuffix(mainDR.ResPath, path.Ext(mainDR.ResPath)))

--- a/api/task/cleaning.go
+++ b/api/task/cleaning.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/metadata"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 
 	"github.com/uncharted-distil/distil/api/serialization"
@@ -29,7 +30,7 @@ import (
 // Clean will clean bad data for further processing.
 func Clean(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
 	// copy the data to a new directory
-	outputPath := createDatasetPaths(schemaFile, dataset, config.CleanOutputSchemaRelative, config.CleanOutputDataRelative)
+	outputPath := createDatasetPaths(schemaFile, dataset, compute.D3MLearningData)
 
 	// load metadata from original schema
 	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)

--- a/api/task/cleaning.go
+++ b/api/task/cleaning.go
@@ -29,10 +29,7 @@ import (
 // Clean will clean bad data for further processing.
 func Clean(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
 	// copy the data to a new directory
-	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.CleanOutputSchemaRelative, config.CleanOutputDataRelative)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to copy source data folder")
-	}
+	outputPath := createDatasetPaths(schemaFile, dataset, config.CleanOutputSchemaRelative, config.CleanOutputDataRelative)
 
 	// load metadata from original schema
 	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)

--- a/api/task/cleaning.go
+++ b/api/task/cleaning.go
@@ -74,9 +74,7 @@ func Clean(schemaFile string, dataset string, config *IngestTaskConfig) (string,
 	if err != nil {
 		return "", errors.Wrap(err, "error writing clustered output")
 	}
-
-	relativePath := getRelativePath(path.Dir(outputPath.outputSchema), outputPath.outputData)
-	mainDR.ResPath = relativePath
+	mainDR.ResPath = path.Dir(outputPath.outputData)
 
 	// write the new schema to file
 	err = datasetStorage.WriteMetadata(outputPath.outputSchema, meta, true, false)

--- a/api/task/cleaning.go
+++ b/api/task/cleaning.go
@@ -16,8 +16,6 @@
 package task
 
 import (
-	"path"
-
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
@@ -29,7 +27,6 @@ import (
 
 // Clean will clean bad data for further processing.
 func Clean(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
-	// copy the data to a new directory
 	outputPath := createDatasetPaths(schemaFile, dataset, compute.D3MLearningData)
 
 	// load metadata from original schema
@@ -74,7 +71,7 @@ func Clean(schemaFile string, dataset string, config *IngestTaskConfig) (string,
 	if err != nil {
 		return "", errors.Wrap(err, "error writing clustered output")
 	}
-	mainDR.ResPath = path.Dir(outputPath.outputData)
+	mainDR.ResPath = outputPath.outputData
 
 	// write the new schema to file
 	err = datasetStorage.WriteMetadata(outputPath.outputSchema, meta, true, false)

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -94,9 +94,7 @@ func ClusterDataset(schemaFile string, dataset string, config *IngestTaskConfig)
 	if err != nil {
 		return "", errors.Wrap(err, "error writing clustered output")
 	}
-
-	relativePath := getRelativePath(path.Dir(outputPath.outputSchema), outputPath.outputData)
-	mainDR.ResPath = relativePath
+	mainDR.ResPath = path.Dir(outputPath.outputData)
 
 	// write the new schema to file
 	err = datasetStorage.WriteMetadata(outputPath.outputSchema, meta, true, false)

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -45,10 +45,7 @@ type ClusterPoint struct {
 
 // ClusterDataset will cluster the dataset fields using a primitive.
 func ClusterDataset(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
-	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.ClusteringOutputSchemaRelative, config.ClusteringOutputDataRelative)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to copy source data folder")
-	}
+	outputPath := createDatasetPaths(schemaFile, dataset, config.ClusteringOutputSchemaRelative, config.ClusteringOutputDataRelative)
 
 	// load metadata from original schema
 	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -45,7 +45,7 @@ type ClusterPoint struct {
 
 // ClusterDataset will cluster the dataset fields using a primitive.
 func ClusterDataset(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
-	outputPath := createDatasetPaths(schemaFile, dataset, config.ClusteringOutputSchemaRelative, config.ClusteringOutputDataRelative)
+	outputPath := createDatasetPaths(schemaFile, dataset, compute.D3MLearningData)
 
 	// load metadata from original schema
 	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -107,11 +107,7 @@ func CreateDataset(dataset string, datasetCtor DatasetConstructor, outputPath st
 
 	// copy to the original output location for consistency
 	if formattedPath != outputDatasetPath {
-		err = os.RemoveAll(outputDatasetPath)
-		if err != nil {
-			return "", "", err
-		}
-
+		// copy the data file and the metadata doc
 		err = util.Copy(formattedPath, path.Dir(schemaPath))
 		if err != nil {
 			return "", "", err

--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -88,6 +88,7 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 	mainDR := meta.GetMainDataResource()
 
 	// keep only the fields in the output (including the new fields as floats)
+	schemaOutputPath := path.Join(featurizedOutputPath, compute.D3MDataSchema)
 	vars := []*model.Variable{}
 	metadataVariables := map[string]*model.Variable{}
 	for _, v := range mainDR.Variables {
@@ -106,8 +107,8 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 		vars = append(vars, v)
 	}
 	mainDR.Variables = vars
+	mainDR.ResPath = dataOutputPath
 
-	schemaOutputPath := path.Join(featurizedOutputPath, compute.D3MDataSchema)
 	err = featurizedDataWriter.WriteMetadata(schemaOutputPath, meta, true, true)
 	if err != nil {
 		return "", "", err

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
 
 	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
@@ -36,7 +37,7 @@ func Format(schemaFile string, dataset string, config *IngestTaskConfig) (string
 	dr := getMainDataResource(meta)
 
 	// copy the data to a new directory
-	outputPath := createDatasetPaths(schemaFile, dataset, config.FormatOutputSchemaRelative, config.FormatOutputDataRelative)
+	outputPath := createDatasetPaths(schemaFile, dataset, compute.D3MLearningData)
 
 	// read the raw data
 	dataPath := path.Join(path.Dir(schemaFile), dr.ResPath)

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -40,7 +40,7 @@ func Format(schemaFile string, dataset string, config *IngestTaskConfig) (string
 	outputPath := createDatasetPaths(schemaFile, dataset, compute.D3MLearningData)
 
 	// read the raw data
-	dataPath := path.Join(path.Dir(schemaFile), dr.ResPath)
+	dataPath := getDataPath(schemaFile, dr)
 	lines, err := util.ReadCSVFile(dataPath, config.HasHeader)
 	if err != nil {
 		return "", errors.Wrap(err, "error reading raw data")
@@ -129,4 +129,15 @@ func getMainDataResource(meta *model.Metadata) *model.DataResource {
 	}
 
 	return dr
+}
+
+func getDataPath(schemaFile string, dataResource *model.DataResource) string {
+	drPath := dataResource.ResPath
+
+	// path can be relative to schema file
+	if len(drPath) > 0 && drPath[0] != '/' {
+		drPath = path.Join(path.Dir(schemaFile), drPath)
+	}
+
+	return drPath
 }

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -80,9 +80,7 @@ func outputDataset(paths *datasetCopyPath, meta *model.Metadata, lines [][]strin
 	if err != nil {
 		return errors.Wrap(err, "error writing output")
 	}
-
-	relativePath := getRelativePath(path.Dir(paths.outputSchema), paths.outputData)
-	dr.ResPath = relativePath
+	dr.ResPath = path.Dir(paths.outputData)
 	dr.ResType = model.ResTypeTable
 
 	// write the new schema to file

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -36,10 +36,7 @@ func Format(schemaFile string, dataset string, config *IngestTaskConfig) (string
 	dr := getMainDataResource(meta)
 
 	// copy the data to a new directory
-	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.FormatOutputSchemaRelative, config.FormatOutputDataRelative)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to copy source data folder")
-	}
+	outputPath := createDatasetPaths(schemaFile, dataset, config.FormatOutputSchemaRelative, config.FormatOutputDataRelative)
 
 	// read the raw data
 	dataPath := path.Join(path.Dir(schemaFile), dr.ResPath)

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -123,9 +123,7 @@ func GeocodeForwardDataset(schemaFile string, dataset string, config *IngestTask
 	if err != nil {
 		return "", errors.Wrap(err, "error writing feature output")
 	}
-
-	relativePath := getRelativePath(path.Dir(outputPath.outputSchema), outputPath.outputData)
-	mainDR.ResPath = relativePath
+	mainDR.ResPath = path.Dir(outputPath.outputData)
 
 	// write the new schema to file
 	err = datasetStorage.WriteMetadata(outputPath.outputSchema, meta, true, false)

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -42,10 +42,7 @@ type GeocodedPoint struct {
 // GeocodeForwardDataset geocodes fields that are types of locations.
 // The results are append to the dataset and the whole is output to disk.
 func GeocodeForwardDataset(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
-	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.GeocodingOutputSchemaRelative, config.GeocodingOutputDataRelative)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to copy source data folder")
-	}
+	outputPath := createDatasetPaths(schemaFile, dataset, config.GeocodingOutputSchemaRelative, config.GeocodingOutputDataRelative)
 
 	// load metadata from original schema
 	meta, err := metadata.LoadMetadataFromClassification(schemaFile, path.Join(path.Dir(schemaFile), config.ClassificationOutputPathRelative), false, true)

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/uncharted-distil/distil-compute/model"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/result"
 
@@ -42,7 +43,7 @@ type GeocodedPoint struct {
 // GeocodeForwardDataset geocodes fields that are types of locations.
 // The results are append to the dataset and the whole is output to disk.
 func GeocodeForwardDataset(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
-	outputPath := createDatasetPaths(schemaFile, dataset, config.GeocodingOutputSchemaRelative, config.GeocodingOutputDataRelative)
+	outputPath := createDatasetPaths(schemaFile, dataset, compute.D3MLearningData)
 
 	// load metadata from original schema
 	meta, err := metadata.LoadMetadataFromClassification(schemaFile, path.Join(path.Dir(schemaFile), config.ClassificationOutputPathRelative), false, true)

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -441,12 +441,12 @@ func IngestMetadata(originalSchemaFile string, schemaFile string, data api.DataS
 // IngestPostgres ingests a dataset to PG storage.
 func IngestPostgres(originalSchemaFile string, schemaFile string, source metadata.DatasetSource,
 	config *IngestTaskConfig, verifyMetadata bool, createMetadataTables bool, fallbackMerged bool) error {
-	datasetDir, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, source, nil, config, verifyMetadata, fallbackMerged)
+	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, source, nil, config, verifyMetadata, fallbackMerged)
 	if err != nil {
 		return err
 	}
 	mainDR := meta.GetMainDataResource()
-	dataDir := path.Join(datasetDir, mainDR.ResPath)
+	dataDir := model.GetResourcePath(schemaFile, mainDR)
 
 	// Connect to the database.
 	postgresConfig := &postgres.Config{
@@ -552,7 +552,7 @@ func loadMetadataForIngest(originalSchemaFile string, schemaFile string, source 
 	}
 
 	mainDR := meta.GetMainDataResource()
-	dataDir := path.Join(datasetDir, mainDR.ResPath)
+	dataDir := model.GetResourcePath(schemaFile, mainDR)
 	log.Infof("using %s as data directory (built from %s and %s)", dataDir, datasetDir, mainDR.ResPath)
 
 	// check and fix metadata issues

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -195,8 +195,7 @@ func createDatasetFromCSV(config *env.Config, csvFile string, datasetName string
 
 	// write out the metadata
 	metadataDestPath := path.Join(outputPath, compute.D3MDataSchema)
-	relativePath := getRelativePath(path.Dir(metadataDestPath), csvDestPath)
-	dataResource.ResPath = relativePath
+	dataResource.ResPath = path.Dir(csvDestPath)
 	err = datasetStorage.WriteMetadata(metadataDestPath, metadata, true, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to write schema")

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -16,8 +16,6 @@
 package task
 
 import (
-	"path"
-
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/metadata"
 
@@ -100,7 +98,7 @@ func Merge(schemaFile string, dataset string, config *IngestTaskConfig) (string,
 	if err != nil {
 		return "", errors.Wrap(err, "error writing merged output")
 	}
-	outputMeta.DataResources[0].ResPath = path.Dir(outputPath.outputData)
+	outputMeta.DataResources[0].ResPath = outputPath.outputData
 
 	// add every source data resource that isnt the main data resource to not lose them
 	for _, dr := range meta.DataResources {

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -30,10 +30,7 @@ import (
 
 // Merge will merge data resources into a single data resource.
 func Merge(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
-	outputPath, err := initializeDatasetCopy(schemaFile, dataset, config.MergedOutputSchemaPathRelative, config.MergedOutputPathRelative)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to copy source data folder")
-	}
+	outputPath := createDatasetPaths(schemaFile, dataset, config.MergedOutputSchemaPathRelative, config.MergedOutputPathRelative)
 
 	// need to manually build the metadata and output it.
 	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -100,9 +100,14 @@ func Merge(schemaFile string, dataset string, config *IngestTaskConfig) (string,
 	if err != nil {
 		return "", errors.Wrap(err, "error writing merged output")
 	}
+	outputMeta.DataResources[0].ResPath = path.Dir(outputPath.outputData)
 
-	relativePath := getRelativePath(path.Dir(outputPath.outputSchema), outputPath.outputData)
-	outputMeta.DataResources[0].ResPath = relativePath
+	// add every source data resource that isnt the main data resource to not lose them
+	for _, dr := range meta.DataResources {
+		if dr != mainDR {
+			outputMeta.DataResources = append(outputMeta.DataResources, dr)
+		}
+	}
 
 	// write the new schema to file
 	err = datasetStorage.WriteMetadata(outputPath.outputSchema, outputMeta, true, false)

--- a/api/task/merge.go
+++ b/api/task/merge.go
@@ -30,7 +30,7 @@ import (
 
 // Merge will merge data resources into a single data resource.
 func Merge(schemaFile string, dataset string, config *IngestTaskConfig) (string, error) {
-	outputPath := createDatasetPaths(schemaFile, dataset, config.MergedOutputSchemaPathRelative, config.MergedOutputPathRelative)
+	outputPath := createDatasetPaths(schemaFile, dataset, compute.D3MLearningData)
 
 	// need to manually build the metadata and output it.
 	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)

--- a/api/task/pipelines.go
+++ b/api/task/pipelines.go
@@ -247,7 +247,7 @@ func getRelativePath(rootPath string, filePath string) string {
 func createDatasetPaths(schemaFile string, dataset string, dataPathRelative string) *datasetCopyPath {
 	sourceFolder := path.Dir(schemaFile)
 	outputSchemaPath := schemaFile
-	outputDataPath := path.Join(sourceFolder, dataPathRelative)
+	outputDataPath := path.Join(sourceFolder, compute.D3MDataFolder, dataPathRelative)
 	outputFolder := sourceFolder
 
 	return &datasetCopyPath{

--- a/api/task/pipelines.go
+++ b/api/task/pipelines.go
@@ -25,11 +25,9 @@ import (
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/result"
-	log "github.com/unchartedsoftware/plog"
 
 	sr "github.com/uncharted-distil/distil/api/compute"
 	"github.com/uncharted-distil/distil/api/env"
-	"github.com/uncharted-distil/distil/api/util"
 )
 
 const (
@@ -247,27 +245,19 @@ func getRelativePath(rootPath string, filePath string) string {
 	return relativePath
 }
 
-func initializeDatasetCopy(schemaFile string, dataset string, schemaPathRelative string, dataPathRelative string) (*datasetCopyPath, error) {
-	// all work done in the temp folder
+func createDatasetPaths(schemaFile string, dataset string, schemaPathRelative string, dataPathRelative string) *datasetCopyPath {
 	basePath := path.Join(env.GetTmpPath(), dataset)
 	sourceFolder := path.Dir(schemaFile)
 	outputSchemaPath := path.Join(basePath, schemaPathRelative)
 	outputDataPath := path.Join(basePath, dataPathRelative)
 	outputFolder := path.Dir(outputSchemaPath)
 
-	// copy the source folder to have all the linked files for merging
-	log.Infof("COPYING FROM %s to %s", sourceFolder, outputFolder)
-	err := util.Copy(sourceFolder, outputFolder)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to copy source data")
-	}
-
 	return &datasetCopyPath{
 		sourceFolder: sourceFolder,
 		outputFolder: outputFolder,
 		outputSchema: outputSchemaPath,
 		outputData:   outputDataPath,
-	}, nil
+	}
 }
 
 func createFriendlyLabel(label string) string {

--- a/api/task/pipelines.go
+++ b/api/task/pipelines.go
@@ -27,7 +27,6 @@ import (
 	"github.com/uncharted-distil/distil-compute/primitive/compute/result"
 
 	sr "github.com/uncharted-distil/distil/api/compute"
-	"github.com/uncharted-distil/distil/api/env"
 )
 
 const (
@@ -245,12 +244,11 @@ func getRelativePath(rootPath string, filePath string) string {
 	return relativePath
 }
 
-func createDatasetPaths(schemaFile string, dataset string, schemaPathRelative string, dataPathRelative string) *datasetCopyPath {
-	basePath := path.Join(env.GetTmpPath(), dataset)
+func createDatasetPaths(schemaFile string, dataset string, dataPathRelative string) *datasetCopyPath {
 	sourceFolder := path.Dir(schemaFile)
-	outputSchemaPath := path.Join(basePath, schemaPathRelative)
-	outputDataPath := path.Join(basePath, dataPathRelative)
-	outputFolder := path.Dir(outputSchemaPath)
+	outputSchemaPath := schemaFile
+	outputDataPath := path.Join(sourceFolder, dataPathRelative)
+	outputFolder := sourceFolder
 
 	return &datasetCopyPath{
 		sourceFolder: sourceFolder,

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -142,7 +142,9 @@ func (p *predictionDataset) CreateDataset(rootDataPath string, datasetName strin
 
 	// update the data resources to match those from the created dataset - they may have changed file types
 	for i, dataResource := range ds.Metadata.DataResources {
+		log.Infof("PREDICTIONS RES PATH: %s", dataResource.ResPath)
 		p.params.Meta.DataResources[i].ResFormat = dataResource.ResFormat
+		p.params.Meta.DataResources[i].ResPath = dataResource.ResPath
 	}
 
 	return &api.RawDataset{
@@ -207,10 +209,11 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 			return nil, errors.Wrap(err, "unable to parse header result")
 		}
 		rawHeader := rawCSVData[0]
+		mainDR := meta.GetMainDataResource()
 		for i, f := range rawHeader {
 			// TODO: col index not necessarily the same as index and thats what needs checking
 			// We check both name and display name as the pre-ingested datasets are keyed of display name
-			if meta.GetMainDataResource().Variables[i].Name != f && meta.GetMainDataResource().Variables[i].DisplayName != f {
+			if mainDR.Variables[i].Name != f && mainDR.Variables[i].DisplayName != f {
 				return nil, errors.Errorf("variables in new prediction file do not match variables in original dataset")
 			}
 		}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -142,7 +142,6 @@ func (p *predictionDataset) CreateDataset(rootDataPath string, datasetName strin
 
 	// update the data resources to match those from the created dataset - they may have changed file types
 	for i, dataResource := range ds.Metadata.DataResources {
-		log.Infof("PREDICTIONS RES PATH: %s", dataResource.ResPath)
 		p.params.Meta.DataResources[i].ResFormat = dataResource.ResFormat
 		p.params.Meta.DataResources[i].ResPath = dataResource.ResPath
 	}

--- a/api/task/rank.go
+++ b/api/task/rank.go
@@ -76,7 +76,7 @@ func Rank(schemaPath string, dataset string, config *IngestTaskConfig) (string, 
 		Features: ranks,
 	}
 
-	// output the classification in the expected JSON format
+	// output the importance in the expected JSON format
 	bytes, err := json.MarshalIndent(importance, "", "    ")
 	if err != nil {
 		return "", errors.Wrap(err, "unable to serialize ranking result")

--- a/api/task/sample.go
+++ b/api/task/sample.go
@@ -40,8 +40,8 @@ func Sample(originalSchemaFile string, schemaFile string, dataset string, config
 	mainDR := meta.GetMainDataResource()
 
 	// extract a sample by simply reading the main CSV file and selecting a subset
-	csvFilePath := path.Join(path.Dir(schemaFile), mainDR.ResPath)
-	originalCSVFilePath := path.Join(path.Dir(originalSchemaFile), mainDR.ResPath)
+	csvFilePath := model.GetResourcePath(schemaFile, mainDR)
+	originalCSVFilePath := model.GetResourcePath(originalSchemaFile, mainDR)
 	csvData, err := util.ReadCSVFile(csvFilePath, false)
 	if err != nil {
 		return "", false, 0, errors.Wrap(err, "unable to parse complete csv dataset")

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20200924154433-5b93533570f9
+	github.com/uncharted-distil/distil-compute v0.0.0-20200925205351-9ae09d38e9c2
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20200925205351-9ae09d38e9c2
+	github.com/uncharted-distil/distil-compute v0.0.0-20201006134037-690e53ba18e3
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201006140143-fb2a49e36a48
+	github.com/uncharted-distil/distil-compute v0.0.0-20201007042553-ed119f8342c4
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/davecgh/go-spew v1.1.1
-	github.com/disintegration/imaging v1.6.2
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/websocket v1.4.0
@@ -28,7 +27,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201006134037-690e53ba18e3
+	github.com/uncharted-distil/distil-compute v0.0.0-20201006140143-fb2a49e36a48
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201006140143-fb2a49e36a48 h1:GIS5yTZNdEMRjuksFi+LHUd8GHHPkVwl8OzGhWLw+tk=
-github.com/uncharted-distil/distil-compute v0.0.0-20201006140143-fb2a49e36a48/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
+github.com/uncharted-distil/distil-compute v0.0.0-20201007042553-ed119f8342c4 h1:dCq41nxwZOPEjtuJKOSyehJl8KvEbnahOXeNttELnio=
+github.com/uncharted-distil/distil-compute v0.0.0-20201007042553-ed119f8342c4/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20200924154433-5b93533570f9 h1:pLQ2Isx3prNt+/XcEKO8mWFmwIgVvjAVYNJ4FC4GeDc=
-github.com/uncharted-distil/distil-compute v0.0.0-20200924154433-5b93533570f9/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
+github.com/uncharted-distil/distil-compute v0.0.0-20200925205351-9ae09d38e9c2 h1:l8C5J5YIhc6Y4QhlL6N+P/jhJbOtk3luLVt4qcLRYs8=
+github.com/uncharted-distil/distil-compute v0.0.0-20200925205351-9ae09d38e9c2/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20200925205351-9ae09d38e9c2 h1:l8C5J5YIhc6Y4QhlL6N+P/jhJbOtk3luLVt4qcLRYs8=
-github.com/uncharted-distil/distil-compute v0.0.0-20200925205351-9ae09d38e9c2/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
+github.com/uncharted-distil/distil-compute v0.0.0-20201006134037-690e53ba18e3 h1:+Cse/YgwC1UlGhqz1cscnYJwkDgjdeQR2s90DrFf7x4=
+github.com/uncharted-distil/distil-compute v0.0.0-20201006134037-690e53ba18e3/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
-github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
@@ -190,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201006134037-690e53ba18e3 h1:+Cse/YgwC1UlGhqz1cscnYJwkDgjdeQR2s90DrFf7x4=
-github.com/uncharted-distil/distil-compute v0.0.0-20201006134037-690e53ba18e3/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
+github.com/uncharted-distil/distil-compute v0.0.0-20201006140143-fb2a49e36a48 h1:GIS5yTZNdEMRjuksFi+LHUd8GHHPkVwl8OzGhWLw+tk=
+github.com/uncharted-distil/distil-compute v0.0.0-20201006140143-fb2a49e36a48/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=
@@ -225,8 +223,6 @@ golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8 h1:hVwzHzIUGRjiF7EcUjqNxk3NCfkPxbDKRdnNE1Rpg0U=
-golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
Ingest will no longer create copies of datasets. It now uses absolute paths and writes data in the same folder after every step.