### PR TITLE
#1943 - Filter Pattern Facets From Display

### DIFF
--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -580,15 +580,14 @@ export function getVariableSummariesByState(
   let currentSummaries = [];
 
   if (Object.keys(summaryDictionary).length > 0 && variables.length > 0) {
-    let sortedVariables = variables;
+    // remove any pattern cluster variables
+    let sortedVariables = variables.filter((sv) => {
+      return sv.colName.indexOf(CLUSTER_PREFIX) < 0;
+    });
     if (ranked) {
       // prioritize FI over MI
       sortedVariables = sortVariablesByImportance(sortedVariables);
     }
-    // remove any pattern cluster variables
-    sortedVariables = sortedVariables.filter((sv) => {
-      return sv.colName.indexOf(CLUSTER_PREFIX) < 0;
-    });
     // select only the current variables on the page
     sortedVariables = filterArrayByPage(pageIndex, pageSize, sortedVariables);
     // map them back to the variable summary dictionary for the current route key

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -33,6 +33,7 @@ import {
 import { getters as routeGetters } from "../store/route/module";
 import store from "../store/store";
 import {
+  CLUSTER_PREFIX,
   formatValue,
   hasComputedVarPrefix,
   IMAGE_TYPE,
@@ -584,7 +585,10 @@ export function getVariableSummariesByState(
       // prioritize FI over MI
       sortedVariables = sortVariablesByImportance(sortedVariables);
     }
-
+    // remove any pattern cluster variables
+    sortedVariables = sortedVariables.filter((sv) => {
+      return sv.colName.indexOf(CLUSTER_PREFIX) < 0;
+    });
     // select only the current variables on the page
     sortedVariables = filterArrayByPage(pageIndex, pageSize, sortedVariables);
     // map them back to the variable summary dictionary for the current route key


### PR DESCRIPTION
Closes #1943 - Added a step in getVariableSummariesByState to filter variables with a "_cluster" prefix from display.