### PR TITLE
#1951 - Time Facet Filter Fix.

### DIFF
--- a/public/components/facets/FacetDateTime.vue
+++ b/public/components/facets/FacetDateTime.vue
@@ -210,9 +210,9 @@ export default Vue.extend({
       } else {
         const maxBasis = this.dateToNum(values[maxIndex - 1].label);
         const offset = maxBasis - this.dateToNum(values[maxIndex - 2].label);
-        upperBound = maxBasis + offset;
+        // increase filter upperbound to definitely include the last date bucket
+        upperBound = maxBasis + offset * 2;
       }
-
       return {
         from: lowerBound,
         to: upperBound,

--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -96,6 +96,7 @@
                 :ignore-highlights="ignoreHighlights"
                 :instanceName="instanceName"
                 @facet-click="onFacetClick"
+                @range-change="onRangeChange"
               />
             </template>
             <template v-else-if="summary.type === 'categorical'">


### PR DESCRIPTION
Closes #1951 - Two fixes:
1. Variable Facets component was not binding on the range-change event, so the filter was never setting. This was actually broken generally for the time-series selection, possibly because of library updates (we leveraged listening to just the click event before.)
2. Now that time series range was setting a filter, I found we had an edge case for the last time bucket where only some/none of that last bucket would select despite being clearly in range, so it's offset was extended to include the whole last bucket in the filter as the range selection implies.