### PR TITLE
Parse confidence results

### DIFF
--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -375,6 +375,11 @@ func GeneratePredictions(datasetURI string, explainedSolutionID string,
 		if err != nil {
 			return nil, err
 		}
+		resultURI, err = reformatResult(resultURI)
+		if err != nil {
+			return nil, err
+		}
+
 		var explainFeatureURI string
 		if outputs[explainableTypeStep] != nil {
 			explainFeatureURI, err = getFileFromOutput(response, outputs[explainableTypeStep].key)


### PR DESCRIPTION
Fixes #1973

Confidence results come as one row per class per d3m index. The changes will filter the results to retain only the class with the highest confidence and write out the filtered data to disk. This new file will then be used by Distil.