### PR TITLE
Confidence Summary Route

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -70,6 +70,7 @@ type DataStorage interface {
 	FetchPredictedSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, extrema *Extrema, mode SummaryMode) (*VariableSummary, error)
 	FetchResultsExtremaByURI(dataset string, storageName string, resultURI string) (*Extrema, error)
 	FetchCorrectnessSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, mode SummaryMode) (*VariableSummary, error)
+	FetchConfidenceSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, mode SummaryMode) (*VariableSummary, error)
 	FetchResidualsSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, extrema *Extrema, mode SummaryMode) (*VariableSummary, error)
 	FetchResidualsExtremaByURI(dataset string, storageName string, resultURI string) (*Extrema, error)
 	FetchExtrema(storageName string, variable *model.Variable) (*Extrema, error)

--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -1,0 +1,142 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package postgres
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/pkg/errors"
+	"github.com/uncharted-distil/distil-compute/model"
+	api "github.com/uncharted-distil/distil/api/model"
+)
+
+// FetchConfidenceSummary fetches a histogram of the confidence associated with a set of classification predictions.
+func (s *Storage) FetchConfidenceSummary(dataset string, storageName string, resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (*api.VariableSummary, error) {
+
+	storageNameResult := s.getResultTable(storageName)
+	targetName, err := s.getResultTargetName(storageNameResult, resultURI)
+	if err != nil {
+		return nil, err
+	}
+
+	variable, err := s.getResultTargetVariable(dataset, targetName)
+	if err != nil {
+		return nil, err
+	}
+
+	var baseline *api.Histogram
+	var filtered *api.Histogram
+	baseline, err = s.fetchConfidenceHistogram(dataset, storageName, variable, targetName, resultURI, nil, mode)
+	if err != nil {
+		return nil, err
+	}
+	if !filterParams.Empty() {
+		filtered, err = s.fetchConfidenceHistogram(dataset, storageName, variable, targetName, resultURI, filterParams, mode)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &api.VariableSummary{
+		Label:    variable.DisplayName,
+		Key:      variable.Name,
+		Type:     model.CategoricalType,
+		VarType:  variable.Type,
+		Baseline: baseline,
+		Filtered: filtered,
+	}, nil
+}
+
+func (s *Storage) fetchConfidenceHistogram(dataset string, storageName string, variable *model.Variable, targetName string, resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (*api.Histogram, error) {
+	storageNameResult := s.getResultTable(storageName)
+
+	// get filter where / params
+	wheres, params, err := s.buildResultQueryFilters(dataset, storageName, resultURI, filterParams, baseTableAlias)
+	if err != nil {
+		return nil, err
+	}
+
+	countCol, err := s.getCountCol(dataset, mode)
+	if err != nil {
+		return nil, err
+	}
+	if countCol == "" {
+		countCol = "*"
+	} else {
+		countCol = fmt.Sprintf("DISTINCT \"%s\"", countCol)
+	}
+
+	wheres = append(wheres, fmt.Sprintf("result.result_id = $%d AND result.target = $%d ", len(params)+1, len(params)+2))
+	params = append(params, resultURI, targetName)
+
+	query := fmt.Sprintf(
+		`SELECT floor(result.confidence / 0.02) as bucket, COUNT(%s) AS count
+		 FROM %s AS result INNER JOIN %s AS data ON result.index = data."%s"
+		 WHERE %s
+		 GROUP BY floor(result.confidence / 0.02);`,
+		countCol, storageNameResult, storageName, model.D3MIndexFieldName, strings.Join(wheres, " AND "))
+
+	// execute the postgres query
+	res, err := s.client.Query(query, params...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch histograms for result summaries from postgres")
+	}
+	defer res.Close()
+
+	return s.parseConfidenceHistogram(res, variable)
+}
+
+func (s *Storage) parseConfidenceHistogram(rows pgx.Rows, variable *model.Variable) (*api.Histogram, error) {
+
+	// parse the confidence data
+	countMap := map[int]int64{}
+	if rows != nil {
+		for rows.Next() {
+			var bucket int
+			var bucketCount int64
+			err := rows.Scan(&bucket, &bucketCount)
+			if err != nil {
+				return nil, errors.Wrap(err, "no confidence histogram aggregation found")
+			}
+			countMap[bucket] = bucketCount
+		}
+		err := rows.Err()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error reading data from postgres")
+		}
+	}
+
+	// create buckets from 0 to 50
+	// bucket 50 is the bucket for instances with confidence = 1
+	buckets := make([]*api.Bucket, 51)
+	for i := 0; i <= 50; i++ {
+		buckets[i] = &api.Bucket{
+			Key:   fmt.Sprintf("%f", float64(i)*0.02),
+			Count: countMap[i],
+		}
+	}
+
+	// assign histogram attributes
+	return &api.Histogram{
+		Buckets: buckets,
+		Extrema: &api.Extrema{
+			Min: float64(0),
+			Max: float64(1),
+		},
+	}, nil
+}

--- a/api/routes/confidence.go
+++ b/api/routes/confidence.go
@@ -1,0 +1,109 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/pkg/errors"
+	"goji.io/v3/pat"
+
+	api "github.com/uncharted-distil/distil/api/model"
+)
+
+// ConfidenceSummaryHandler bins predicted result confidence data for consumption in a downstream summary view.
+func ConfidenceSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.SolutionStorageCtor, dataCtor api.DataStorageCtor) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// extract route parameters
+		dataset := pat.Param(r, "dataset")
+
+		// get variable summary mode
+		mode, err := api.SummaryModeFromString(pat.Param(r, "mode"))
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		resultUUID, err := url.PathUnescape(pat.Param(r, "results-uuid"))
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable to unescape results uuid"))
+			return
+		}
+
+		// parse POST params
+		params, err := getPostParameters(r)
+		if err != nil {
+			handleError(w, errors.Wrap(err, "Unable to parse post parameters"))
+			return
+		}
+
+		// get variable names and ranges out of the params
+		filterParams, err := api.ParseFilterParamsFromJSON(params)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		solution, err := solutionCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		data, err := dataCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		meta, err := metaCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		ds, err := meta.FetchDataset(dataset, false, false)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		storageName := ds.StorageName
+
+		// get the result URI. Error ignored to make it ES compatible.
+		res, err := solution.FetchSolutionResultByUUID(resultUUID)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// fetch summary histogram
+		summary, err := data.FetchConfidenceSummary(dataset, storageName, res.ResultURI, filterParams, api.SummaryMode(mode))
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// marshal data and sent the response back
+		err = handleJSON(w, SummaryResult{
+			Summary: summary,
+		})
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
+			return
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -278,6 +278,7 @@ func main() {
 	registerRoutePost(mux, "/distil/target-summary/:dataset/:target/:results-uuid/:mode", routes.TargetSummaryHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/residuals-summary/:dataset/:target/:results-uuid/:mode", routes.ResidualsSummaryHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/correctness-summary/:dataset/:results-uuid/:mode", routes.CorrectnessSummaryHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
+	registerRoutePost(mux, "/distil/confidence-summary/:dataset/:results-uuid/:mode", routes.ConfidenceSummaryHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/prediction-result-summary/:results-uuid/:mode", routes.PredictionResultSummaryHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/solution-result-summary/:results-uuid/:mode", routes.SolutionResultSummaryHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/geocode/:dataset/:variable", routes.GeocodingHandler(esMetadataStorageCtor, pgDataStorageCtor))


### PR DESCRIPTION
Creation of the confidence summary route (`/distil/confidence-summary/:dataset/:results-uuid/:mode`) that has the same input and output structure as the correctness summary route. It creates 51 buckets in intervals of 0.02 with extrema [0,1].