### PR TITLE
Empty Confidence Result

### DIFF
--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -81,6 +81,7 @@ func (s *Storage) fetchConfidenceHistogram(dataset string, storageName string, v
 		countCol = fmt.Sprintf("DISTINCT \"%s\"", countCol)
 	}
 
+	wheres = append(wheres, "confidence is not null")
 	wheres = append(wheres, fmt.Sprintf("result.result_id = $%d AND result.target = $%d ", len(params)+1, len(params)+2))
 	params = append(params, resultURI, targetName)
 
@@ -119,6 +120,10 @@ func (s *Storage) parseConfidenceHistogram(rows pgx.Rows, variable *model.Variab
 		if err != nil {
 			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
+	}
+
+	if len(countMap) == 0 {
+		return nil, nil
 	}
 
 	// create buckets from 0 to 50

--- a/api/routes/confidence.go
+++ b/api/routes/confidence.go
@@ -89,6 +89,13 @@ func ConfidenceSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api
 			handleError(w, err)
 			return
 		}
+		if res == nil {
+			err = handleJSON(w, SummaryResult{})
+			if err != nil {
+				handleError(w, errors.Wrap(err, "unable marshal nil histogram into JSON"))
+			}
+			return
+		}
 
 		// fetch summary histogram
 		summary, err := data.FetchConfidenceSummary(dataset, storageName, res.ResultURI, filterParams, api.SummaryMode(mode))

--- a/api/routes/correctness_summary.go
+++ b/api/routes/correctness_summary.go
@@ -95,6 +95,16 @@ func CorrectnessSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor ap
 			return
 		}
 
+		if res == nil {
+			err = handleJSON(w, CorrectnessSummary{
+				CorrectnessSummary: nil,
+			})
+			if err != nil {
+				handleError(w, errors.Wrap(err, "unable marshal nil histogram into JSON"))
+			}
+			return
+		}
+
 		// fetch summary histogram
 		summary, err := data.FetchCorrectnessSummary(dataset, storageName, res.ResultURI, filterParams, api.SummaryMode(mode))
 		if err != nil {


### PR DESCRIPTION
For pipelines with no confidence, return an empty list instead of erroring. Also add some error handling in cases where an invalid result id is used.