### PR TITLE
#1962 prediction confidence facets

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	suffixReg = regexp.MustCompile(`:error|:predicted$`)
+	suffixReg = regexp.MustCompile(`:error|:predicted|:confidence$`)
 )
 
 // ExportedModel represents a description of an exported model.
@@ -167,6 +167,11 @@ func GetErrorKey(solutionID string) string {
 	return solutionID + ":error"
 }
 
+// GetConfidenceKey returns a solutions error col key.
+func GetConfidenceKey(solutionID string) string {
+	return solutionID + ":confidence"
+}
+
 // IsPredictedKey returns true if the key matches a predicted key.
 func IsPredictedKey(key string) bool {
 	return strings.HasSuffix(key, ":predicted")
@@ -175,6 +180,11 @@ func IsPredictedKey(key string) bool {
 // IsErrorKey returns true if the key matches an error key.
 func IsErrorKey(key string) bool {
 	return strings.HasSuffix(key, ":error")
+}
+
+// IsConfidenceKey returns true if the key matches an error key.
+func IsConfidenceKey(key string) bool {
+	return strings.HasSuffix(key, ":confidence")
 }
 
 // IsResultKey returns true if the key matches an predicted or error key.

--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -55,7 +55,7 @@ func (s *Storage) FetchConfidenceSummary(dataset string, storageName string, res
 	return &api.VariableSummary{
 		Label:    variable.DisplayName,
 		Key:      variable.Name,
-		Type:     model.CategoricalType,
+		Type:     model.NumericalType,
 		VarType:  variable.Type,
 		Baseline: baseline,
 		Filtered: filtered,

--- a/api/routes/confidence.go
+++ b/api/routes/confidence.go
@@ -104,6 +104,9 @@ func ConfidenceSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api
 			return
 		}
 
+		summary.Key = api.GetConfidenceKey(res.SolutionID)
+		summary.Label = "Confidence"
+
 		// marshal data and sent the response back
 		err = handleJSON(w, SummaryResult{
 			Summary: summary,

--- a/api/routes/solutions.go
+++ b/api/routes/solutions.go
@@ -40,6 +40,7 @@ type SolutionResponse struct {
 	Timestamp        time.Time              `json:"timestamp"`
 	PredictedKey     string                 `json:"predictedKey"`
 	ErrorKey         string                 `json:"errorKey"`
+	ConfidenceKey    string                 `json:"confidenceKey"`
 }
 
 // SolutionsHandler fetches solutions associated with a given dataset and target.
@@ -83,8 +84,9 @@ func SolutionsHandler(solutionCtor model.SolutionStorageCtor) func(http.Response
 					Timestamp:  sol.CreatedTime,
 					Progress:   sol.State.Progress,
 					// keys
-					PredictedKey: model.GetPredictedKey(sol.SolutionID),
-					ErrorKey:     model.GetErrorKey(sol.SolutionID),
+					PredictedKey:  model.GetPredictedKey(sol.SolutionID),
+					ErrorKey:      model.GetErrorKey(sol.SolutionID),
+					ConfidenceKey: model.GetConfidenceKey(sol.SolutionID),
 				}
 				if len(sol.Results) > 0 {
 					// result
@@ -150,8 +152,9 @@ func SolutionHandler(solutionCtor model.SolutionStorageCtor) func(http.ResponseW
 			ResultID:         resultID,
 			FittedSolutionID: fittedSolutionID,
 			// keys
-			PredictedKey: model.GetPredictedKey(sol.SolutionID),
-			ErrorKey:     model.GetErrorKey(sol.SolutionID),
+			PredictedKey:  model.GetPredictedKey(sol.SolutionID),
+			ErrorKey:      model.GetErrorKey(sol.SolutionID),
+			ConfidenceKey: model.GetConfidenceKey(sol.SolutionID),
 		}
 
 		// marshal data and sent the response back

--- a/public/components/ResultFacets.vue
+++ b/public/components/ResultFacets.vue
@@ -40,6 +40,7 @@
         :predicted-summary="group.predictedSummary"
         :residuals-summary="group.residualsSummary"
         :correctness-summary="group.correctnessSummary"
+        :confidence-summary="group.confidenceSummary"
       />
     </div>
   </div>
@@ -74,6 +75,7 @@ import {
   getSolutionResultSummary,
   getResidualSummary,
   getCorrectnessSummary,
+  getConfidenceSummary,
 } from "../util/summaries";
 
 interface SummaryGroup {
@@ -83,6 +85,7 @@ interface SummaryGroup {
   predictedSummary: VariableSummary;
   residualsSummary: VariableSummary;
   correctnessSummary: VariableSummary;
+  confidenceSummary: VariableSummary;
   targetSummary: VariableSummary;
   scores: Score[];
 }
@@ -157,6 +160,9 @@ export default Vue.extend({
         const correctnessSummary = !this.showResiduals
           ? getCorrectnessSummary(solutionId)
           : null;
+        const confidenceSummary = !this.showResiduals
+          ? getConfidenceSummary(solutionId)
+          : null;
         const scores = solution.scores;
 
         return {
@@ -166,6 +172,7 @@ export default Vue.extend({
           predictedSummary: predictedSummary,
           residualsSummary: residualSummary,
           correctnessSummary: correctnessSummary,
+          confidenceSummary: confidenceSummary,
           targetSummary: this.resultTargetSummary,
           scores: scores,
         };

--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -282,7 +282,6 @@ export default Vue.extend({
     },
 
     confidenceSummaries(): VariableSummary[] {
-      console.log(this.confidenceSummary);
       return this.confidenceSummary ? [this.confidenceSummary] : [];
     },
 

--- a/public/components/facets/FacetNumerical.vue
+++ b/public/components/facets/FacetNumerical.vue
@@ -22,10 +22,20 @@
       </type-change-menu>
     </div>
 
-    <facet-template target="facet-bars-value" title="${tooltip}">
+    <facet-template
+      target="facet-bars-value"
+      title="${tooltip}"
+      v-if="facetData.values.length > 0"
+    >
     </facet-template>
 
-    <div slot="footer" class="facet-footer-container">
+    <div slot="content" v-else></div>
+
+    <div
+      slot="footer"
+      class="facet-footer-container"
+      v-if="facetData.values.length > 0"
+    >
       <facet-plugin-zoom-bar
         min-bar-width="8"
         auto-hide="true"
@@ -37,6 +47,9 @@
         v-child="computeCustomHTML()"
         class="facet-footer-custom-html"
       ></div>
+    </div>
+    <div slot="footer" class="facet-footer-container" v-else>
+      No Data Avialable
     </div>
   </facet-bars>
 </template>

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -250,6 +250,15 @@ function updateSolutionResults(
         ? varModes.get(req.target)
         : SummaryMode.Default,
     });
+    resultsActions.fetchConfidenceSummary(store, {
+      dataset: req.dataset,
+      solutionId: res.solutionId,
+      highlight: context.getters.getDecodedHighlight,
+      dataMode: dataMode,
+      varMode: varModes.has(req.target)
+        ? varModes.get(req.target)
+        : SummaryMode.Default,
+    });
   }
 }
 

--- a/public/store/requests/index.ts
+++ b/public/store/requests/index.ts
@@ -40,6 +40,7 @@ export interface Solution extends SolutionRequest {
   scores: Score[];
   predictedKey: string;
   errorKey: string;
+  confidenceKey: string;
   isBad: boolean;
 }
 

--- a/public/store/results/getters.ts
+++ b/public/store/results/getters.ts
@@ -146,6 +146,12 @@ export const getters = {
     return state.correctnessSummaries;
   },
 
+  // confidence
+
+  getConfidenceSummaries(state: ResultsState): VariableSummary[] {
+    return state.confidenceSummaries;
+  },
+
   // forecasts
 
   getPredictedTimeseries(state: ResultsState): Dictionary<TimeSeries> {

--- a/public/store/results/index.ts
+++ b/public/store/results/index.ts
@@ -32,6 +32,8 @@ export interface ResultsState {
   residualsExtrema: Extrema;
   // correctness summary (correct vs. incorrect) for predicted categorical data
   correctnessSummaries: VariableSummary[];
+  // confidence summary (how sure the system is of it's predictions) for any predicted data
+  confidenceSummaries: VariableSummary[];
   // timeseries by solutionID, timeseriesID
   timeseries: Dictionary<TimeSeries>;
   // forecasts by solution ID
@@ -57,6 +59,8 @@ export const state: ResultsState = {
   residualsExtrema: { min: null, max: null },
   // correctness summary (correct vs. incorrect) for predicted categorical data
   correctnessSummaries: [],
+  // confidence summary (how sure the system is of it's predictions) for any predicted data
+  confidenceSummaries: [],
   // forecasts
   timeseries: {},
   forecasts: {},

--- a/public/store/results/module.ts
+++ b/public/store/results/module.ts
@@ -62,6 +62,8 @@ export const getters = {
   getResidualsExtrema: read(moduleGetters.getResidualsExtrema),
   // correctness
   getCorrectnessSummaries: read(moduleGetters.getCorrectnessSummaries),
+  // confidence
+  getConfidenceSummaries: read(moduleGetters.getConfidenceSummaries),
   // result table data
   getResultDataNumRows: read(moduleGetters.getResultDataNumRows),
   // forecasts
@@ -94,6 +96,9 @@ export const actions = {
   // correctness
   fetchCorrectnessSummary: dispatch(moduleActions.fetchCorrectnessSummary),
   fetchCorrectnessSummaries: dispatch(moduleActions.fetchCorrectnessSummaries),
+  // correctness
+  fetchConfidenceSummary: dispatch(moduleActions.fetchConfidenceSummary),
+  fetchConfidenceSummaries: dispatch(moduleActions.fetchConfidenceSummaries),
   // forecast
   fetchForecastedTimeseries: dispatch(moduleActions.fetchForecastedTimeseries),
   // variable rankings
@@ -127,6 +132,8 @@ export const mutations = {
   updateCorrectnessSummaries: commit(
     moduleMutations.updateCorrectnessSummaries
   ),
+  // predicted
+  updateConfidenceSummaries: commit(moduleMutations.updateConfidenceSummaries),
   // forecasts
   updatePredictedTimeseries: commit(moduleMutations.updatePredictedTimeseries),
   updatePredictedForecast: commit(moduleMutations.updatePredictedForecast),

--- a/public/store/results/mutations.ts
+++ b/public/store/results/mutations.ts
@@ -73,6 +73,12 @@ export const mutations = {
     updateSummaries(summary, state.correctnessSummaries);
   },
 
+  // confidence
+
+  updateConfidenceSummaries(state: ResultsState, summary: VariableSummary) {
+    updateSummaries(summary, state.confidenceSummaries);
+  },
+
   // forecast
 
   updatePredictedTimeseries(

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -568,6 +568,15 @@ export const actions = {
       solutionID: solutionId,
     });
 
+    resultActions.fetchConfidenceSummaries(store, {
+      dataset: dataset,
+      target: target,
+      requestIds: requestIds,
+      highlight: highlight,
+      dataMode: dataMode,
+      varModes: varModes,
+    });
+
     const task = routeGetters.getRouteTask(store);
 
     if (!task) {

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -237,11 +237,8 @@ export function fetchResultExemplars(
   const variables = datasetGetters.getVariables(store);
   const variable = variables.find((v) => v.colName === variableName);
 
-  const baselineExemplars = summary.baseline.exemplars;
-  const filteredExemplars =
-    summary.filtered && summary.filtered.exemplars
-      ? summary.filtered.exemplars
-      : null;
+  const baselineExemplars = summary.baseline?.exemplars;
+  const filteredExemplars = summary.filtered?.exemplars;
   const exemplars = filteredExemplars ? filteredExemplars : baselineExemplars;
 
   if (exemplars) {
@@ -685,6 +682,11 @@ export function getTableDataItems(data: TableData): TableRow[] {
           if (colValue.weight !== null && colValue.weight !== undefined) {
             row[colName].weight = colValue.weight;
           }
+          if (colValue.confidence !== undefined) {
+            const conKey = colName + "confidence";
+            row[conKey] = {};
+            row[conKey].value = colValue.confidence;
+          }
         } else {
           row[colName] = formatValue(colValue.value, colType);
         }
@@ -726,6 +728,15 @@ export function getTableDataFields(data: TableData): Dictionary<TableColumn> {
         variable = requestGetters.getActiveSolutionTargetVariable(store)[0]; // always a single value
         label = variable.colDisplayName;
         description = `Model predicted value for ${variable.colName}`;
+
+        result[col.key + "confidence"] = {
+          label: label + "_Confidence",
+          key: col.key + "confidence",
+          type: "numeric",
+          weight: null,
+          headerTitle: `Prediction confidence ${variable.colName}`,
+          sortable: true,
+        };
       } else if (isErrorCol(col.key)) {
         variable = requestGetters.getActiveSolutionTargetVariable(store)[0];
         label = "Error";

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -682,11 +682,15 @@ export function getTableDataItems(data: TableData): TableRow[] {
           if (colValue.weight !== null && colValue.weight !== undefined) {
             row[colName].weight = colValue.weight;
           }
+
+          // confidence code, draft pending UX feedback
+          /*
           if (colValue.confidence !== undefined) {
             const conKey = colName + "confidence";
             row[conKey] = {};
             row[conKey].value = colValue.confidence;
           }
+          */
         } else {
           row[colName] = formatValue(colValue.value, colType);
         }
@@ -729,6 +733,8 @@ export function getTableDataFields(data: TableData): Dictionary<TableColumn> {
         label = variable.colDisplayName;
         description = `Model predicted value for ${variable.colName}`;
 
+        // confidence code, draft pending UX feedback
+        /*
         result[col.key + "confidence"] = {
           label: label + "_Confidence",
           key: col.key + "confidence",
@@ -737,6 +743,7 @@ export function getTableDataFields(data: TableData): Dictionary<TableColumn> {
           headerTitle: `Prediction confidence ${variable.colName}`,
           sortable: true,
         };
+        */
       } else if (isErrorCol(col.key)) {
         variable = requestGetters.getActiveSolutionTargetVariable(store)[0];
         label = "Error";

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -302,7 +302,19 @@ export function applyColor(colors: FacetColor[]): string {
     --facet-bars-${i}-unselected-contrast-hover: ${c.color};
     --facet-bars-${i}-muted: ${c.color};
     --facet-bars-${i}-muted-contrast: ${c.color};
-    --facet-bars-${i}-muted-contrast-hover: ${c.colorHover};`;
+    --facet-bars-${i}-muted-contrast-hover: ${c.colorHover};
+    --facet-terms-bar-${i}-normal: ${c.color};
+    --facet-terms-bar-${i}-normal-contrast: ${c.colorHover};
+    --facet-terms-bar-${i}-normal-contrast-hover: ${c.color};
+    --facet-terms-bar-${i}-selected: ${c.color};
+    --facet-terms-bar-${i}-selected-contrast: ${c.colorHover};
+    --facet-terms-bar-${i}-selected-contrast-hover: ${c.color};
+    --facet-terms-bar-${i}-unselected: ${c.colorHover};
+    --facet-terms-bar-${i}-unselected-contrast: ${c.colorHover};
+    --facet-terms-bar-${i}-unselected-contrast-hover: ${c.color};
+    --facet-terms-bar-${i}-muted: ${c.color};
+    --facet-terms-bar-${i}-muted-contrast: ${c.color};
+    --facet-terms-bar-${i}-muted-contrast-hover: ${c.colorHover};`;
   });
   return result;
 }
@@ -311,6 +323,9 @@ export function getSubSelectionValues(
   rowSelection: RowSelection,
   max: number
 ): number[][] {
+  if (!summary.baseline?.buckets) {
+    return [];
+  }
   const include = routeGetters.getRouteInclude(store);
   const hasFilterBuckets = hasFiltered(summary);
   if (!hasFilterBuckets && !rowSelection) {
@@ -380,6 +395,9 @@ export function rowLabelMatches(
 }
 
 export function getRowSelectionLabels(summary: VariableSummary): string[] {
+  if (!summary.baseline?.buckets) {
+    return [];
+  }
   const include = routeGetters.getRouteInclude(store);
   const selectedRows = include
     ? datasetGetters.getIncludedSelectedRowData(store)

--- a/public/util/summaries.ts
+++ b/public/util/summaries.ts
@@ -31,3 +31,10 @@ export function getPredictionResultSummary(requestId: string): VariableSummary {
     .getPredictionSummaries(store)
     .find((s) => getIDFromKey(s.key) === requestId);
 }
+
+export function getConfidenceSummary(solutionID: string): VariableSummary {
+  return resultGetters
+    .getConfidenceSummaries(store)
+    .find((s) => getIDFromKey(s.key) === solutionID);
+  return null;
+}


### PR DESCRIPTION
Closes #1962. Updates to the API to complete support of confidence facet information by adding confidence key (like error and prediction key) to the solution return and confidence route with a helper in model. Updated the confidence storage return to set numerical type as it's a 0 to 1 set of buckets. Updated the requests and results store and the summaries util to retrieve and store the confidence summary, then used that stored info in ResultFacets and updated the ResultGroup and FacetNumerical components and the facet and data util to handle the data and more importantly handle the case where no confidence data is set. Also added tentative table support for confidences with changes to the data util, but commented that out pending UX feedback. Also fixed missing color change functionality for categorical error facets by adding additional facet util code.