### PR TITLE
Webgl points

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -35,8 +35,8 @@
     </div>
     <div
       class="cluster-toggle"
-      :class="{ active: isSelectionMode }"
-      @click="isClustering = !isClustering"
+      :class="{ active: isClustering }"
+      @click="toggleClustering"
     >
       <a class="cluster-icon" title="Cluster" aria-label="Cluster Tiles">
         <i class="fa fa-object-group fa-lg" aria-hidden="true" />
@@ -203,7 +203,7 @@ export default Vue.extend({
     dataFields: Object as () => Dictionary<TableColumn>,
     summaries: Array as () => VariableSummary[],
     quadOpacity: { type: Number, default: 0.8 },
-    pointOpacity: { type: Number, default: 0.1 },
+    pointOpacity: { type: Number, default: 0.5 },
     zoomThreshold: { type: Number, default: 8 },
   },
 
@@ -241,7 +241,7 @@ export default Vue.extend({
       },
       selectionToolId: "selection-tool-layer",
       showExit: false,
-      pointSize: 3,
+      pointSize: 1,
       isClustering: false,
     };
   },
@@ -666,6 +666,12 @@ export default Vue.extend({
       this.isClustering = !this.isClustering;
       if (this.isClustering && this.map.getZoom() < this.zoomThreshold) {
         this.currentState = this.clusterState;
+        this.updateMapState();
+        return;
+      }
+      if (!this.isClustering && this.map.getZoom() < this.zoomThreshold) {
+        this.currentState = this.pointState;
+        this.updateMapState();
       }
     },
     /**
@@ -852,7 +858,7 @@ export default Vue.extend({
         const color = Color(area.color).rgb().object(); // convert hex color to rgb
         const maxVal = 255;
         // normalize color values
-        color.a = this.quadOpacity;
+        color.a = this.pointOpacity;
         color.r /= maxVal;
         color.g /= maxVal;
         color.b /= maxVal;
@@ -1104,8 +1110,15 @@ export default Vue.extend({
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
 }
-.geo-plot-container .selection-toggle:hover .cluster-icon:hover {
+.cluster-toggle:hover {
+  background-color: #f4f4f4;
+}
+.cluster-toggle.active {
+  color: #26b8d1;
+}
+.geo-plot-container .selection-toggle:hover {
   background-color: #f4f4f4;
 }
 
@@ -1124,10 +1137,7 @@ export default Vue.extend({
   position: absolute;
 }
 
-.geo-plot-container
-  .selection-toggle.active
-  .selection-toggle-control
-  .cluster-icon:hover {
+.geo-plot-container .selection-toggle.active .selection-toggle-control {
   color: #26b8d1;
 }
 

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -185,7 +185,7 @@ interface LumoPoint {
 }
 // Minimum pixels size of clickable target displayed on the map.
 const TARGETSIZE = 6;
-const clusterIcon = "fas fa-layer-group";
+
 export default Vue.extend({
   name: "geo-plot",
 
@@ -660,6 +660,15 @@ export default Vue.extend({
       this.map.fitToBounds(mapBounds);
     },
     /**
+     * toggle clustering
+     */
+    toggleClustering() {
+      this.isClustering = !this.isClustering;
+      if (this.isClustering && this.map.getZoom() < this.zoomThreshold) {
+        this.currentState = this.clusterState;
+      }
+    },
+    /**
      * on selection tool toggle disable or enable the quad interactions such as click or hover
      */
     toggleSelectionTool() {
@@ -1096,7 +1105,7 @@ export default Vue.extend({
   justify-content: center;
   align-items: center;
 }
-.geo-plot-container .selection-toggle:hover {
+.geo-plot-container .selection-toggle:hover .cluster-icon:hover {
   background-color: #f4f4f4;
 }
 
@@ -1115,7 +1124,10 @@ export default Vue.extend({
   position: absolute;
 }
 
-.geo-plot-container .selection-toggle.active .selection-toggle-control {
+.geo-plot-container
+  .selection-toggle.active
+  .selection-toggle-control
+  .cluster-icon:hover {
   color: #26b8d1;
 }
 

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -168,5 +168,5 @@ export function clearHighlight(router: VueRouter) {
 export function highlightsExist(router: VueRouter) {
   const route = routeGetters.getRoute(store);
   const highlights = "highlights";
-  return route.query[highlights] != null;
+  return route.query[highlights] !== null;
 }


### PR DESCRIPTION
closes #1991
- Added circle representation for the tiles in the webgl-geoplot.
- Uses fragment shader that converts points to circles
- Defines gl_PointSize relative to zoom
- Added point opacity prop defaults to 0.5
- Added cluster toggle button and icon that toggles between circles and cluster state (only sets zoomed out state if in tiled state)
![Peek 2020-10-20 20-01](https://user-images.githubusercontent.com/25306965/96657225-a6def980-130f-11eb-955b-38dc1c2b3047.gif)
