### PR TITLE
Fixed pixel circles, and fix for when only 1 tile is passed in.

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -242,7 +242,7 @@ export default Vue.extend({
       },
       selectionToolId: "selection-tool-layer",
       showExit: false,
-      pointSize: 1,
+      pointSize: 0.1,
       isClustering: false,
     };
   },
@@ -763,9 +763,9 @@ export default Vue.extend({
       // set mapBounds to a single tile to start
       const mapBounds = new lumo.Bounds(
         quads[0].x,
-        quads[1].x,
+        quads[0].x,
         quads[0].y,
-        quads[1].y
+        quads[0].y
       );
       // extend bounds to fit the entire quad set
       quads.forEach((q) => {


### PR DESCRIPTION
The get bounds was assuming we would always have two tiles. (Fixed to assume that when getBounds is called a minimum of 1 tile is available)
Changed circles to be the same pixel size regardless of zoom.