### PR TITLE
Geobounds group

### DIFF
--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -888,14 +888,12 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 		}
 		if variable.DistilRole == model.VarDistilRoleGrouping {
 			// if this is a group var, find the grouping ID col and use that
-			if variable.Grouping != nil {
+			if variable.Grouping != nil && variable.Grouping.GetIDCol() != "" {
 				groupVariable, err := findVariable(variable.Grouping.GetIDCol(), variables)
 				if err != nil {
 					return err
 				}
 				groupingVariableIndex = groupVariable.Index
-			} else {
-				groupingVariableIndex = variable.Index
 			}
 		}
 	}
@@ -1071,16 +1069,12 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 
 func findVariable(variableName string, variables []*model.Variable) (*model.Variable, error) {
 	// extract the variable instance from its name
-	var variable *model.Variable
 	for _, v := range variables {
 		if v.Name == variableName {
-			variable = v
+			return v, nil
 		}
 	}
-	if variable == nil {
-		return nil, errors.Errorf("can't find target variable instance %s", variableName)
-	}
-	return variable, nil
+	return nil, errors.Errorf("can't find target variable instance %s", variableName)
 }
 
 func findVariables(variableNames []string, variables []*model.Variable) ([]*model.Variable, error) {

--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -445,8 +445,19 @@ func CreateSatelliteGrouping() map[string]interface{} {
 	grouping["idCol"] = "group_id"
 	grouping["imageCol"] = "image_file"
 	grouping["type"] = model.MultiBandImageType
-	grouping["coordinate"] = "__geo_coordinates"
-	grouping["hidden"] = []string{"image_file", "band", "group_id", "coordinates"}
+	grouping["hidden"] = []string{"image_file", "band", "group_id"}
+
+	return grouping
+}
+
+// CreateGeoBoundsGrouping dumps the geobounds grouping structure into a map.
+// It assumes that the dataset has the same structure as during upload.
+func CreateGeoBoundsGrouping() map[string]interface{} {
+	grouping := map[string]interface{}{}
+	grouping["type"] = model.GeoBoundsType
+	grouping["coordinatesCol"] = "coordinates"
+	grouping["polygonCol"] = "__geo_coordinates"
+	grouping["hidden"] = []string{"coordinates", "__geo_coordinates"}
 
 	return grouping
 }

--- a/api/model/storage/elastic/variable.go
+++ b/api/model/storage/elastic/variable.go
@@ -243,10 +243,15 @@ func (s *Storage) parseGrouping(variable map[string]interface{}) (model.BaseGrou
 		if !ok {
 			return nil, errors.New("unable to parse remote sensing grouping")
 		}
+	} else if model.IsGeoBounds(groupingType) {
+		grouping = &model.GeoBoundsGrouping{}
+		ok = json.Struct(variable, grouping, model.VarGroupingField)
+		if !ok {
+			return nil, errors.New("unable to parse geobounds sensing grouping")
+		}
 	} else {
 		return nil, errors.Errorf("unrecognized grouping type '%s'", groupingType)
 	}
-
 	return grouping, nil
 }
 

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -125,14 +125,7 @@ func updateClusterFilter(metadataStorage api.MetadataStorage, dataset string, da
 		return err
 	}
 
-	if variable.IsGrouping() {
-		clusterCol, ok := api.GetClusterColFromGrouping(variable.Grouping)
-		if ok && dataMode == api.ClusterDataMode && api.HasClusterData(dataset, clusterCol, metadataStorage) {
-			filter.Key = clusterCol
-		} else {
-			filter.Key = variable.Grouping.GetIDCol()
-		}
-	}
+	api.UpdateFilterKey(metadataStorage, dataset, dataMode, filter, variable)
 
 	return nil
 }

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -198,19 +198,19 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 
 			field = NewTimeSeriesField(s, dataset, storageName, tsg.ClusterCol, variable.Name, variable.DisplayName, variable.Type,
 				variable.Grouping.GetIDCol(), timeColVar.Name, timeColVar.Type, valueColVar.Name, valueColVar.Type)
-
 		} else if model.IsGeoCoordinate(variable.Grouping.GetType()) {
 			gcg := variable.Grouping.(*model.GeoCoordinateGrouping)
 			field = NewCoordinateField(variable.Name, s, dataset, storageName, gcg.XCol, gcg.YCol, variable.DisplayName, variable.Grouping.GetType(), "")
 		} else if model.IsMultiBandImage(variable.Grouping.GetType()) {
 			rsg := variable.Grouping.(*model.MultiBandImageGrouping)
 			field = NewMultiBandImageField(s, dataset, storageName, rsg.ClusterCol, variable.Name, variable.DisplayName, variable.Grouping.GetType(), rsg.IDCol, rsg.BandCol)
+		} else if model.IsGeoBounds(variable.Type) {
+			gbg := variable.Grouping.(*model.GeoBoundsGrouping)
+			field = NewBoundsField(s, dataset, storageName, gbg.CoordinatesCol, gbg.PolygonCol, variable.Name, variable.DisplayName, variable.Grouping.GetType(), "")
 		} else {
 			return nil, errors.Errorf("variable grouping `%s` of type `%s` does not support summary", variable.Grouping.GetIDCol(), variable.Grouping.GetType())
 		}
-
 	} else {
-
 		// if timeseries mode, get the grouping field and use that for counts
 		countCol := ""
 		if mode == api.TimeseriesMode || mode == api.MultiBandImageMode {
@@ -237,8 +237,6 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 			field = NewImageField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type, countCol)
 		} else if model.IsDateTime(variable.Type) {
 			field = NewDateTimeField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type, countCol)
-		} else if model.IsGeoBounds(variable.Type) {
-			field = NewBoundsField(s, dataset, storageName, variable.Name, variable.DisplayName, variable.Type, countCol)
 		} else {
 			return nil, errors.Errorf("variable `%s` of type `%s` does not support summary", variable.Name, variable.Type)
 		}

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -72,7 +72,7 @@ type IngestTaskConfig struct {
 // IngestSteps is a collection of parameters that specify ingest behaviour.
 type IngestSteps struct {
 	ClassificationOverwrite bool
-	RawGrouping             map[string]interface{}
+	RawGroupings            []map[string]interface{}
 }
 
 // NewDefaultClient creates a new client to use when submitting pipelines.
@@ -243,9 +243,9 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	log.Infof("finished ingesting the dataset")
 
 	// set the known grouping information
-	if steps.RawGrouping != nil {
+	if steps.RawGroupings != nil {
 		log.Infof("creating groupings in metadata")
-		err = SetGroups(datasetID, steps.RawGrouping, metaStorage, config)
+		err = SetGroups(datasetID, steps.RawGroupings, metaStorage, config)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to set grouping")
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/davecgh/go-spew v1.1.1
-	github.com/gofrs/uuid v3.2.0+incompatible
+	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/websocket v1.4.0
 	github.com/h2non/filetype v1.0.12
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201016205609-a9feaf54f763
+	github.com/uncharted-distil/distil-compute v0.0.0-20201021191111-30889b4472be
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
+github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -189,10 +191,13 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/uncharted-distil/distil v0.0.0-20201010010447-8f973f558d61/go.mod h1:sZt65getRqdzhvaypB/Lkp0FveSC//5gR4y1HFdgvKs=
+github.com/uncharted-distil/distil v0.0.0-20201021180035-0b69a96b9651/go.mod h1:W5mxcVpmyx4BhROA9eb6+ISbwt8refZTe+9q5Z8tDe4=
 github.com/uncharted-distil/distil-compute v0.0.0-20201007042553-ed119f8342c4 h1:dCq41nxwZOPEjtuJKOSyehJl8KvEbnahOXeNttELnio=
 github.com/uncharted-distil/distil-compute v0.0.0-20201007042553-ed119f8342c4/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
 github.com/uncharted-distil/distil-compute v0.0.0-20201016205609-a9feaf54f763 h1:kAmCgkXqQFwiuEngV4lYGnCgmmvZoKiNhX4KBxwoh8Q=
 github.com/uncharted-distil/distil-compute v0.0.0-20201016205609-a9feaf54f763/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
+github.com/uncharted-distil/distil-compute v0.0.0-20201021191111-30889b4472be h1:l/ZzCQkZSmyL/pnDIp1EShDxhIZQn9YavcnUpjhXi64=
+github.com/uncharted-distil/distil-compute v0.0.0-20201021191111-30889b4472be/go.mod h1:8ki5yjJDKCJQvLHD3p7TLL1gsXu95hD/JaF9jqvnHps=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=


### PR DESCRIPTION
Geo bounds were stored in the system as a real vector variable, as well as an associated PostGIS polygon string variable that was marked as metadata.  These were not implemented as a group, which makes it difficult to optionally add image bounds as feature data a model can train on.  This update creates a new GeoBounds group that contains both the original realVector variable that can be re-typed by a user, and when created, a PostGIS polygon string that is for internal use.  The GeoBounds group variable is then used to expose the image bounds to the client.