### PR TITLE
1610 adding categorical feature update timeseries grouping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday v2.0.0+incompatible
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/uncharted-distil/distil-compute v0.0.0-20201016205609-a9feaf54f763
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a

--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -139,7 +139,7 @@ export default Vue.extend({
         const isCategorical: boolean = group.type === "categorical";
         if (this.isTimeseries && isCategorical) {
           // Change the meaning of the button as this action is different than the default one.
-          trainingElem.textContent = "Add to Timeserie";
+          trainingElem.textContent = "Add to Timeseries";
         }
 
         trainingElem.addEventListener("click", async () => {

--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -173,7 +173,7 @@ export default Vue.extend({
           });
 
           if (this.isTimeseries && isCategorical) {
-            // Fetch the grouping of timeserie
+            // Fetch the information of the timeseries grouping
             const currentGrouping = datasetGetters
               .getGroupings(this.$store)
               .find((v) => v.colName === targetName)?.grouping;

--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -40,14 +40,13 @@
 <script lang="ts">
 import Vue from "vue";
 import { overlayRouteEntry } from "../util/routes";
-import { Variable, VariableSummary, Task } from "../store/dataset/index";
+import { Variable, VariableSummary } from "../store/dataset/index";
 import {
   actions as datasetActions,
   getters as datasetGetters,
 } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
 import {
-  filterSummariesByDataset,
   getVariableSummariesByState,
   NUM_PER_PAGE,
   searchVariables,
@@ -55,7 +54,6 @@ import {
 import { AVAILABLE_TRAINING_VARS_INSTANCE } from "../store/route/index";
 import { Group } from "../util/facets";
 import VariableFacets from "./facets/VariableFacets.vue";
-import { Dictionary } from "vue-router/types/router";
 import { actions as appActions } from "../store/app/module";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 
@@ -125,7 +123,10 @@ export default Vue.extend({
       return (group: Group) => {
         const trainingElem = document.createElement("button");
         trainingElem.className += "btn btn-sm btn-outline-secondary mb-2";
-        trainingElem.innerHTML = "Add";
+        trainingElem.textContent = "Add";
+
+        // In the case of a categorical variable with a timeserie selected.
+
         trainingElem.addEventListener("click", async () => {
           // log UI event on server
           appActions.logUserEvent(this.$store, {
@@ -169,16 +170,20 @@ export default Vue.extend({
         subActivity: SubActivity.DATA_TRANSFORMATION,
         details: {},
       });
+
       const training = routeGetters.getDecodedTrainingVariableNames(
         this.$store
       );
+
       this.availableVariables.forEach((variable) => {
         training.push(variable.colName);
       });
+
       const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
         training: training.join(","),
         availableTrainingVarsPage: 1,
       });
+
       this.$router.push(entry).catch((err) => console.warn(err));
     },
   },
@@ -190,6 +195,7 @@ export default Vue.extend({
   display: flex;
   flex-direction: column;
 }
+
 .available-variables-menu {
   display: flex;
   justify-content: space-between;

--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     class="available-training-variables"
-    v-bind:class="{ included: includedActive, excluded: !includedActive }"
+    :class="{ included: includedActive, excluded: !includedActive }"
   >
     <p class="nav-link font-weight-bold">
       Available Features
-      <i class="float-right fa fa-angle-right fa-lg"></i>
+      <i class="float-right fa fa-angle-right fa-lg" />
     </p>
     <variable-facets
       ref="facets"
@@ -28,9 +28,9 @@
           {{ subtitle }}
         </div>
         <div v-if="availableVariableSummaries.length > 0">
-          <b-button size="sm" variant="outline-secondary" @click="addAll"
-            >Add All</b-button
-          >
+          <b-button size="sm" variant="outline-secondary" @click="addAll">
+            Add All
+          </b-button>
         </div>
       </div>
     </variable-facets>
@@ -70,12 +70,15 @@ export default Vue.extend({
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);
     },
+
     includedActive(): boolean {
       return routeGetters.getRouteInclude(this.$store);
     },
+
     availableTrainingVarsSearch(): string {
       return routeGetters.getRouteAvailableTrainingVarsSearch(this.$store);
     },
+
     availableVariableSummaries(): VariableSummary[] {
       const pageIndex = routeGetters.getRouteAvailableTrainingVarsPage(
         this.$store
@@ -94,27 +97,32 @@ export default Vue.extend({
 
       return currentSummaries;
     },
+
     availableVariables(): Variable[] {
       return searchVariables(
         routeGetters.getAvailableVariables(this.$store),
         this.availableTrainingVarsSearch
       );
     },
+
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);
     },
+
     subtitle(): string {
       return `${this.availableVariables.length} features available`;
     },
+
     numRowsPerPage(): number {
       return NUM_PER_PAGE;
     },
+
     instanceName(): string {
       return AVAILABLE_TRAINING_VARS_INSTANCE;
     },
-    html(): (group: Group) => HTMLDivElement {
+
+    html(): (group: Group) => HTMLElement {
       return (group: Group) => {
-        const container = document.createElement("div");
         const trainingElem = document.createElement("button");
         trainingElem.className += "btn btn-sm btn-outline-secondary mb-2";
         trainingElem.innerHTML = "Add";
@@ -146,8 +154,8 @@ export default Vue.extend({
           });
           this.$router.push(entry).catch((err) => console.warn(err));
         });
-        container.appendChild(trainingElem);
-        return container;
+
+        return trainingElem;
       };
     },
   },
@@ -177,7 +185,7 @@ export default Vue.extend({
 });
 </script>
 
-<style>
+<style scoped>
 .available-training-variables {
   display: flex;
   flex-direction: column;

--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -151,13 +151,13 @@ export default Vue.extend({
             details: { feature: group.colName },
           });
 
+          const dataset = routeGetters.getRouteDataset(this.$store);
+          const targetName = routeGetters.getRouteTargetVariable(this.$store);
+
           // get an updated view of the training data list
           const training = routeGetters
             .getDecodedTrainingVariableNames(this.$store)
             .concat([group.colName]);
-
-          const dataset = routeGetters.getRouteDataset(this.$store);
-          const targetName = routeGetters.getRouteTargetVariable(this.$store);
 
           // update task based on the current training data
           const taskResponse = await datasetActions.fetchTask(this.$store, {

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -168,7 +168,7 @@ export default Vue.extend({
       // In the case of timeseries, we add their Min/Max/Mean.
       if (this.isTimeseries) {
         items = items?.map((item) => {
-          const timeserieId = item[this.timeseriesGroupings[0].idCol].value;
+          const timeserieId = item[this.timeseriesGroupings?.[0]?.idCol]?.value;
           const minMaxMean = this.timeseriesInfo(timeserieId);
           return { ...item, ...minMaxMean };
         });

--- a/public/components/TrainingVariables.vue
+++ b/public/components/TrainingVariables.vue
@@ -156,13 +156,13 @@ export default Vue.extend({
         // the target variable contains grouping information (Timeseries/Geocoordinate)
         if (!!targetVar?.grouping) {
           let hideRemoveButton = false;
-          const seriesId = targetVar.grouping.subIds;
+          const seriesIds = targetVar.grouping.subIds;
 
-          // Check their is any series IDs
-          if (seriesId.length > 0) {
+          // Check there is any series IDs
+          if (seriesIds.length > 0) {
             // Make sure to show the button for all of them.
-            if (seriesId.length !== 1) {
-              hideRemoveButton = !seriesId.some((v) => v === group.colName);
+            if (seriesIds.length !== 1) {
+              hideRemoveButton = !seriesIds.some((v) => v === group.colName);
             }
             // unless there is only one series ID, then we hide the remove button.
             else {
@@ -179,9 +179,9 @@ export default Vue.extend({
         // Create the remove button
         const removeBtn = document.createElement("button");
         removeBtn.className += "btn btn-sm btn-outline-secondary mr-1 mb-2";
-        removeBtn.innerHTML = "Remove";
+        removeBtn.textContent = "Remove";
 
-        // In the case of a categorical variable with a timeserie selected.
+        // Is the variable of categorical type
         const isCategorical: boolean = group.type === "categorical";
 
         if (this.isTimeseries && isCategorical) {

--- a/public/components/TrainingVariables.vue
+++ b/public/components/TrainingVariables.vue
@@ -5,7 +5,7 @@
   >
     <p class="nav-link font-weight-bold">
       Features to Model
-      <i class="float-right fa fa-angle-right fa-lg"></i>
+      <i class="float-right fa fa-angle-right fa-lg" />
     </p>
     <variable-facets
       ref="facets"
@@ -27,13 +27,13 @@
           {{ subtitle }}
         </div>
         <div v-if="isAllTrainingVariablesRemovable">
-          <b-button size="sm" variant="outline-secondary" @click="removeAll"
-            >Remove All</b-button
-          >
+          <b-button size="sm" variant="outline-secondary" @click="removeAll">
+            Remove All
+          </b-button>
         </div>
       </div>
       <div v-if="trainingVariableSummaries.length === 0">
-        <i class="no-selections-icon fa fa-arrow-circle-left"></i>
+        <i class="no-selections-icon fa fa-arrow-circle-left" />
       </div>
     </variable-facets>
   </div>
@@ -51,6 +51,7 @@ import {
 import { TRAINING_VARS_INSTANCE } from "../store/route/index";
 import { Group } from "../util/facets";
 import {
+  getComposedVariableKey,
   NUM_PER_PAGE,
   getVariableSummariesByState,
   searchVariables,
@@ -115,10 +116,7 @@ export default Vue.extend({
       return currentSummaries;
     },
 
-    /**
-     * Check if all the training variables are removable.
-     * @return {Boolean}
-     */
+    /* Check if all the training variables are removable. */
     isAllTrainingVariablesRemovable(): boolean {
       // Fetch the variables in the timeseries grouping.
       const timeseriesGrouping = datasetGetters.getTimeseriesGroupingVariables(
@@ -134,6 +132,10 @@ export default Vue.extend({
       return trainingVariables.length > 0;
     },
 
+    isTimeseries(): boolean {
+      return routeGetters.isTimeseries(this.$store);
+    },
+
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);
     },
@@ -144,35 +146,51 @@ export default Vue.extend({
       return TRAINING_VARS_INSTANCE;
     },
 
-    html(): (Group) => HTMLDivElement {
+    html(): (Group) => HTMLElement {
       return (group: Group) => {
-        // exclude remove button if the var is an id / sub-id of the
-        // timeseries grouping.
-
+        // get the target variable information
         const targetVar = this.variables.find((v) => {
           return v.colName === this.target;
         });
 
-        if (targetVar?.grouping) {
-          let isGroupingID = false;
-          if (targetVar.grouping.subIds.length > 0) {
-            isGroupingID = !!targetVar.grouping.subIds.find((v) => {
-              return v === group.colName;
-            });
+        // the target variable contains grouping information (Timeseries/Geocoordinate)
+        if (!!targetVar?.grouping) {
+          let hideRemoveButton = false;
+          const seriesId = targetVar.grouping.subIds;
+
+          // Check their is any series IDs
+          if (seriesId.length > 0) {
+            // Make sure to show the button for all of them.
+            if (seriesId.length !== 1) {
+              hideRemoveButton = !seriesId.some((v) => v === group.colName);
+            }
+            // unless there is only one series ID, then we hide the remove button.
+            else {
+              hideRemoveButton = true;
+            }
           } else {
-            isGroupingID = targetVar.grouping.idCol === group.key;
+            hideRemoveButton = targetVar.grouping.idCol === group.key;
           }
-          if (isGroupingID) {
-            return;
-          }
+
+          // Hide the remove button
+          if (hideRemoveButton) return;
         }
 
-        const container = document.createElement("div");
-        const remove = document.createElement("button");
-        remove.className += "btn btn-sm btn-outline-secondary mr-1 mb-2";
-        remove.innerHTML = "Remove";
+        // Create the remove button
+        const removeBtn = document.createElement("button");
+        removeBtn.className += "btn btn-sm btn-outline-secondary mr-1 mb-2";
+        removeBtn.innerHTML = "Remove";
 
-        remove.addEventListener("click", async () => {
+        // In the case of a categorical variable with a timeserie selected.
+        const isCategorical: boolean = group.type === "categorical";
+
+        if (this.isTimeseries && isCategorical) {
+          // Change the meaning of the button as this action is different than the default one.
+          removeBtn.textContent = "Remove from Timeseries";
+        }
+
+        removeBtn.addEventListener("click", async () => {
+          // log UI event on server
           appActions.logUserEvent(this.$store, {
             feature: Feature.REMOVE_FEATURE,
             activity: Activity.DATA_PREPARATION,
@@ -180,6 +198,10 @@ export default Vue.extend({
             details: { feature: group.colName },
           });
 
+          const dataset = routeGetters.getRouteDataset(this.$store);
+          const targetName = routeGetters.getRouteTargetVariable(this.$store);
+
+          // get an updated view of the training data list
           const training = routeGetters.getDecodedTrainingVariableNames(
             this.$store
           );
@@ -187,20 +209,42 @@ export default Vue.extend({
 
           // update task based on the current training data
           const taskResponse = await datasetActions.fetchTask(this.$store, {
-            dataset: routeGetters.getRouteDataset(this.$store),
-            targetName: routeGetters.getRouteTargetVariable(this.$store),
+            dataset,
+            targetName,
             variableNames: training,
           });
 
+          // update route with training data
           const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
             training: training.join(","),
             task: taskResponse.data.task.join(","),
           });
+
+          if (this.isTimeseries && isCategorical) {
+            // Fetch the information of the timeseries grouping
+            const currentGrouping = datasetGetters
+              .getGroupings(this.$store)
+              .find((v) => v.colName === targetName)?.grouping;
+
+            // Simply duplicate its grouping information and remove the series ID
+            const grouping = JSON.parse(JSON.stringify(currentGrouping));
+            grouping.subIds = grouping.subIds.filter(
+              (subId) => subId !== group.colName
+            );
+            grouping.idCol = getComposedVariableKey(grouping.subIds);
+
+            // Request to update the timeseries grouping without this series ID
+            await datasetActions.updateGrouping(this.$store, {
+              variable: targetName,
+              grouping,
+            });
+          }
+
           this.$router.push(entry).catch((err) => console.warn(err));
           removeFiltersByName(this.$router, group.colName);
         });
-        container.appendChild(remove);
-        return container;
+
+        return removeBtn;
       };
     },
   },
@@ -231,15 +275,17 @@ export default Vue.extend({
 });
 </script>
 
-<style>
+<style scoped>
 .training-variables {
   display: flex;
   flex-direction: column;
 }
+
 .no-selections-icon {
   color: #32cd32;
   font-size: 46px;
 }
+
 .training-variables-menu {
   display: flex;
   justify-content: space-between;

--- a/public/components/facets/FacetCategorical.vue
+++ b/public/components/facets/FacetCategorical.vue
@@ -264,6 +264,7 @@ export default Vue.extend({
         return _.isFunction(this.html)
           ? this.html({
               colName: this.summary.key,
+              type: "categorical",
             })
           : this.html;
       }

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -643,6 +643,24 @@ export const actions = {
     }
   },
 
+  async updateGrouping(
+    context: DatasetContext,
+    args: { variable: string; grouping: Grouping }
+  ): Promise<any> {
+    if (!validateArgs(args, ["dataset", "grouping"])) {
+      return null;
+    }
+
+    const grouping = args.grouping;
+    const dataset = grouping.dataset;
+
+    // Remove the existing grouping
+    await axios.post(`/distil/remove-grouping/${dataset}/${args.variable}`, {});
+
+    // Reset it with an extra idCol
+    await this.setGrouping(context, { dataset, grouping });
+  },
+
   async setVariableType(
     context: DatasetContext,
     args: { dataset: string; field: string; type: string }

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -647,18 +647,23 @@ export const actions = {
     context: DatasetContext,
     args: { variable: string; grouping: Grouping }
   ): Promise<any> {
-    if (!validateArgs(args, ["dataset", "grouping"])) {
+    if (!validateArgs(args, ["variable", "grouping"])) {
       return null;
     }
 
+    const variable = args.variable;
     const grouping = args.grouping;
     const dataset = grouping.dataset;
 
-    // Remove the existing grouping
-    await axios.post(`/distil/remove-grouping/${dataset}/${args.variable}`, {});
+    try {
+      // Remove the existing grouping
+      await axios.post(`/distil/remove-grouping/${dataset}/${variable}`, {});
 
-    // Reset it with an extra idCol
-    await this.setGrouping(context, { dataset, grouping });
+      // Recreate it with an extra idCol
+      await actions.setGrouping(context, { dataset, grouping });
+    } catch (error) {
+      console.error(error);
+    }
   },
 
   async setVariableType(

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -85,6 +85,7 @@ export const actions = {
   deleteVariable: dispatch(moduleActions.deleteVariable),
   setGrouping: dispatch(moduleActions.setGrouping),
   removeGrouping: dispatch(moduleActions.removeGrouping),
+  updateGrouping: dispatch(moduleActions.updateGrouping),
   uploadDataFile: dispatch(moduleActions.uploadDataFile),
   // variables
   fetchVariables: dispatch(moduleActions.fetchVariables),

--- a/public/views/VariableGrouping.vue
+++ b/public/views/VariableGrouping.vue
@@ -26,45 +26,80 @@
         Integer, Date/Time or Decimal Type.
       </p>
     </b-modal>
-    <b-row class="flex-0-nav"></b-row>
 
-    <b-row class="flex-shrink-0 align-items-center bg-white">
-      <b-col v-if="isTimeseries" cols="4" class="offset-md-1">
-        <h5 class="header-label">Configure Time Series</h5>
-      </b-col>
-      <b-col v-if="isGeocoordinate" cols="4" class="offset-md-1">
-        <h5 class="header-label">Configure Geocoordinate</h5>
-      </b-col>
-    </b-row>
+    <!-- Spacer for the App.vue <navigation> component -->
+    <div class="row flex-0-nav" />
 
-    <b-container class="mt-3 h-100">
+    <!-- Title of the page -->
+    <header class="header row justify-content-center">
+      <b-col cols="12" md="10">
+        <h5 class="header-title">
+          Configure
+          <span v-if="isTimeseries">Time Series</span>
+          <span v-else>Geocoordinate</span>
+        </h5>
+      </b-col>
+    </header>
+
+    <!-- Information -->
+    <section class="sub-header row justify-content-center">
+      <b-col cols="12" md="10">
+        <template v-if="isTimeseries">
+          To predict a value over time <strong>(forecasting)</strong> your
+          target should be a <strong>timeseries.</strong><br />
+          Select a <strong>time</strong> column, a <strong>value</strong> column
+          and if available, optionally add one or more
+          <strong>series id</strong> column(s) to create multiple timeseries.
+        </template>
+        <template v-else>
+          If your data contains geocoordinate data (<strong
+            >latitude, longitude</strong
+          >) in separate columns, select those to display the location data on a
+          map.
+        </template>
+      </b-col>
+    </section>
+
+    <!-- Form -->
+    <section class="mt-3 container">
       <b-row>
-        <b-col v-if="isTimeseries" cols="12">
-          <p>
-            To predict a value over time <strong>(forecasting)</strong> your
-            target should be a <strong>timeseries.</strong><br />
-            Select a <strong>time</strong> column, a
-            <strong>value</strong> column and if available, optionally add one
-            or more <strong>series id</strong> column(s) to create multiple
-            timeseries.
-          </p>
-        </b-col>
-        <b-col v-if="isGeocoordinate" cols="12">
-          <p>
-            If your data contains geocoordinate data (<strong
-              >latitude, longitude</strong
-            >) in separate columns, select those to display the location data on
-            a map.
-          </p>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="6" v-if="isTimeseries">
-          <template v-if="idCols.length > 0">
+        <b-col cols="6">
+          <!-- X column -->
+          <b-row class="mt-1 mb-1">
+            <b-col cols="5">
+              <b v-if="isTimeseries">Time Column:</b>
+              <b v-else>Longitude Column:</b>
+            </b-col>
+            <b-col cols="7">
+              <b-form-select
+                v-model="xCol"
+                :options="xColOptions"
+                @input="onChange"
+              />
+            </b-col>
+          </b-row>
+
+          <!-- Y column -->
+          <b-row class="mt-1 mb-1">
+            <b-col cols="5">
+              <b v-if="isTimeseries">Value Column:</b>
+              <b v-else>Latitude Column:</b>
+            </b-col>
+            <b-col cols="7">
+              <b-form-select
+                v-model="yCol"
+                :options="yColOptions"
+                @input="onChange"
+              />
+            </b-col>
+          </b-row>
+
+          <!-- ID columns -->
+          <template v-if="isTimeseries && idCols.length > 0">
             <b-row
-              class="mt-1 mb-1"
               v-for="(idCol, index) in idCols"
               :key="idCol.value"
+              class="mt-1 mb-1"
             >
               <b-col cols="5">
                 <template
@@ -75,126 +110,69 @@
               </b-col>
 
               <b-col
+                v-if="idOptions(idCol.value).length !== 0"
                 cols="7"
                 class="d-flex align-content-center"
-                v-if="idOptions(idCol.value).length !== 0"
               >
                 <b-form-select
-                  class="mr-auto"
                   v-model="idCol.value"
+                  class="mr-auto"
                   :options="idOptions(idCol.value)"
                   @input="onIdChange"
                 />
                 <b-button
+                  v-if="idCol.value"
                   class="ml-1"
                   variant="outline-danger"
-                  v-if="idCol.value"
                   title="Clear Selection"
                   @click="removeIdCol(idCol.value)"
                 >
-                  <i class="fa fa-times-circle"></i>
+                  <i class="fa fa-times-circle" />
                 </b-button>
               </b-col>
             </b-row>
           </template>
-
-          <b-row class="mt-1 mb-1">
-            <b-col cols="5">
-              <b>Time Column:</b>
-            </b-col>
-
-            <b-col cols="7">
-              <b-form-select
-                v-model="xCol"
-                :options="xColOptions"
-                @input="onChange"
-              />
-            </b-col>
-          </b-row>
-
-          <b-row class="mt-1 mb-1">
-            <b-col cols="5">
-              <b>Value Column:</b>
-            </b-col>
-
-            <b-col cols="7">
-              <b-form-select
-                v-model="yCol"
-                :options="yColOptions"
-                @input="onChange"
-              />
-            </b-col>
-          </b-row>
-        </b-col>
-        <b-col cols="6" v-if="isGeocoordinate">
-          <b-row class="mt-1 mb-1">
-            <b-col cols="5">
-              <b>Longitude Column:</b>
-            </b-col>
-
-            <b-col cols="7">
-              <b-form-select
-                v-model="xCol"
-                :options="xColOptions"
-                @input="onChange"
-              />
-            </b-col>
-          </b-row>
-
-          <b-row class="mt-1 mb-1">
-            <b-col cols="5">
-              <b>Latitude Column:</b>
-            </b-col>
-
-            <b-col cols="7">
-              <b-form-select
-                v-model="yCol"
-                :options="yColOptions"
-                @input="onChange"
-              />
-            </b-col>
-          </b-row>
         </b-col>
 
+        <!-- Facet Preview -->
         <b-col cols="6">
           <div v-if="isReady && previewSummary && previewSummary.baseline">
             <component
-              :summary="previewSummary"
               :is="getFacetByType(groupingType)"
-            >
-            </component>
+              :summary="previewSummary"
+            />
           </div>
           <div v-else>
-            <facet-loading :summary="{ label: 'pending' }"> </facet-loading>
+            <facet-loading :summary="{ label: 'pending' }" />
           </div>
         </b-col>
       </b-row>
 
+      <!-- Buttons -->
       <b-row align-h="center">
         <b-btn
-          class="mt-3 var-grouping-button"
+          class="mt-3 grouping-button"
           variant="outline-secondary"
           :disabled="isPending"
           @click="onClose"
         >
           <div class="row justify-content-center">
-            <i class="fa fa-times-circle fa-2x mr-2"></i>
+            <i class="fa fa-times-circle fa-2x mr-2" />
             <b>Cancel</b>
           </div>
         </b-btn>
         <b-btn
-          class="mt-3 var-grouping-button"
+          class="mt-3 grouping-button"
           variant="primary"
           :disabled="isPending || !isReady"
           @click="onGroup"
         >
           <div class="row justify-content-center">
-            <i class="fa fa-check-circle fa-2x mr-2"></i>
+            <i class="fa fa-check-circle fa-2x mr-2" />
             <b>Submit</b>
           </div>
         </b-btn>
       </b-row>
-
       <b-row class="grouping-progress">
         <b-progress
           v-if="isPending"
@@ -202,9 +180,9 @@
           variant="secondary"
           striped
           :animated="true"
-        ></b-progress>
+        />
       </b-row>
-    </b-container>
+    </section>
   </div>
 </template>
 
@@ -280,22 +258,28 @@ export default Vue.extend({
       isUpdating: false,
     };
   },
+
   computed: {
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);
     },
+
     target(): string {
       return routeGetters.getRouteTargetVariable(this.$store);
     },
+
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);
     },
+
     groupingType(): string {
       return routeGetters.getGroupingType(this.$store);
     },
+
     isGeocoordinate(): boolean {
       return this.groupingType === GEOCOORDINATE_TYPE;
     },
+
     isTimeseries(): boolean {
       return this.groupingType === TIMESERIES_TYPE;
     },
@@ -372,9 +356,9 @@ export default Vue.extend({
         (v) => v.indexOf(this.xCol) > -1 && v.indexOf(this.yCol) > -1
       )[0];
       const minKey = minimumRouteKey();
-      const pv = summaryDictionary?.[previewKey]?.[minKey];
-      return pv;
+      return summaryDictionary?.[previewKey]?.[minKey];
     },
+
     showGeoModal: {
       get(): boolean {
         return (
@@ -388,6 +372,7 @@ export default Vue.extend({
         console.info("insufficient geocoordinate variables");
       },
     },
+
     showTimeModal: {
       get(): boolean {
         return (
@@ -435,7 +420,8 @@ export default Vue.extend({
       }
       return [];
     },
-    onIdChange(arg) {
+
+    onIdChange() {
       const values = this.idCols.map((c) => c.value).filter((v) => v);
       if (values.length === this.prevIdCols) {
         return;
@@ -445,6 +431,7 @@ export default Vue.extend({
       this.prevIdCols++;
       this.onChange();
     },
+
     removeIdCol(value) {
       this.idCols = this.idCols.filter((idCol) => idCol.value !== value);
       this.prevIdCols--;
@@ -454,26 +441,33 @@ export default Vue.extend({
         this.clearGrouping();
       }
     },
+
     isIDCol(arg): boolean {
       return !!this.idCols.find((id) => id.value === arg);
     },
+
     isXCol(arg): boolean {
       return arg === this.xCol;
     },
+
     isYCol(arg): boolean {
       return arg === this.yCol;
     },
+
     isOtherCol(arg): boolean {
       return this.other.indexOf(arg) !== -1;
     },
+
     onChange() {
       if (this.isReady) {
         this.submitGrouping(false);
       }
     },
+
     onGroup() {
       this.submitGrouping(true);
     },
+
     getHiddenCols(idCol) {
       const hiddenCols = [this.xCol, this.yCol];
       if (idCol !== null) {
@@ -481,9 +475,11 @@ export default Vue.extend({
       }
       return hiddenCols;
     },
+
     async submitGrouping(gotoTarget: boolean) {
       await this.clearGrouping();
       this.isUpdating = true;
+
       // Create a list of id values, filtering out the empty entry
       const ids = this.idCols.map((c) => c.value).filter((v) => v);
 
@@ -541,12 +537,13 @@ export default Vue.extend({
 });
 </script>
 
-<style>
-.var-grouping-button {
+<style scoped>
+.grouping-button {
   margin: 0 8px;
   width: 25% !important;
   line-height: 32px !important;
 }
+
 .grouping-progress {
   margin: 6px 10%;
 }


### PR DESCRIPTION
This PR is my smallest iteration to get the job done. The groupings might need a cleaning at some point, as what I've done looks more like a hack than an enhancement.

- Create a `updateGrouping()` action that deletes the current grouping and create a new one.

- When the user is selecting features, if the target variable is a time series: all categorical variables **Add** button change to **Add to Timeserie** and will call `updateGrouping()` with current grouping information taken from the store.

- Clean up the **VariableGrouping** page.