### PR TITLE
ES Dataset Storage Field Names

### DIFF
--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -45,19 +45,19 @@ type RawDataset struct {
 
 // Dataset represents a decsription of a dataset.
 type Dataset struct {
-	ID              string                 `json:"datasetID"`
-	Name            string                 `json:"datasetName"`
+	ID              string                 `json:"id"`
+	Name            string                 `json:"name"`
 	StorageName     string                 `json:"storageName"`
 	Folder          string                 `json:"datasetFolder"`
 	Description     string                 `json:"description"`
 	Summary         string                 `json:"summary"`
-	SummaryML       string                 `json:"summaryMachine"`
+	SummaryML       string                 `json:"summaryML"`
 	Variables       []*model.Variable      `json:"variables"`
 	NumRows         int64                  `json:"numRows"`
 	NumBytes        int64                  `json:"numBytes"`
 	Provenance      string                 `json:"provenance"`
 	Source          metadata.DatasetSource `json:"source"`
-	JoinSuggestions []*JoinSuggestion      `json:"datasetOrigins"`
+	JoinSuggestions []*JoinSuggestion      `json:"joinSuggestion"`
 	JoinScore       float64                `json:"joinScore"`
 	Type            DatasetType            `json:"type"`
 	LearningDataset string                 `json:"learningDataset"`

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -45,19 +45,19 @@ type RawDataset struct {
 
 // Dataset represents a decsription of a dataset.
 type Dataset struct {
-	ID              string                 `json:"id"`
-	Name            string                 `json:"name"`
+	ID              string                 `json:"datasetID"`
+	Name            string                 `json:"datasetName"`
 	StorageName     string                 `json:"storageName"`
 	Folder          string                 `json:"datasetFolder"`
 	Description     string                 `json:"description"`
 	Summary         string                 `json:"summary"`
-	SummaryML       string                 `json:"summaryML"`
+	SummaryML       string                 `json:"summaryMachine"`
 	Variables       []*model.Variable      `json:"variables"`
 	NumRows         int64                  `json:"numRows"`
 	NumBytes        int64                  `json:"numBytes"`
 	Provenance      string                 `json:"provenance"`
 	Source          metadata.DatasetSource `json:"source"`
-	JoinSuggestions []*JoinSuggestion      `json:"joinSuggestion"`
+	JoinSuggestions []*JoinSuggestion      `json:"datasetOrigins"`
 	JoinScore       float64                `json:"joinScore"`
 	Type            DatasetType            `json:"type"`
 	LearningDataset string                 `json:"learningDataset"`

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -40,7 +40,24 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 
 // UpdateDataset updates a dataset already stored in ES.
 func (s *Storage) UpdateDataset(dataset *api.Dataset) error {
-	bytes, err := json.Marshal(dataset)
+	source := map[string]interface{}{
+		"datasetName":     dataset.Name,
+		"datasetID":       dataset.ID,
+		"storageName":     dataset.StorageName,
+		"description":     dataset.Description,
+		"summary":         dataset.Summary,
+		"summaryMachine":  dataset.SummaryML,
+		"numRows":         dataset.NumRows,
+		"numBytes":        dataset.NumBytes,
+		"variables":       dataset.Variables,
+		"datasetFolder":   dataset.Folder,
+		"source":          dataset.Source,
+		"datasetOrigins":  dataset.JoinSuggestions,
+		"type":            dataset.Type,
+		"learningDataset": dataset.LearningDataset,
+	}
+
+	bytes, err := json.Marshal(source)
 	if err != nil {
 		return errors.Wrapf(err, "failed to marshal document source")
 	}


### PR DESCRIPTION
Fixes #1990 

Dataset searches were failing because the update dataset function was serializing directly from a struct which did not use the right tags. Ideally, we would have domain model objects that capture the field names we want to use on the server side and serialize properly at the boundaries, but right now we have everything tied together from the client on down. A suitable fix was to serialize based on a purpose built map.