### PR TITLE
#1979 select modelling metrics

### DIFF
--- a/api/routes/model_metrics.go
+++ b/api/routes/model_metrics.go
@@ -1,0 +1,69 @@
+//
+//   Copyright © 2020 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/pkg/errors"
+	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/util"
+	"goji.io/v3/pat"
+)
+
+// ModelMetricDesc provides a scoring ID, display name, and description.
+type ModelMetricDesc struct {
+	ID          util.MetricID `json:"id"`
+	DisplayName string        `json:"displayName"`
+	Description string        `json:"description"`
+}
+
+// ModelMetrics provides a lit of combinations to be serialized to JSON for transport to the
+// client.
+type ModelMetrics struct {
+	Combinations []*ModelMetricDesc `json:"metrics"`
+}
+
+// ModelMetricsHandler fetches a list of available model metric methods for an analysis task.
+func ModelMetricsHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		task := pat.Param(r, "task")
+		taskMetrics := make(map[string]util.Metric)
+
+		if strings.Contains(task, util.ClassificationTask) {
+			taskMetrics = util.TaskMetricMap[util.ClassificationTask]
+		} else if strings.Contains(task, util.RegressionTask) || strings.Contains(task, util.ForecastingTask) {
+			taskMetrics = util.TaskMetricMap[util.RegressionTask]
+		} else {
+			taskMetrics = util.AllModelMetrics
+		}
+
+		idx := 0
+		metricsList := make([]*ModelMetricDesc, len(taskMetrics))
+		for _, value := range taskMetrics {
+			metricsList[idx] = &ModelMetricDesc{value.ID, value.DisplayName, value.Description}
+			idx++
+		}
+
+		metrics := ModelMetrics{metricsList}
+		err := handleJSON(w, metrics)
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
+			return
+		}
+	}
+}

--- a/api/routes/model_metrics.go
+++ b/api/routes/model_metrics.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	api "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/util"
 	"goji.io/v3/pat"
@@ -44,16 +45,16 @@ func ModelMetricsHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter,
 		task := pat.Param(r, "task")
 		taskMetrics := make(map[string]util.Metric)
 
-		if strings.Contains(task, util.ClassificationTask) {
-			if strings.Contains(task, util.MultiClassTask) {
-				taskMetrics = util.TaskMetricMap[util.MultiClassTask]
-			} else if strings.Contains(task, util.BinaryTask) {
-				taskMetrics = util.TaskMetricMap[util.BinaryTask]
+		if strings.Contains(task, compute.ClassificationTask) {
+			if strings.Contains(task, compute.MultiClassTask) {
+				taskMetrics = util.TaskMetricMap[compute.MultiClassTask]
+			} else if strings.Contains(task, compute.BinaryTask) {
+				taskMetrics = util.TaskMetricMap[compute.BinaryTask]
 			} else {
-				taskMetrics = util.TaskMetricMap[util.ClassificationTask]
+				taskMetrics = util.TaskMetricMap[compute.ClassificationTask]
 			}
-		} else if strings.Contains(task, util.RegressionTask) || strings.Contains(task, util.ForecastingTask) {
-			taskMetrics = util.TaskMetricMap[util.RegressionTask]
+		} else if strings.Contains(task, compute.RegressionTask) || strings.Contains(task, compute.ForecastingTask) {
+			taskMetrics = util.TaskMetricMap[compute.RegressionTask]
 		} else {
 			taskMetrics = util.AllModelMetrics
 		}

--- a/api/routes/model_metrics.go
+++ b/api/routes/model_metrics.go
@@ -45,7 +45,13 @@ func ModelMetricsHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter,
 		taskMetrics := make(map[string]util.Metric)
 
 		if strings.Contains(task, util.ClassificationTask) {
-			taskMetrics = util.TaskMetricMap[util.ClassificationTask]
+			if strings.Contains(task, util.MultiClassTask) {
+				taskMetrics = util.TaskMetricMap[util.MultiClassTask]
+			} else if strings.Contains(task, util.BinaryTask) {
+				taskMetrics = util.TaskMetricMap[util.BinaryTask]
+			} else {
+				taskMetrics = util.TaskMetricMap[util.ClassificationTask]
+			}
 		} else if strings.Contains(task, util.RegressionTask) || strings.Contains(task, util.ForecastingTask) {
 			taskMetrics = util.TaskMetricMap[util.RegressionTask]
 		} else {

--- a/api/util/metrics.go
+++ b/api/util/metrics.go
@@ -15,6 +15,10 @@
 
 package util
 
+import (
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
+)
+
 const (
 	// Accuracy identifies model metric based on nearness to the original result.
 	Accuracy = "accuracy"
@@ -24,22 +28,12 @@ const (
 	F1Micro = "f1Micro"
 	// F1Macro identifies model metric based on precision and recall.
 	F1Macro = "f1Macro"
-	// JaccardSimilarityScore identifies model metric based on
-	JaccardSimilarityScore = "jaccardSimilarityScore"
 	// MeanAbsoluteError identifies model metric based on
 	MeanAbsoluteError = "meanAbsoluteError"
 	// MeanSquaredError identifies model metric based on the quality of the estimator.
 	MeanSquaredError = "meanSquaredError"
 	// NormalizedMutualInformation identifies model metric based on the relationship between variables.
 	NormalizedMutualInformation = "normalizedMutualInformation"
-	// ObjectDetectionAP identifies model metric based on
-	ObjectDetectionAP = "objectDetectionAP"
-	// Precision identifies model metric based on nearness to expected result
-	Precision = "precision"
-	// PrecisionAtTopK identifies model metric based on
-	PrecisionAtTopK = "precisionAtTopK"
-	// Recall identifies model metric based on
-	Recall = "recall"
 	// RocAuc identifies model metric based on
 	RocAuc = "rocAuc"
 	// RocAucMicro identifies model metric based on
@@ -52,78 +46,6 @@ const (
 	RootMeanSquaredErrorAvg = "rootMeanSquaredErrorAvg"
 	// RSquared identifies model metric based on
 	RSquared = "rSquared"
-
-	// ForecastingTask represents timeseries forcasting
-	ForecastingTask = "forecasting"
-	// ClassificationTask represents a classification task on image, timeseries or basic tabular data
-	ClassificationTask = "classification"
-	// RegressionTask represents a regression task on image, timeseries or basic tabular data
-	RegressionTask = "regression"
-	// ClusteringTask represents an unsupervised clustering task on image, timeseries or basic tabular data
-	ClusteringTask = "clustering"
-	// LinkPredictionTask represents a link prediction task on graph data
-	LinkPredictionTask = "linkPrediction"
-	// VertexClassificationTask represents a vertex nomination task on graph data
-	VertexClassificationTask = "vertexClassification"
-	// VertexNominationTask represents a vertex nomination task on graph data
-	VertexNominationTask = "vertexNomination"
-	// CommunityDetectionTask represents an unsupervised community detectiontask on on graph data
-	CommunityDetectionTask = "communityDetection"
-	// GraphMatchingTask represents an unsupervised matching task on graph data
-	GraphMatchingTask = "graphMatching"
-	// CollaborativeFilteringTask represents a collaborative filtering recommendation task on basic tabular data
-	CollaborativeFilteringTask = "collaborativeFiltering"
-	// ObjectDetectionTask represents an object detection task on image data
-	ObjectDetectionTask = "objectDetection"
-	// SemiSupervisedTask represents a semi-supervised classification task on tabular data
-	SemiSupervisedTask = "semiSupervised"
-	// BinaryTask represents task involving a single binary value for each prediction
-	BinaryTask = "binary"
-	// MultiClassTask represents a task involving a multi class value for each prediction
-	MultiClassTask = "multiClass"
-	// MultiLabelTask represents a task involving multiple lables for each each prediction
-	MultiLabelTask = "multiLabel"
-	// UnivariateTask represents a task involving predictions on a single variable
-	UnivariateTask = "univariate"
-	// MultivariateTask represents a task involving predictions on multiple variables
-	MultivariateTask = "multivariate"
-	// OverlappingTask represents a task involving overlapping predictions
-	OverlappingTask = "overlapping"
-	// NonOverlappingTask represents a task involving non-overlapping predictions
-	NonOverlappingTask = "nonOverlapping"
-	// TabularTask represents a task involving tabular data
-	TabularTask = "tabular"
-	// RelationalTask represents a task involving relational data
-	RelationalTask = "relational"
-	// ImageTask represents a task involving image data
-	ImageTask = "image"
-	// AudioTask represents a task involving audio data
-	AudioTask = "audio"
-	// VideoTask represents a task involving video data
-	VideoTask = "video"
-	// SpeechTask represents a task involving speech data
-	SpeechTask = "speech"
-	// TextTask represents a task involving text data
-	TextTask = "text"
-	// GraphTask represents a task involving graph data
-	GraphTask = "graph"
-	// MultiGraphTask represents a task involving multiple graph data
-	MultiGraphTask = "multigraph"
-	// TimeSeriesTask represents a task involving timeseries data
-	TimeSeriesTask = "timeseries"
-	// GroupedTask represents a task involving grouped data
-	GroupedTask = "grouped"
-	// GeospatialTask represents a task involving geospatial data
-	GeospatialTask = "geospatial"
-	// RemoteSensingTask represents a task involving remote sensing data
-	RemoteSensingTask = "remoteSensing"
-	// LupiTask represents a task involving LUPI (Learning Using Priveleged Information) data
-	LupiTask = "lupi"
-	// UndefinedTask is a flag for undefined/unknown task values
-	UndefinedTask = "undefined"
-
-	// UndefinedMetric is a flag for undefined/uknown metric values
-	UndefinedMetric = "undefined"
 )
 
 // MetricID uniquely identifies model metric methods
@@ -137,38 +59,106 @@ type Metric struct {
 }
 
 var (
+	allModelLabels = map[string]string{
+		Accuracy:                    compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(Accuracy)),
+		F1:                          compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(F1)),
+		F1Macro:                     compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(F1Macro)),
+		F1Micro:                     compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(F1Micro)),
+		RocAuc:                      compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(RocAuc)),
+		RocAucMacro:                 compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(RocAucMacro)),
+		RocAucMicro:                 compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(RocAucMicro)),
+		MeanAbsoluteError:           compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(MeanAbsoluteError)),
+		MeanSquaredError:            compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(MeanSquaredError)),
+		NormalizedMutualInformation: compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(NormalizedMutualInformation)),
+		RootMeanSquaredError:        compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(RootMeanSquaredError)),
+		RootMeanSquaredErrorAvg:     compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(RootMeanSquaredErrorAvg)),
+		RSquared:                    compute.GetMetricLabel(compute.ConvertProblemMetricToTA2(RSquared)),
+	}
+
 	// AllModelMetrics defines a list of model scoring metrics
 	AllModelMetrics = map[string]Metric{
-		Accuracy:                    {Accuracy, "Accuracy", "Accuracy scores the result based only on the percentage of correct predictions."},
-		F1:                          {F1, "F1", "F1 scoring averages true positives, false negatives and false positives for binary classifications, balancing precision and recall."},
-		F1Macro:                     {F1Macro, "F1 Macro", "F1 Macro scoring averages true positives, false negatives and false positives for all multi-class classification options, balancing precision and recall."},
-		F1Micro:                     {F1Micro, "F1 Micro", "F1 Micro scoring averages true positives, false negatives and false positives for each multi-class classification options for multi-class problems, balancing precision and recall."},
-		RocAuc:                      {RocAuc, "RocAuc", "RocAuc scoring compares relationship between inputs on result for binary classifications."},
-		RocAucMacro:                 {RocAucMacro, "RocAuc Macro", "RocAuc scoring compares the relationship between inputs and the result for all multi-class classification options."},
-		RocAucMicro:                 {RocAucMicro, "RocAuc Micro", "RocAuc scoring compares hte relationship between inputs and the result for each multi-class classification options."},
-		MeanAbsoluteError:           {MeanAbsoluteError, "MAE", "The mean absolute error (MAE) measures the average magnitude of errors in a set of predictions."},
-		MeanSquaredError:            {MeanSquaredError, "MSE", "The mean squared error measures the quality of an estimator where values closer to 0 are better."},
-		NormalizedMutualInformation: {NormalizedMutualInformation, "NMI", "Normalized Mutual Information scores the relationship / lack of entropy between variables where 0 is no relationship and 1 is a strong relationship."},
-		RootMeanSquaredError:        {RootMeanSquaredError, "RMSE", "The root mean squared error measures the quality of an estimator and the average magnitude of the error."},
-		RootMeanSquaredErrorAvg:     {RootMeanSquaredErrorAvg, "RMSEA", "The root mean squared error average measures the quality of an estimator and the average magnitude of the error averaged across classifcations options."},
-		RSquared:                    {RSquared, "RQ", "The root squared measures the relationship between predictions and their inputs where values closer to 1 suggest a strong correlation."},
+		Accuracy: {
+			Accuracy,
+			allModelLabels[Accuracy],
+			allModelLabels[Accuracy] + " scores the result based only on the percentage of correct predictions.",
+		},
+		F1: {
+			F1,
+			allModelLabels[F1],
+			allModelLabels[F1] + " scoring averages true positives, false negatives and false positives for binary classifications, balancing precision and recall.",
+		},
+		F1Macro: {
+			F1Macro,
+			allModelLabels[F1Macro],
+			"F1 Macro scoring averages true positives, false negatives and false positives for all multi-class classification options, balancing precision and recall.",
+		},
+		F1Micro: {
+			F1Micro,
+			allModelLabels[F1Micro],
+			allModelLabels[F1Micro] + " scoring averages true positives, false negatives and false positives for each multi-class classification options for multi-class problems, balancing precision and recall.",
+		},
+		RocAuc: {
+			RocAuc,
+			allModelLabels[RocAuc],
+			allModelLabels[RocAuc] + " scoring compares relationship between inputs on result for binary classifications.",
+		},
+		RocAucMacro: {
+			RocAucMacro,
+			allModelLabels[RocAucMacro],
+			allModelLabels[RocAucMacro] + " scoring compares the relationship between inputs and the result for all multi-class classification options.",
+		},
+		RocAucMicro: {
+			RocAucMicro,
+			allModelLabels[RocAucMicro],
+			allModelLabels[RocAucMicro] + " scoring compares hte relationship between inputs and the result for each multi-class classification options.",
+		},
+		MeanAbsoluteError: {
+			MeanAbsoluteError,
+			allModelLabels[MeanAbsoluteError],
+			allModelLabels[MeanAbsoluteError] + " measures the average magnitude of errors in a set of predictions.",
+		},
+		MeanSquaredError: {
+			MeanSquaredError,
+			allModelLabels[MeanSquaredError],
+			allModelLabels[MeanSquaredError] + " measures the quality of an estimator where values closer to 0 are better.",
+		},
+		NormalizedMutualInformation: {
+			NormalizedMutualInformation,
+			allModelLabels[NormalizedMutualInformation],
+			allModelLabels[NormalizedMutualInformation] + " scores the relationship / lack of entropy between variables where 0 is no relationship and 1 is a strong relationship.",
+		},
+		RootMeanSquaredError: {
+			RootMeanSquaredError,
+			allModelLabels[RootMeanSquaredError],
+			allModelLabels[RootMeanSquaredError] + " measures the quality of an estimator and the average magnitude of the error.",
+		},
+		RootMeanSquaredErrorAvg: {
+			RootMeanSquaredErrorAvg,
+			allModelLabels[RootMeanSquaredErrorAvg],
+			allModelLabels[RootMeanSquaredErrorAvg] + " measures the quality of an estimator and the average magnitude of the error averaged across classifcations options.",
+		},
+		RSquared: {
+			RSquared,
+			allModelLabels[RSquared],
+			allModelLabels[RSquared] + " measures the relationship between predictions and their inputs where values closer to 1 suggest a strong correlation.",
+		},
 	}
 
 	//TaskMetricMap maps tasks to metrics
 	TaskMetricMap = map[string]map[string]Metric{
-		BinaryTask: {
+		compute.BinaryTask: {
 			Accuracy: AllModelMetrics[Accuracy],
 			F1:       AllModelMetrics[F1],
 			RocAuc:   AllModelMetrics[RocAuc],
 		},
-		MultiClassTask: {
+		compute.MultiClassTask: {
 			Accuracy:    AllModelMetrics[Accuracy],
 			F1Macro:     AllModelMetrics[F1Micro],
 			F1Micro:     AllModelMetrics[F1Macro],
 			RocAucMacro: AllModelMetrics[RocAucMacro],
 			RocAucMicro: AllModelMetrics[RocAucMicro],
 		},
-		ClassificationTask: {
+		compute.ClassificationTask: {
 			Accuracy:    AllModelMetrics[Accuracy],
 			F1:          AllModelMetrics[F1],
 			F1Macro:     AllModelMetrics[F1Micro],
@@ -177,7 +167,7 @@ var (
 			RocAucMacro: AllModelMetrics[RocAucMacro],
 			RocAucMicro: AllModelMetrics[RocAucMicro],
 		},
-		RegressionTask: {
+		compute.RegressionTask: {
 			MeanAbsoluteError:       AllModelMetrics[MeanAbsoluteError],
 			MeanSquaredError:        AllModelMetrics[MeanSquaredError],
 			RootMeanSquaredError:    AllModelMetrics[RootMeanSquaredError],

--- a/api/util/metrics.go
+++ b/api/util/metrics.go
@@ -156,6 +156,18 @@ var (
 
 	//TaskMetricMap maps tasks to metrics
 	TaskMetricMap = map[string]map[string]Metric{
+		BinaryTask: {
+			Accuracy: AllModelMetrics[Accuracy],
+			F1:       AllModelMetrics[F1],
+			RocAuc:   AllModelMetrics[RocAuc],
+		},
+		MultiClassTask: {
+			Accuracy:    AllModelMetrics[Accuracy],
+			F1Macro:     AllModelMetrics[F1Micro],
+			F1Micro:     AllModelMetrics[F1Macro],
+			RocAucMacro: AllModelMetrics[RocAucMacro],
+			RocAucMicro: AllModelMetrics[RocAucMicro],
+		},
 		ClassificationTask: {
 			Accuracy:    AllModelMetrics[Accuracy],
 			F1:          AllModelMetrics[F1],

--- a/api/util/metrics.go
+++ b/api/util/metrics.go
@@ -1,0 +1,176 @@
+//
+//   Copyright © 2020 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package util
+
+const (
+	// Accuracy identifies model metric based on nearness to the original result.
+	Accuracy = "accuracy"
+	// F1 identifies model metric based on precision and recall
+	F1 = "f1"
+	// F1Micro identifies model metric based  on precision and recall
+	F1Micro = "f1Micro"
+	// F1Macro identifies model metric based on precision and recall.
+	F1Macro = "f1Macro"
+	// JaccardSimilarityScore identifies model metric based on
+	JaccardSimilarityScore = "jaccardSimilarityScore"
+	// MeanAbsoluteError identifies model metric based on
+	MeanAbsoluteError = "meanAbsoluteError"
+	// MeanSquaredError identifies model metric based on the quality of the estimator.
+	MeanSquaredError = "meanSquaredError"
+	// NormalizedMutualInformation identifies model metric based on the relationship between variables.
+	NormalizedMutualInformation = "normalizedMutualInformation"
+	// ObjectDetectionAP identifies model metric based on
+	ObjectDetectionAP = "objectDetectionAP"
+	// Precision identifies model metric based on nearness to expected result
+	Precision = "precision"
+	// PrecisionAtTopK identifies model metric based on
+	PrecisionAtTopK = "precisionAtTopK"
+	// Recall identifies model metric based on
+	Recall = "recall"
+	// RocAuc identifies model metric based on
+	RocAuc = "rocAuc"
+	// RocAucMicro identifies model metric based on
+	RocAucMicro = "rocAucMicro"
+	// RocAucMacro identifies model metric based on
+	RocAucMacro = "rocAucMacro"
+	// RootMeanSquaredError identifies model metric based on
+	RootMeanSquaredError = "rootMeanSquaredError"
+	// RootMeanSquaredErrorAvg identifies model metric based on
+	RootMeanSquaredErrorAvg = "rootMeanSquaredErrorAvg"
+	// RSquared identifies model metric based on
+	RSquared = "rSquared"
+
+	// ForecastingTask represents timeseries forcasting
+	ForecastingTask = "forecasting"
+	// ClassificationTask represents a classification task on image, timeseries or basic tabular data
+	ClassificationTask = "classification"
+	// RegressionTask represents a regression task on image, timeseries or basic tabular data
+	RegressionTask = "regression"
+	// ClusteringTask represents an unsupervised clustering task on image, timeseries or basic tabular data
+	ClusteringTask = "clustering"
+	// LinkPredictionTask represents a link prediction task on graph data
+	LinkPredictionTask = "linkPrediction"
+	// VertexClassificationTask represents a vertex nomination task on graph data
+	VertexClassificationTask = "vertexClassification"
+	// VertexNominationTask represents a vertex nomination task on graph data
+	VertexNominationTask = "vertexNomination"
+	// CommunityDetectionTask represents an unsupervised community detectiontask on on graph data
+	CommunityDetectionTask = "communityDetection"
+	// GraphMatchingTask represents an unsupervised matching task on graph data
+	GraphMatchingTask = "graphMatching"
+	// CollaborativeFilteringTask represents a collaborative filtering recommendation task on basic tabular data
+	CollaborativeFilteringTask = "collaborativeFiltering"
+	// ObjectDetectionTask represents an object detection task on image data
+	ObjectDetectionTask = "objectDetection"
+	// SemiSupervisedTask represents a semi-supervised classification task on tabular data
+	SemiSupervisedTask = "semiSupervised"
+	// BinaryTask represents task involving a single binary value for each prediction
+	BinaryTask = "binary"
+	// MultiClassTask represents a task involving a multi class value for each prediction
+	MultiClassTask = "multiClass"
+	// MultiLabelTask represents a task involving multiple lables for each each prediction
+	MultiLabelTask = "multiLabel"
+	// UnivariateTask represents a task involving predictions on a single variable
+	UnivariateTask = "univariate"
+	// MultivariateTask represents a task involving predictions on multiple variables
+	MultivariateTask = "multivariate"
+	// OverlappingTask represents a task involving overlapping predictions
+	OverlappingTask = "overlapping"
+	// NonOverlappingTask represents a task involving non-overlapping predictions
+	NonOverlappingTask = "nonOverlapping"
+	// TabularTask represents a task involving tabular data
+	TabularTask = "tabular"
+	// RelationalTask represents a task involving relational data
+	RelationalTask = "relational"
+	// ImageTask represents a task involving image data
+	ImageTask = "image"
+	// AudioTask represents a task involving audio data
+	AudioTask = "audio"
+	// VideoTask represents a task involving video data
+	VideoTask = "video"
+	// SpeechTask represents a task involving speech data
+	SpeechTask = "speech"
+	// TextTask represents a task involving text data
+	TextTask = "text"
+	// GraphTask represents a task involving graph data
+	GraphTask = "graph"
+	// MultiGraphTask represents a task involving multiple graph data
+	MultiGraphTask = "multigraph"
+	// TimeSeriesTask represents a task involving timeseries data
+	TimeSeriesTask = "timeseries"
+	// GroupedTask represents a task involving grouped data
+	GroupedTask = "grouped"
+	// GeospatialTask represents a task involving geospatial data
+	GeospatialTask = "geospatial"
+	// RemoteSensingTask represents a task involving remote sensing data
+	RemoteSensingTask = "remoteSensing"
+	// LupiTask represents a task involving LUPI (Learning Using Priveleged Information) data
+	LupiTask = "lupi"
+	// UndefinedTask is a flag for undefined/unknown task values
+	UndefinedTask = "undefined"
+
+	// UndefinedMetric is a flag for undefined/uknown metric values
+	UndefinedMetric = "undefined"
+)
+
+// MetricID uniquely identifies model metric methods
+type MetricID string
+
+// Metric defines the ID, display name and description for various model metrics
+type Metric struct {
+	ID          MetricID
+	DisplayName string
+	Description string
+}
+
+var (
+	// AllModelMetrics defines a list of model scoring metrics
+	AllModelMetrics = map[string]Metric{
+		Accuracy:                    {Accuracy, "Accuracy", "Accuracy scores the result based on nearness to the original result."},
+		F1:                          {F1, "F1", "F1 scoring balances precision and recall etc."},
+		F1Macro:                     {F1Macro, "F1 Macro", "F1 scoring balances precision and recall etc."},
+		F1Micro:                     {F1Micro, "F1 Micro", "F1 scoring balances precision and recall etc."},
+		RocAuc:                      {RocAuc, "RocAuc", "RocAuc scoring compares relationship between inputs on result."},
+		RocAucMacro:                 {RocAucMacro, "RocAuc Macro", "RocAuc scoring compares relationship between inputs on result."},
+		RocAucMicro:                 {RocAucMicro, "RocAuc Micro", "RocAuc scoring compares relationship between inputs on result."},
+		MeanAbsoluteError:           {MeanAbsoluteError, "MAE", "The mean absolute error is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
+		MeanSquaredError:            {MeanSquaredError, "MSE", "The mean squared error is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
+		NormalizedMutualInformation: {NormalizedMutualInformation, "NMI", "Normalized Mutual Information scores the relationship between variables on a scale of 0 to 1."},
+		RootMeanSquaredError:        {RootMeanSquaredError, "RMSE", "The root mean squared error is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
+		RootMeanSquaredErrorAvg:     {RootMeanSquaredErrorAvg, "RMSEA", "The root mean squared error average is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
+		RSquared:                    {RSquared, "RQ", "The root squared is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
+	}
+
+	//TaskMetricMap maps tasks to metrics
+	TaskMetricMap = map[string]map[string]Metric{
+		ClassificationTask: {
+			Accuracy:    AllModelMetrics[Accuracy],
+			F1:          AllModelMetrics[F1],
+			F1Macro:     AllModelMetrics[F1Micro],
+			F1Micro:     AllModelMetrics[F1Macro],
+			RocAuc:      AllModelMetrics[RocAuc],
+			RocAucMacro: AllModelMetrics[RocAucMacro],
+			RocAucMicro: AllModelMetrics[RocAucMicro],
+		},
+		RegressionTask: {
+			MeanAbsoluteError:       AllModelMetrics[MeanAbsoluteError],
+			MeanSquaredError:        AllModelMetrics[MeanSquaredError],
+			RootMeanSquaredError:    AllModelMetrics[RootMeanSquaredError],
+			RootMeanSquaredErrorAvg: AllModelMetrics[RootMeanSquaredErrorAvg],
+			RSquared:                AllModelMetrics[RSquared],
+		},
+	}
+)

--- a/api/util/metrics.go
+++ b/api/util/metrics.go
@@ -139,19 +139,19 @@ type Metric struct {
 var (
 	// AllModelMetrics defines a list of model scoring metrics
 	AllModelMetrics = map[string]Metric{
-		Accuracy:                    {Accuracy, "Accuracy", "Accuracy scores the result based on nearness to the original result."},
-		F1:                          {F1, "F1", "F1 scoring balances precision and recall etc."},
-		F1Macro:                     {F1Macro, "F1 Macro", "F1 scoring balances precision and recall etc."},
-		F1Micro:                     {F1Micro, "F1 Micro", "F1 scoring balances precision and recall etc."},
-		RocAuc:                      {RocAuc, "RocAuc", "RocAuc scoring compares relationship between inputs on result."},
-		RocAucMacro:                 {RocAucMacro, "RocAuc Macro", "RocAuc scoring compares relationship between inputs on result."},
-		RocAucMicro:                 {RocAucMicro, "RocAuc Micro", "RocAuc scoring compares relationship between inputs on result."},
-		MeanAbsoluteError:           {MeanAbsoluteError, "MAE", "The mean absolute error is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
-		MeanSquaredError:            {MeanSquaredError, "MSE", "The mean squared error is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
-		NormalizedMutualInformation: {NormalizedMutualInformation, "NMI", "Normalized Mutual Information scores the relationship between variables on a scale of 0 to 1."},
-		RootMeanSquaredError:        {RootMeanSquaredError, "RMSE", "The root mean squared error is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
-		RootMeanSquaredErrorAvg:     {RootMeanSquaredErrorAvg, "RMSEA", "The root mean squared error average is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
-		RSquared:                    {RSquared, "RQ", "The root squared is a measure of the quality of an estimator—it is always non-negative, and values closer to 0 are better."},
+		Accuracy:                    {Accuracy, "Accuracy", "Accuracy scores the result based only on the percentage of correct predictions."},
+		F1:                          {F1, "F1", "F1 scoring averages true positives, false negatives and false positives for binary classifications, balancing precision and recall."},
+		F1Macro:                     {F1Macro, "F1 Macro", "F1 Macro scoring averages true positives, false negatives and false positives for all multi-class classification options, balancing precision and recall."},
+		F1Micro:                     {F1Micro, "F1 Micro", "F1 Micro scoring averages true positives, false negatives and false positives for each multi-class classification options for multi-class problems, balancing precision and recall."},
+		RocAuc:                      {RocAuc, "RocAuc", "RocAuc scoring compares relationship between inputs on result for binary classifications."},
+		RocAucMacro:                 {RocAucMacro, "RocAuc Macro", "RocAuc scoring compares the relationship between inputs and the result for all multi-class classification options."},
+		RocAucMicro:                 {RocAucMicro, "RocAuc Micro", "RocAuc scoring compares hte relationship between inputs and the result for each multi-class classification options."},
+		MeanAbsoluteError:           {MeanAbsoluteError, "MAE", "The mean absolute error (MAE) measures the average magnitude of errors in a set of predictions."},
+		MeanSquaredError:            {MeanSquaredError, "MSE", "The mean squared error measures the quality of an estimator where values closer to 0 are better."},
+		NormalizedMutualInformation: {NormalizedMutualInformation, "NMI", "Normalized Mutual Information scores the relationship / lack of entropy between variables where 0 is no relationship and 1 is a strong relationship."},
+		RootMeanSquaredError:        {RootMeanSquaredError, "RMSE", "The root mean squared error measures the quality of an estimator and the average magnitude of the error."},
+		RootMeanSquaredErrorAvg:     {RootMeanSquaredErrorAvg, "RMSEA", "The root mean squared error average measures the quality of an estimator and the average magnitude of the error averaged across classifcations options."},
+		RSquared:                    {RSquared, "RQ", "The root squared measures the relationship between predictions and their inputs where values closer to 1 suggest a strong correlation."},
 	}
 
 	//TaskMetricMap maps tasks to metrics

--- a/main.go
+++ b/main.go
@@ -262,6 +262,7 @@ func main() {
 	registerRoute(mux, "/distil/load/:solution-id/:fitted", routes.LoadHandler(esExportedModelStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/distil/solution-variable-rankings/:solution-id", routes.SolutionVariableRankingHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoute(mux, "/distil/export-results/:produce-request-id", routes.ExportResultHandler(pgSolutionStorageCtor, pgDataStorageCtor, esMetadataStorageCtor))
+	registerRoute(mux, "/distil/model-metrics/:task", routes.ModelMetricsHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor, esExportedModelStorageCtor))
 
 	// POST

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
       return routeGetters.getDecodedSolutionRequestFilterParams(this.$store);
     },
     metrics(): string[] {
-      return null;
+      return routeGetters.getModelMetrics(this.$store);
     },
     trainingSelected(): boolean {
       return !_.isEmpty(this.training);

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -23,7 +23,6 @@ import {
   MULTIBAND_IMAGE_TYPE,
   UNKNOWN_TYPE,
 } from "../../util/types";
-import { Highlight } from "../dataset/index";
 import { getters as routeGetters } from "../route/module";
 import store, { DistilState } from "../store";
 import {
@@ -37,9 +36,11 @@ import {
   DatasetPendingRequestType,
   DatasetState,
   Grouping,
+  Highlight,
   isClusteredGrouping,
   JoinDatasetImportPendingRequest,
   JoinSuggestionPendingRequest,
+  Metrics,
   SummaryMode,
   Task,
   TimeSeriesValue,
@@ -1285,6 +1286,22 @@ export const actions = {
       );
       const bands = repsonse.data.combinations;
       mutations.updateBands(context, bands);
+    } catch (error) {
+      console.error(error);
+    }
+  },
+
+  async fetchModelingMetrics(context: DatasetContext, args: { task: string }) {
+    if (!validateArgs(args, ["task"])) {
+      return null;
+    }
+
+    try {
+      const repsonse = await axios.get<Metrics>(
+        `distil/model-metrics/${args.task}`
+      );
+      const metrics = repsonse.data.metrics;
+      mutations.updateMetrics(context, metrics);
     } catch (error) {
       console.error(error);
     }

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -10,6 +10,7 @@ import {
   TimeSeries,
   BandCombination,
   Row,
+  Metric,
 } from "./index";
 import { Dictionary } from "../../util/dict";
 import { getTableDataItems, getTableDataFields } from "../../util/data";
@@ -177,5 +178,9 @@ export const getters = {
 
   getMultiBandCombinations(state: DatasetState): BandCombination[] {
     return state.bands;
+  },
+
+  getModelingMetrics(state: DatasetState): Metric[] {
+    return state.metrics;
   },
 };

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -360,6 +360,7 @@ export interface DatasetState {
   pendingRequests: DatasetPendingRequest[];
   task: Task;
   bands: BandCombination[];
+  metrics: Metric[];
 }
 
 export interface WorkingSet {
@@ -375,6 +376,24 @@ export interface BandCombination {
 
 export interface BandCombinations {
   combinations: BandCombination[];
+}
+
+export interface Metric {
+  id: BandID;
+  displayName: string;
+  description: string;
+}
+
+export interface Metrics {
+  metrics: Metric[];
+}
+
+export interface MetricDropdownItem {
+  value: {
+    id: string;
+    description: string;
+  };
+  text: string;
 }
 
 export const state: DatasetState = {
@@ -416,4 +435,7 @@ export const state: DatasetState = {
 
   // bands
   bands: [],
+
+  // metrics
+  metrics: [],
 };

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -72,6 +72,9 @@ export const getters = {
 
   // Remote sensing image band combinatinos
   getMultiBandCombinations: read(moduleGetters.getMultiBandCombinations),
+
+  // Modeling metric methologies
+  getModelingMetrics: read(moduleGetters.getModelingMetrics),
 };
 
 // Typed actions
@@ -137,6 +140,8 @@ export const actions = {
   fetchMultiBandCombinations: dispatch(
     moduleActions.fetchMultiBandCombinations
   ),
+  // modeling metric methodologies
+  fetchModelingMetrics: dispatch(moduleActions.fetchModelingMetrics),
   updateRowSelectionData: dispatch(moduleActions.updateRowSelectionData),
 };
 
@@ -174,4 +179,5 @@ export const mutations = {
   setExcludedTableData: commit(moduleMutations.setExcludedTableData),
   updateBands: commit(moduleMutations.updateBands),
   updateRowSelectionData: commit(moduleMutations.updateRowSelectionData),
+  updateMetrics: commit(moduleMutations.updateMetrics),
 };

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -11,6 +11,7 @@ import {
   Task,
   BandCombination,
   TimeSeriesValue,
+  Metric,
 } from "./index";
 import {
   updateSummariesPerVariable,
@@ -362,5 +363,9 @@ export const mutations = {
 
   updateBands(state: DatasetState, bands: BandCombination[]) {
     state.bands = bands;
+  },
+
+  updateMetrics(state: DatasetState, metrics: Metric[]) {
+    state.metrics = metrics;
   },
 };

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -598,6 +598,13 @@ export const getters = {
     );
   },
 
+  getModelMetrics(state: Route): string[] {
+    const metrics = <string>state.query.metrics;
+    if (!metrics) {
+      return null;
+    }
+    return metrics.split(",");
+  },
   /* Check if the current page is SELECT_TARGET_ROUTE. */
   isPageSelectTarget(state: Route): Boolean {
     return state.path === SELECT_TARGET_ROUTE;

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -112,6 +112,7 @@ export const getters = {
   getModelLimit: read(moduleGetters.getModelLimit),
   getModelTimeLimit: read(moduleGetters.getModelTimeLimit),
   getModelQuality: read(moduleGetters.getModelQuality),
+  getModelMetrics: read(moduleGetters.getModelMetrics),
   isPageSelectTarget: read(moduleGetters.isPageSelectTarget),
   isPageSelectTraining: read(moduleGetters.isPageSelectTraining),
 };

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -55,6 +55,7 @@ export interface RouteArgs {
   modelLimit?: number;
   modelQuality?: string;
   dataSize?: number;
+  metrics?: string;
 }
 
 /**


### PR DESCRIPTION
Added new distil/model-metrics route to api and consumed it in the front end to populate dropdown & descriptions in model settings that provides different metrics based on ML task type (broadly classification vs. regression, with special handlers for binary vs. multi-class classification.)