### PR TITLE
Display unselected points

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -667,7 +667,7 @@ func (s *Storage) FetchData(dataset string, storageName string, filterParams *ap
 
 	// if there are no filters, and we are returning the exclude set, we expect
 	// no results in the filtered set
-	isFiltered := filterParams.Filters != nil || filterParams.Highlight != nil 
+	isFiltered := filterParams.Filters != nil || filterParams.Highlight != nil
 	if invert && !isFiltered {
 		return &api.FilteredData{
 			NumRows: numRows,
@@ -710,7 +710,6 @@ func (s *Storage) FetchData(dataset string, storageName string, filterParams *ap
 		query = fmt.Sprintf("%s LIMIT %d", query, filterParams.Size)
 	}
 	query = query + ";"
-
 	// execute the postgres query
 	batch.Queue(query, params...)
 	resBatch := s.client.SendBatch(batch)

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -309,7 +309,7 @@ func (s *Storage) buildExcludeFilter(dataset string, wheres []string, params []i
 
 	case model.GeoBoundsFilter:
 		// geo bounds
-		where := fmt.Sprintf("!ST_WITHIN(%s, $%d)", name, len(params)+1)
+		where := fmt.Sprintf("ST_WITHIN(%s, $%d)=false", name, len(params)+1)
 		params = append(params, buildBoundsGeometryString(filter.Bounds))
 		wheres = append(wheres, where)
 
@@ -667,7 +667,8 @@ func (s *Storage) FetchData(dataset string, storageName string, filterParams *ap
 
 	// if there are no filters, and we are returning the exclude set, we expect
 	// no results in the filtered set
-	if invert && filterParams.Filters == nil {
+	isFiltered := filterParams.Filters != nil || filterParams.Highlight != nil 
+	if invert && !isFiltered {
 		return &api.FilteredData{
 			NumRows: numRows,
 			Columns: make([]*api.Column, 0),

--- a/api/routes/data.go
+++ b/api/routes/data.go
@@ -71,7 +71,10 @@ func DataHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataStorageCt
 			handleError(w, errors.Wrap(err, "unable to expand filter params"))
 			return
 		}
-
+		// isHighlight added for querying data the highlighted data for data tables
+		if params["isHighlight"] == nil && expandedFilterParams.Filters == nil{
+			expandedFilterParams.Highlight = nil
+		}
 		// fetch filtered data based on the supplied search parameters
 		data, err := storage.FetchData(dataset, storageName, expandedFilterParams, invertBool)
 		if err != nil {

--- a/api/routes/data.go
+++ b/api/routes/data.go
@@ -72,7 +72,7 @@ func DataHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataStorageCt
 			return
 		}
 		// isHighlight added for querying data the highlighted data for data tables
-		if params["isHighlight"] == nil && expandedFilterParams.Filters == nil{
+		if params["isHighlight"] == nil && expandedFilterParams.Filters == nil {
 			expandedFilterParams.Highlight = nil
 		}
 		// fetch filtered data based on the supplied search parameters

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -422,7 +422,7 @@ export default Vue.extend({
                 lng: lng,
                 lat: lat,
                 row: item,
-                color: this.colorPrediction(item),
+                color: this.tileColor(item),
               };
             }
 
@@ -479,7 +479,7 @@ export default Vue.extend({
           [fullCoordinates[5].Float, fullCoordinates[4].Float], // Corner C as [Lat, Lng]
         ] as LatLngBoundsLiteral;
 
-        const color = this.colorPrediction(item);
+        const color = this.tileColor(item);
 
         longitudes.push(fullCoordinates[4].Float - fullCoordinates[0].Float); // Corner C Lng - Corner A Lng
 
@@ -975,7 +975,6 @@ export default Vue.extend({
         console.error("Error createHighlight no available key");
         return;
       }
-
       updateHighlight(this.$router, {
         context: this.instanceName,
         dataset: this.dataset,
@@ -1019,7 +1018,7 @@ export default Vue.extend({
       this.isImageDrilldown = false;
     },
 
-    colorPrediction(item: any) {
+    tileColor(item: any) {
       let color = "#255DCC"; // Default
 
       if (item[this.targetField] && item[this.predictedField]) {
@@ -1027,6 +1026,9 @@ export default Vue.extend({
           item[this.targetField].value === item[this.predictedField].value
             ? "#03c003" // Correct: green.
             : "#be0000"; // Incorrect: red.
+      }
+      if (item.isExcluded) {
+        return "#999999";
       }
 
       return color;

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -39,7 +39,7 @@
     <div class="table-title-container">
       <p class="selection-data-slot-summary">
         <data-size
-          :currentSize="numItems"
+          :currentSize="numRows"
           :total="numRows"
           @submit="onDataSizeSubmit"
         />

--- a/public/components/SelectGeoPlot.vue
+++ b/public/components/SelectGeoPlot.vue
@@ -43,9 +43,9 @@ export default Vue.extend({
     },
 
     items(): TableRow[] {
-      const tableData = datasetGetters.getHighlightedTableDataItems(
-        this.$store
-      );
+      const tableData = this.includedActive
+        ? datasetGetters.getHighlightedIncludeTableDataItems(this.$store)
+        : datasetGetters.getHighlightedExcludeTableDataItems(this.$store);
       const highlighted = tableData
         ? tableData.map((h) => {
             return { ...h, isExcluded: true };

--- a/public/components/SelectGeoPlot.vue
+++ b/public/components/SelectGeoPlot.vue
@@ -55,7 +55,9 @@ export default Vue.extend({
         ? datasetGetters
             .getIncludedTableDataItems(this.$store)
             .concat(highlighted)
-        : datasetGetters.getExcludedTableDataItems(this.$store);
+        : datasetGetters
+            .getExcludedTableDataItems(this.$store)
+            .concat(highlighted);
     },
     trainingVarsSearch(): string {
       return routeGetters.getRouteTrainingVarsSearch(this.$store);

--- a/public/components/SelectGeoPlot.vue
+++ b/public/components/SelectGeoPlot.vue
@@ -43,14 +43,19 @@ export default Vue.extend({
     },
 
     items(): TableRow[] {
-      const excluded = datasetGetters
-        .getExcludedTableDataItems(this.$store)
-        .map((i) => {
-          return { ...i, isExcluded: true };
-        });
-      return datasetGetters
-        .getIncludedTableDataItems(this.$store)
-        .concat(excluded);
+      const tableData = datasetGetters.getHighlightedTableDataItems(
+        this.$store
+      );
+      const highlighted = tableData
+        ? tableData.map((h) => {
+            return { ...h, isExcluded: true };
+          })
+        : [];
+      return this.includedActive
+        ? datasetGetters
+            .getIncludedTableDataItems(this.$store)
+            .concat(highlighted)
+        : datasetGetters.getExcludedTableDataItems(this.$store);
     },
     trainingVarsSearch(): string {
       return routeGetters.getRouteTrainingVarsSearch(this.$store);

--- a/public/components/SelectGeoPlot.vue
+++ b/public/components/SelectGeoPlot.vue
@@ -43,9 +43,14 @@ export default Vue.extend({
     },
 
     items(): TableRow[] {
-      return this.includedActive
-        ? datasetGetters.getIncludedTableDataItems(this.$store)
-        : datasetGetters.getExcludedTableDataItems(this.$store);
+      const excluded = datasetGetters
+        .getExcludedTableDataItems(this.$store)
+        .map((i) => {
+          return { ...i, isExcluded: true };
+        });
+      return datasetGetters
+        .getIncludedTableDataItems(this.$store)
+        .concat(excluded);
     },
     trainingVarsSearch(): string {
       return routeGetters.getRouteTrainingVarsSearch(this.$store);

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1256,13 +1256,14 @@ export const actions = {
       filterParams: FilterParams;
       highlight: Highlight;
       dataMode: DataMode;
+      include: boolean;
     }
   ) {
     return actions.fetchTableData(context, {
       dataset: args.dataset,
       filterParams: args.filterParams,
       highlight: { ...args.highlight, include: EXCLUDE_FILTER },
-      include: true,
+      include: args.include,
       dataMode: args.dataMode,
       isHighlight: true,
     });
@@ -1291,7 +1292,9 @@ export const actions = {
       args.highlight
     );
     if (!!args.isHighlight) {
-      mutator = mutations.setHighlightedTableData; // set mutator for highlight
+      mutator = args.include
+        ? mutations.setHighlightedIncludeTableData
+        : mutations.setHighlightedExcludeTableData; // set mutator for highlight
       filterParams = { ...filterParams, isHighlight: true }; // add extra param
     }
 

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1249,6 +1249,24 @@ export const actions = {
       dataMode: args.dataMode,
     });
   },
+  fetchHighlightedTableData(
+    context: DatasetContext,
+    args: {
+      dataset: string;
+      filterParams: FilterParams;
+      highlight: Highlight;
+      dataMode: DataMode;
+    }
+  ) {
+    return actions.fetchTableData(context, {
+      dataset: args.dataset,
+      filterParams: args.filterParams,
+      highlight: { ...args.highlight, include: EXCLUDE_FILTER },
+      include: false,
+      dataMode: args.dataMode,
+      isHighlight: true,
+    });
+  },
 
   async fetchTableData(
     context: DatasetContext,
@@ -1258,21 +1276,24 @@ export const actions = {
       highlight: Highlight;
       include: boolean;
       dataMode: DataMode;
+      isHighlight?: boolean;
     }
   ) {
     if (!validateArgs(args, ["dataset", "filterParams"])) {
       return null;
     }
 
-    const mutator = args.include
+    let mutator = args.include
       ? mutations.setIncludedTableData
       : mutations.setExcludedTableData;
-
-    const filterParams = addHighlightToFilterParams(
+    let filterParams = addHighlightToFilterParams(
       args.filterParams,
-      args.highlight,
-      args.include ? INCLUDE_FILTER : EXCLUDE_FILTER
+      args.highlight
     );
+    if (!!args.isHighlight) {
+      mutator = mutations.setHighlightedTableData; // set mutator for highlight
+      filterParams = { ...filterParams, isHighlight: true }; // add extra param
+    }
 
     const dataModeDefault = args.dataMode ? args.dataMode : DataMode.Default;
     filterParams.dataMode = dataModeDefault;

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -10,7 +10,11 @@ import {
   validateArgs,
 } from "../../util/data";
 import { Dictionary } from "../../util/dict";
-import { FilterParams } from "../../util/filters";
+import {
+  EXCLUDE_FILTER,
+  FilterParams,
+  INCLUDE_FILTER,
+} from "../../util/filters";
 import { addHighlightToFilterParams } from "../../util/highlights";
 import { loadImage } from "../../util/image";
 import {
@@ -1266,7 +1270,8 @@ export const actions = {
 
     const filterParams = addHighlightToFilterParams(
       args.filterParams,
-      args.highlight
+      args.highlight,
+      args.include ? INCLUDE_FILTER : EXCLUDE_FILTER
     );
 
     const dataModeDefault = args.dataMode ? args.dataMode : DataMode.Default;

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1262,7 +1262,7 @@ export const actions = {
       dataset: args.dataset,
       filterParams: args.filterParams,
       highlight: { ...args.highlight, include: EXCLUDE_FILTER },
-      include: false,
+      include: true,
       dataMode: args.dataMode,
       isHighlight: true,
     });

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -103,7 +103,6 @@ export const getters = {
   getFiles(state: DatasetState): Dictionary<any> {
     return state.files;
   },
-
   getTimeseriesExtrema(state: DatasetState): Dictionary<TimeseriesExtrema> {
     return state.timeseriesExtrema;
   },
@@ -119,7 +118,9 @@ export const getters = {
   hasIncludedTableData(state: DatasetState): boolean {
     return !!state.includedSet.tableData;
   },
-
+  getHighlightedSet(state: DatasetState): TableData {
+    return state.highlightedSet.tableData;
+  },
   getIncludedTableData(state: DatasetState): TableData {
     return state.includedSet.tableData;
   },
@@ -133,7 +134,9 @@ export const getters = {
       ? state.includedSet.tableData.numRowsFiltered
       : 0;
   },
-
+  getHighlightedTableDataItems(state: DatasetState) {
+    return getTableDataItems(state.highlightedSet.tableData);
+  },
   getIncludedTableDataItems(state: DatasetState, getters: any): TableRow[] {
     return getTableDataItems(state.includedSet.tableData);
   },

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -118,8 +118,11 @@ export const getters = {
   hasIncludedTableData(state: DatasetState): boolean {
     return !!state.includedSet.tableData;
   },
-  getHighlightedSet(state: DatasetState): TableData {
-    return state.highlightedSet.tableData;
+  getHighlightedIncludeSet(state: DatasetState): TableData {
+    return state.highlightedIncludeSet.tableData;
+  },
+  getHighlightedExcludeSet(state: DatasetState): TableData {
+    return state.highlightedExcludeSet.tableData;
   },
   getIncludedTableData(state: DatasetState): TableData {
     return state.includedSet.tableData;
@@ -134,8 +137,11 @@ export const getters = {
       ? state.includedSet.tableData.numRowsFiltered
       : 0;
   },
-  getHighlightedTableDataItems(state: DatasetState) {
-    return getTableDataItems(state.highlightedSet.tableData);
+  getHighlightedIncludeTableDataItems(state: DatasetState) {
+    return getTableDataItems(state.highlightedIncludeSet.tableData);
+  },
+  getHighlightedExcludeTableDataItems(state: DatasetState) {
+    return getTableDataItems(state.highlightedExcludeSet.tableData);
   },
   getIncludedTableDataItems(state: DatasetState, getters: any): TableRow[] {
     return getTableDataItems(state.includedSet.tableData);

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -359,7 +359,8 @@ export interface DatasetState {
   joinTableData: Dictionary<TableData>;
   includedSet: WorkingSet;
   excludedSet: WorkingSet;
-  highlightedSet: WorkingSet;
+  highlightedIncludeSet: WorkingSet;
+  highlightedExcludeSet: WorkingSet;
   pendingRequests: DatasetPendingRequest[];
   task: Task;
   bands: BandCombination[];
@@ -419,7 +420,12 @@ export const state: DatasetState = {
     variableSummariesByKey: {},
     rowSelectionData: [],
   },
-  highlightedSet: {
+  highlightedIncludeSet: {
+    tableData: null,
+    variableSummariesByKey: {},
+    rowSelectionData: [],
+  },
+  highlightedExcludeSet: {
     tableData: null,
     variableSummariesByKey: {},
     rowSelectionData: [],

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -12,6 +12,7 @@ export interface Highlight {
   dataset: string;
   key: string;
   value: any;
+  include?: string;
 }
 
 export interface Column {
@@ -358,6 +359,7 @@ export interface DatasetState {
   joinTableData: Dictionary<TableData>;
   includedSet: WorkingSet;
   excludedSet: WorkingSet;
+  highlightedSet: WorkingSet;
   pendingRequests: DatasetPendingRequest[];
   task: Task;
   bands: BandCombination[];
@@ -417,7 +419,11 @@ export const state: DatasetState = {
     variableSummariesByKey: {},
     rowSelectionData: [],
   },
-
+  highlightedSet: {
+    tableData: null,
+    variableSummariesByKey: {},
+    rowSelectionData: [],
+  },
   // linked files / representation data
   files: {},
   timeseries: {},

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -209,6 +209,7 @@ export interface TableRow {
   _rowVariant: string;
   _cellVariants: Dictionary<string>;
   d3mIndex?: number;
+  isExcluded?: boolean;
 }
 
 export interface TimeseriesExtrema {

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -52,8 +52,11 @@ export const getters = {
   // join data
   getJoinDatasetsTableData: read(moduleGetters.getJoinDatasetsTableData),
   // highlighted data
-  getHighlightedTableDataItems: read(
-    moduleGetters.getHighlightedTableDataItems
+  getHighlightedIncludeTableDataItems: read(
+    moduleGetters.getHighlightedIncludeTableDataItems
+  ),
+  getHighlightedExcludeTableDataItems: read(
+    moduleGetters.getHighlightedExcludeTableDataItems
   ),
   // included data
   hasIncludedTableData: read(moduleGetters.hasIncludedTableData),
@@ -180,7 +183,12 @@ export const mutations = {
   clearJoinDatasetsTableData: commit(
     moduleMutations.clearJoinDatasetsTableData
   ),
-  setHighlightedTableData: commit(moduleMutations.setHighlightedTableData),
+  setHighlightedIncludeTableData: commit(
+    moduleMutations.setHighlightedIncludeTableData
+  ),
+  setHighlightedExcludeTableData: commit(
+    moduleMutations.setHighlightedExcludeTableData
+  ),
   setIncludedTableData: commit(moduleMutations.setIncludedTableData),
   setExcludedTableData: commit(moduleMutations.setExcludedTableData),
   updateBands: commit(moduleMutations.updateBands),

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -51,7 +51,10 @@ export const getters = {
 
   // join data
   getJoinDatasetsTableData: read(moduleGetters.getJoinDatasetsTableData),
-
+  // highlighted data
+  getHighlightedTableDataItems: read(
+    moduleGetters.getHighlightedTableDataItems
+  ),
   // included data
   hasIncludedTableData: read(moduleGetters.hasIncludedTableData),
   getIncludedTableData: read(moduleGetters.getIncludedTableData),
@@ -135,6 +138,7 @@ export const actions = {
   // included / excluded table data
   fetchIncludedTableData: dispatch(moduleActions.fetchIncludedTableData),
   fetchExcludedTableData: dispatch(moduleActions.fetchExcludedTableData),
+  fetchHighlightedTableData: dispatch(moduleActions.fetchHighlightedTableData),
   // task info
   fetchTask: dispatch(moduleActions.fetchTask),
   // multiband image band combinations
@@ -176,6 +180,7 @@ export const mutations = {
   clearJoinDatasetsTableData: commit(
     moduleMutations.clearJoinDatasetsTableData
   ),
+  setHighlightedTableData: commit(moduleMutations.setHighlightedTableData),
   setIncludedTableData: commit(moduleMutations.setIncludedTableData),
   setExcludedTableData: commit(moduleMutations.setExcludedTableData),
   updateBands: commit(moduleMutations.updateBands),

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -335,7 +335,9 @@ export const mutations = {
   clearJoinDatasetsTableData(state: DatasetState) {
     state.joinTableData = {};
   },
-
+  setHighlightedTableData(state: DatasetState, tableData: TableData) {
+    state.highlightedSet.tableData = Object.freeze(tableData);
+  },
   // sets the current selected data into the store
   setIncludedTableData(state: DatasetState, tableData: TableData) {
     // freezing the return to prevent slow, unnecessary deep reactivity.

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -335,8 +335,11 @@ export const mutations = {
   clearJoinDatasetsTableData(state: DatasetState) {
     state.joinTableData = {};
   },
-  setHighlightedTableData(state: DatasetState, tableData: TableData) {
-    state.highlightedSet.tableData = Object.freeze(tableData);
+  setHighlightedIncludeTableData(state: DatasetState, tableData: TableData) {
+    state.highlightedIncludeSet.tableData = Object.freeze(tableData);
+  },
+  setHighlightedExcludeTableData(state: DatasetState, tableData: TableData) {
+    state.highlightedExcludeSet.tableData = Object.freeze(tableData);
   },
   // sets the current selected data into the store
   setIncludedTableData(state: DatasetState, tableData: TableData) {

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -8,6 +8,7 @@ import {
   sortVariablesByImportance,
 } from "../../util/data";
 import { Dictionary } from "../../util/dict";
+import { EXCLUDE_FILTER } from "../../util/filters";
 import { getPredictionsById } from "../../util/predictions";
 import {
   DataMode,
@@ -445,7 +446,21 @@ export const actions = {
       }),
     ]);
   },
-
+  updateHighlight(context: ViewContext) {
+    const dataset = context.getters.getRouteDataset;
+    const highlight = context.getters.getDecodedHighlight;
+    const filterParams = context.getters.getDecodedSolutionRequestFilterParams;
+    const dataMode = context.getters.getDataMode;
+    return datasetActions.fetchHighlightedTableData(store, {
+      dataset: dataset,
+      filterParams: filterParams,
+      highlight: highlight,
+      dataMode: dataMode,
+    });
+  },
+  clearHighlight(context: ViewContext) {
+    datasetMutations.setHighlightedTableData(store, null);
+  },
   async fetchResultsData(context: ViewContext) {
     // clear previous state
     resultMutations.clearTargetSummary(store);

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -451,15 +451,26 @@ export const actions = {
     const highlight = context.getters.getDecodedHighlight;
     const filterParams = context.getters.getDecodedSolutionRequestFilterParams;
     const dataMode = context.getters.getDataMode;
-    return datasetActions.fetchHighlightedTableData(store, {
-      dataset: dataset,
-      filterParams: filterParams,
-      highlight: highlight,
-      dataMode: dataMode,
-    });
+    return Promise.all([
+      datasetActions.fetchHighlightedTableData(store, {
+        dataset: dataset,
+        filterParams: filterParams,
+        highlight: highlight,
+        dataMode: dataMode,
+        include: true,
+      }), // include
+      datasetActions.fetchHighlightedTableData(store, {
+        dataset: dataset,
+        filterParams: filterParams,
+        highlight: highlight,
+        dataMode: dataMode,
+        include: false,
+      }), // exclude
+    ]);
   },
   clearHighlight(context: ViewContext) {
-    datasetMutations.setHighlightedTableData(store, null);
+    datasetMutations.setHighlightedIncludeTableData(store, null);
+    datasetMutations.setHighlightedExcludeTableData(store, null);
   },
   async fetchResultsData(context: ViewContext) {
     // clear previous state

--- a/public/store/view/module.ts
+++ b/public/store/view/module.ts
@@ -34,6 +34,8 @@ export const actions = {
   fetchSelectTargetData: dispatch(moduleActions.fetchSelectTargetData),
   fetchSelectTrainingData: dispatch(moduleActions.fetchSelectTrainingData),
   updateSelectTrainingData: dispatch(moduleActions.updateSelectTrainingData),
+  updateHighlight: dispatch(moduleActions.updateHighlight),
+  clearHighlight: dispatch(moduleActions.clearHighlight),
   fetchResultsData: dispatch(moduleActions.fetchResultsData),
   updateResultsSummaries: dispatch(moduleActions.updateResultsSummaries),
   updateResultsSolution: dispatch(moduleActions.updateResultsSolution),

--- a/public/util/filters.ts
+++ b/public/util/filters.ts
@@ -110,6 +110,7 @@ export interface FilterParams {
   variables: string[];
   size?: number;
   dataMode?: string;
+  isHighlight?: boolean;
 }
 
 /**

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -141,6 +141,10 @@ export function addHighlightToFilterParams(
   highlight: Highlight,
   mode: string = INCLUDE_FILTER
 ): FilterParams {
+  if (highlight && highlight.include) {
+    // added the potential for tweaking the mode outside of the immediate store code
+    mode = highlight.include;
+  }
   const params = _.cloneDeep(filterParams);
   const highlightFilter = createFilterFromHighlight(highlight, mode);
   if (highlightFilter) {

--- a/public/views/SelectTraining.vue
+++ b/public/views/SelectTraining.vue
@@ -137,6 +137,11 @@ export default Vue.extend({
   watch: {
     highlightString() {
       viewActions.updateSelectTrainingData(this.$store);
+      if (!this.highlightString) {
+        viewActions.clearHighlight(this.$store);
+        return;
+      }
+      viewActions.updateHighlight(this.$store);
     },
     trainingStr() {
       viewActions.updateSelectTrainingData(this.$store);


### PR DESCRIPTION
- Objective of branch to add unselected points to geoplot. (while maintaining the standard geoplot functioning for the result view)
- Changed dropped down max display size to default to max
- Added extra list to store to contain the highlighted data (getters and actions to go along with it)
- Added extra param to data route isHighlight (not required to be there for standard use of the route)
- Basic overview of how this works: whenever there is a highlight created run the inclusive and exclusive version of the query and store this in the highlight lists (include and exclude highlight lists).
- Slight issue with cluster not updating might be another PR.
closes #2007 