### PR TITLE
#1994 Highlight Confidence & #1967 Model Feature Display

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -489,23 +489,7 @@ func (s *Storage) buildErrorResultWhere(wheres []string, params []interface{}, r
 
 func (s *Storage) buildConfidenceResultWhere(wheres []string, params []interface{}, confidenceFilter *model.Filter) ([]string, []interface{}, error) {
 	// Add a clause to filter residuals to the existing where
-
-	// Error keys are a string of the form <solutionID>:error.  We need to pull the solution ID out so we can find the name of the target var.
-	solutionID := api.StripKeySuffix(confidenceFilter.Key)
-
-	request, err := s.FetchRequestBySolutionID(solutionID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	targetVariable, err := s.getResultTargetVariable(request.Dataset, request.TargetFeature())
-	if err != nil {
-		return nil, nil, err
-	}
-
-	typedError := getErrorTyped("", targetVariable.Name)
-
-	where := fmt.Sprintf("(%s >= $%d AND %s <= $%d)", typedError, len(params)+1, typedError, len(params)+2)
+	where := fmt.Sprintf("(result.confidence >= $%d AND result.confidence <= $%d)", len(params)+1, len(params)+2)
 	params = append(params, *confidenceFilter.Min)
 	params = append(params, *confidenceFilter.Max)
 

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -488,7 +488,7 @@ func (s *Storage) buildErrorResultWhere(wheres []string, params []interface{}, r
 }
 
 func (s *Storage) buildConfidenceResultWhere(wheres []string, params []interface{}, confidenceFilter *model.Filter) ([]string, []interface{}, error) {
-	// Add a clause to filter residuals to the existing where
+	// Add a clause to filter confidence to the existing where
 	where := fmt.Sprintf("(result.confidence >= $%d AND result.confidence <= $%d)", len(params)+1, len(params)+2)
 	params = append(params, *confidenceFilter.Min)
 	params = append(params, *confidenceFilter.Max)

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -569,7 +569,7 @@ func addIncludeConfidenceResultToWhere(wheres []string, params []interface{}, co
 }
 
 func addExcludeConfidenceResultToWhere(wheres []string, params []interface{}, confidenceFilter *model.Filter) ([]string, []interface{}, error) {
-	where := fmt.Sprintf("(confidence < $%d AND confidence > $%d)", len(params)+1, len(params)+2)
+	where := fmt.Sprintf("(confidence < $%d OR confidence > $%d)", len(params)+1, len(params)+2)
 	params = append(params, *confidenceFilter.Min)
 	params = append(params, *confidenceFilter.Max)
 

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -558,6 +558,26 @@ func addExcludeErrorFilterToWhere(wheres []string, params []interface{}, alias s
 	return wheres, params, nil
 }
 
+func addIncludeConfidenceResultToWhere(wheres []string, params []interface{}, confidenceFilter *model.Filter) ([]string, []interface{}, error) {
+	where := fmt.Sprintf("(confidence >= $%d AND confidence <= $%d)", len(params)+1, len(params)+2)
+	params = append(params, *confidenceFilter.Min)
+	params = append(params, *confidenceFilter.Max)
+
+	// Append the AND clause
+	wheres = append(wheres, where)
+	return wheres, params, nil
+}
+
+func addExcludeConfidenceResultToWhere(wheres []string, params []interface{}, confidenceFilter *model.Filter) ([]string, []interface{}, error) {
+	where := fmt.Sprintf("(confidence < $%d AND confidence > $%d)", len(params)+1, len(params)+2)
+	params = append(params, *confidenceFilter.Min)
+	params = append(params, *confidenceFilter.Max)
+
+	// Append the AND clause
+	wheres = append(wheres, where)
+	return wheres, params, nil
+}
+
 func addTableAlias(prefix string, fields []string, addToColumn bool) []string {
 	fieldsPrepended := make([]string, len(fields))
 	for i, f := range fields {
@@ -655,6 +675,21 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 			wheres, params, err = addExcludeErrorFilterToWhere(wheres, params, dataTableAlias, targetName, filters.residualFilter)
 			if err != nil {
 				return nil, errors.Wrap(err, "Could not add error to where clause")
+			}
+		}
+	}
+
+	// Add the error filter into the where clause if it was included in the filter set
+	if filters.confidenceFilter != nil {
+		if filters.confidenceFilter.Mode == model.IncludeFilter {
+			wheres, params, err = addIncludeConfidenceResultToWhere(wheres, params, filters.confidenceFilter)
+			if err != nil {
+				return nil, errors.Wrap(err, "Could not add confidence to where clause")
+			}
+		} else {
+			wheres, params, err = addExcludeConfidenceResultToWhere(wheres, params, filters.confidenceFilter)
+			if err != nil {
+				return nil, errors.Wrap(err, "Could not add confidence to where clause")
 			}
 		}
 	}

--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -64,34 +64,34 @@
         </div>
       </div>
 
-      <div v-if="!expanded" class="card-expanded">
-        <b-button
-          class="full-width hover"
-          variant="outline-secondary"
-          v-on:click="toggleExpansion()"
-        >
-          More Details...
-        </b-button>
-      </div>
-
-      <div v-if="expanded" class="card-expanded">
-        <span><b>Full Description:</b></span>
-        <p v-html="highlightedDescription()"></p>
-        <b-button
-          class="full-width hover"
-          variant="outline-secondary"
-          v-on:click="toggleExpansion()"
-        >
-          Less Details...
-        </b-button>
+      <div class="row mt-1">
+        <div v-if="!expanded" class="col-12">
+          <b-button
+            class="full-width hover"
+            variant="outline-secondary"
+            @click="toggleExpansion()"
+          >
+            More Details...
+          </b-button>
+        </div>
+        <div v-if="expanded" class="col-12">
+          <span><b>Full Description:</b></span>
+          <p v-html="highlightedDescription()" />
+          <b-button
+            class="full-width hover"
+            variant="outline-secondary"
+            @click="toggleExpansion()"
+          >
+            Less Details...
+          </b-button>
+        </div>
       </div>
     </div>
     <error-modal
       :show="showImportFailure"
       title="Import Failed"
       @close="showImportFailure = !showImportFailure"
-    >
-    </error-modal>
+    />
   </div>
 </template>
 
@@ -128,6 +128,14 @@ export default Vue.extend({
     allowImport: Boolean as () => boolean,
   },
 
+  data() {
+    return {
+      expanded: false,
+      importPending: false,
+      showImportFailure: false,
+    };
+  },
+
   computed: {
     terms(): string {
       return routeGetters.getRouteTerms(this.$store);
@@ -147,14 +155,6 @@ export default Vue.extend({
     percentComplete(): number {
       return 100;
     },
-  },
-
-  data() {
-    return {
-      expanded: false,
-      importPending: false,
-      showImportFailure: false,
-    };
   },
 
   methods: {
@@ -257,9 +257,6 @@ export default Vue.extend({
 }
 .full-width {
   width: 100%;
-}
-.card-expanded {
-  padding-top: 15px;
 }
 .import-progress-bar {
   position: relative;

--- a/public/components/ModelPreview.vue
+++ b/public/components/ModelPreview.vue
@@ -1,8 +1,12 @@
 <template>
-  <div class="card card-result" @click="onResult()">
-    <div class="model-header hover card-header" variant="dark">
+  <div class="card card-result">
+    <div
+      class="model-header hover card-header"
+      variant="dark"
+      @click="onResult()"
+    >
       <a class="nav-link">
-        <i class="fa fa-connectdevelop"></i> <b>Model Name:</b>
+        <i class="fa fa-connectdevelop" /> <b>Model Name:</b>
         {{ model.modelName }}
       </a>
       <a class="nav-link"><b>Dateset Name:</b> {{ model.datasetName }}</a>
@@ -14,7 +18,7 @@
         <div class="col-4">
           <span><b>Features:</b></span>
           <ul>
-            <li :key="variable.name" v-for="variable in model.variables">
+            <li v-for="variable in topVariables" :key="variable">
               {{ variable }}
             </li>
           </ul>
@@ -24,6 +28,33 @@
           <p class="small-text">
             {{ model.modelDescription || "n/a" }}
           </p>
+        </div>
+      </div>
+
+      <div class="row mt-1">
+        <div v-if="!expanded" class="col-12">
+          <b-button
+            class="full-width hover"
+            variant="outline-secondary"
+            @click="toggleExpansion()"
+          >
+            More Details...
+          </b-button>
+        </div>
+        <div v-if="expanded" class="col-12">
+          <span><b>All Variables:</b></span>
+          <p>
+            <span v-for="(variable, i) in model.variables" :key="variable">
+              {{ variable + (i !== model.variables.length - 1 ? ", " : ".") }}
+            </span>
+          </p>
+          <b-button
+            class="full-width hover"
+            variant="outline-secondary"
+            @click="toggleExpansion()"
+          >
+            Less Details...
+          </b-button>
         </div>
       </div>
     </div>
@@ -36,11 +67,25 @@ import Vue from "vue";
 import { Model } from "../store/model/index";
 import { openModelSolution } from "../util/solutions";
 
+const NUM_TOP_FEATURES = 5;
+
 export default Vue.extend({
   name: "model-preview",
 
   props: {
     model: Object as () => Model,
+  },
+
+  data() {
+    return {
+      expanded: false,
+    };
+  },
+
+  computed: {
+    topVariables(): string[] {
+      return this.model.variables.slice(0, NUM_TOP_FEATURES);
+    },
   },
 
   methods: {
@@ -51,6 +96,9 @@ export default Vue.extend({
         fittedSolutionId: this.model.fittedSolutionId,
         variableFeatures: this.model.variables,
       });
+    },
+    toggleExpansion() {
+      this.expanded = !this.expanded;
     },
   },
 });

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -122,8 +122,12 @@ const fetchVariableSummaries = async (context, args) => {
 
   const allTrainingVariables = routeGetters.getTrainingVariables(store);
 
+  const sortedAllTrainingVariables = ranked
+    ? sortVariablesByImportance(allTrainingVariables.slice())
+    : allTrainingVariables;
+
   const searchedTrainingVariables = searchVariables(
-    allTrainingVariables,
+    sortedAllTrainingVariables,
     trainingSearch
   );
 


### PR DESCRIPTION
Closes #1994. Closes #1967.
- filter.go & result.go have new cases and functions to catch the confidence case and filter on it.
- modelPreview.vue now only shows the "top 5" from the list of variable names sent back in the model summary (filed an issue to actually send back variable scores as well so we can sort them and get a true top 5 later,) while also adding a toggle similar to dataset preview with the complete list of variables since we have the data and so people who want to look at it can see that detail before making a decision on which model to open. 
- datasetPreview.vue updated to match the cleaned up layout I set up on modelPreview.vue
- actions.ts has a quick fix for unloaded/missing features to model in select model features view when ranked as they weren't being sorted for loading like the available features were.