### PR TITLE
Mosaic image debounce memory management

### DIFF
--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -16,6 +16,7 @@
                 :type="imageField.type"
                 :key="fieldKey"
                 uniqueTrail="mosaic"
+                :debounce="true"
               ></image-preview>
             </template>
             <image-label

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -15,6 +15,7 @@
                 :on-click="onImageClick"
                 :type="imageField.type"
                 :key="fieldKey"
+                uniqueTrail="mosaic"
               ></image-preview>
             </template>
             <image-label
@@ -44,8 +45,9 @@
 
 <script lang="ts">
 import Vue from "vue";
-import ImageLabel from "./ImageLabel";
-import ImagePreview from "./ImagePreview";
+import _ from "lodash";
+import ImageLabel from "./ImageLabel.vue";
+import ImagePreview from "./ImagePreview.vue";
 import {
   RowSelection,
   TableColumn,
@@ -107,6 +109,7 @@ export default Vue.extend({
 
       return this.items.slice(start, end);
     },
+
     itemCount(): number {
       return this.includedActive
         ? datasetGetters.getIncludedTableDataLength(this.$store)

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -90,12 +90,8 @@ export default Vue.extend({
         this.cleanUp();
         this.hasRendered = false;
         this.hasRequested = false;
-        if (!this.image) {
-          this.clearImage();
-          this.getImage();
-        } else {
-          this.injectImage();
-        }
+        this.clearImage();
+        this.getImage();
       }
     },
 
@@ -279,7 +275,7 @@ export default Vue.extend({
   },
   created() {
     this.debouncedRequestImage = _.debounce(
-      this.requestImage,
+      this.requestImage.bind(this),
       this.debounceWaitTime
     );
     if (this.debounce) {
@@ -290,6 +286,9 @@ export default Vue.extend({
   },
   destroyed() {
     this.cleanUp();
+    if (this.debounce) {
+      this.getImage.cancel();
+    }
   },
 });
 </script>

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -38,6 +38,7 @@ import ImageDrilldown from "./ImageDrilldown.vue";
 import {
   getters as datasetGetters,
   actions as datasetActions,
+  mutations as datasetMutations,
 } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
 import { circleSpinnerHTML } from "../util/spinner";
@@ -64,6 +65,7 @@ export default Vue.extend({
   props: {
     row: Object as () => TableRow,
     imageUrl: String as () => string,
+    uniqueTrail: { type: String as () => string, default: "" },
     type: String as () => string,
     width: {
       default: 64,
@@ -83,6 +85,7 @@ export default Vue.extend({
   watch: {
     imageUrl(newUrl: string, oldUrl: string) {
       if (newUrl !== oldUrl) {
+        this.cleanUp();
         this.hasRendered = false;
         this.hasRequested = false;
         if (!this.image) {
@@ -97,6 +100,7 @@ export default Vue.extend({
     // Refresh image on band change
     band(newBand: string, oldBand: string) {
       if (newBand !== oldBand) {
+        this.cleanUp();
         this.hasRendered = false;
         this.hasRequested = false;
         if (this.isVisible) {
@@ -240,6 +244,15 @@ export default Vue.extend({
         console.warn(`Image Data Type ${this.type} is not supported`);
       }
     },
+    cleanUp() {
+      const empty = "";
+      if (this.uniqueTrail !== empty) {
+        datasetMutations.removeFile(
+          this.$store,
+          `${this.imageId}/${this.uniqueTrail}`
+        );
+      }
+    },
   },
 
   async beforeMount() {
@@ -252,6 +265,9 @@ export default Vue.extend({
         dataset: this.dataset,
       });
     }
+  },
+  destroyed() {
+    this.cleanUp();
   },
 });
 </script>

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -10,11 +10,7 @@ import {
   validateArgs,
 } from "../../util/data";
 import { Dictionary } from "../../util/dict";
-import {
-  EXCLUDE_FILTER,
-  FilterParams,
-  INCLUDE_FILTER,
-} from "../../util/filters";
+import { EXCLUDE_FILTER, FilterParams } from "../../util/filters";
 import { addHighlightToFilterParams } from "../../util/highlights";
 import { loadImage } from "../../util/image";
 import {
@@ -1118,6 +1114,7 @@ export const actions = {
       imageId: string;
       bandCombination: string;
       isThumbnail: boolean;
+      uniqueTrail?: string;
     }
   ) {
     if (!validateArgs(args, ["dataset", "imageId", "bandCombination"])) {
@@ -1128,7 +1125,10 @@ export const actions = {
       const response = await loadImage(
         `distil/multiband-image/${args.dataset}/${args.imageId}/${args.bandCombination}/${args.isThumbnail}`
       );
-      mutations.updateFile(context, { url: args.imageId, file: response });
+      const imageUrl = !!args.uniqueTrail
+        ? `${args.imageId}/${args.uniqueTrail}`
+        : args.imageId;
+      mutations.updateFile(context, { url: imageUrl, file: response });
     } catch (error) {
       console.error(error);
     }

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -1,10 +1,10 @@
 import { Module } from "vuex";
-import { state, DatasetState } from "./index";
-import { getters as moduleGetters } from "./getters";
-import { actions as moduleActions } from "./actions";
-import { mutations as moduleMutations } from "./mutations";
-import { DistilState } from "../store";
 import { getStoreAccessors } from "vuex-typescript";
+import { DistilState } from "../store";
+import { actions as moduleActions } from "./actions";
+import { getters as moduleGetters } from "./getters";
+import { DatasetState, state } from "./index";
+import { mutations as moduleMutations } from "./mutations";
 
 export const datasetModule: Module<DatasetState, DistilState> = {
   getters: moduleGetters,
@@ -178,6 +178,7 @@ export const mutations = {
   removePendingRequest: commit(moduleMutations.removePendingRequest),
   // files
   updateFile: commit(moduleMutations.updateFile),
+  removeFile: commit(moduleMutations.removeFile),
   updateTimeseries: commit(moduleMutations.updateTimeseries),
   // included / excluded table data
   setJoinDatasetsTableData: commit(moduleMutations.setJoinDatasetsTableData),

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -1,28 +1,28 @@
 import _ from "lodash";
 import Vue from "vue";
-import { Dictionary } from "../../util/dict";
 import {
-  DatasetState,
-  Variable,
-  Dataset,
-  VariableSummary,
-  TableData,
-  DatasetPendingRequest,
-  Task,
-  BandCombination,
-  TimeSeriesValue,
-  Metric,
-} from "./index";
-import {
-  updateSummariesPerVariable,
   isDatamartProvenance,
+  updateSummariesPerVariable,
 } from "../../util/data";
+import { Dictionary } from "../../util/dict";
+import { getSelectedRows } from "../../util/row";
 import {
   GEOCOORDINATE_TYPE,
-  LONGITUDE_TYPE,
   LATITUDE_TYPE,
+  LONGITUDE_TYPE,
 } from "../../util/types";
-import { getSelectedRows } from "../../util/row";
+import {
+  BandCombination,
+  Dataset,
+  DatasetPendingRequest,
+  DatasetState,
+  Metric,
+  TableData,
+  Task,
+  TimeSeriesValue,
+  Variable,
+  VariableSummary,
+} from "./index";
 
 function sortDatasets(a: Dataset, b: Dataset) {
   if (
@@ -250,7 +250,9 @@ export const mutations = {
   updateFile(state: DatasetState, args: { url: string; file: any }) {
     Vue.set(state.files, args.url, args.file);
   },
-
+  removeFile(state: DatasetState, url: string) {
+    Vue.delete(state.files, url);
+  },
   updateTimeseries(
     state: DatasetState,
     args: {


### PR DESCRIPTION
closes #2020 
- Added debounce to image mosaic
- Added cleanup functions for removing img src from the store after it is not needed
- Added uniqueTrail to fetchingImages ( allows for components to have specific ownership of images, therefore allowing them to be deleted without having to worry if another component is referencing the image.)