### PR TITLE
Fix filter badges from overflowing.

### DIFF
--- a/public/components/FilterBadge.vue
+++ b/public/components/FilterBadge.vue
@@ -1,29 +1,8 @@
 <template>
-  <div class="filter-badge" v-bind:class="{ active: activeFilter }">
-    {{ filterName }}
-    <span v-if="filter.type === NUMERICAL_FILTER">
-      {{ filter.min.toFixed(2) }} : {{ filter.max.toFixed(2) }}
-    </span>
-    <span v-if="filter.type === DATETIME_FILTER">
-      {{ formatDate(filter.min * 1000) }} : {{ formatDate(filter.max * 1000) }}
-    </span>
-    <span v-if="filter.type === GEOBOUNDS_FILTER">
-      [{{ filter.minX.toFixed(2) }}, {{ filter.minY.toFixed(2) }}] to [{{
-        filter.maxX.toFixed(2)
-      }}, {{ filter.maxY.toFixed(2) }}]
-    </span>
-    <span
-      v-if="
-        filter.type === CATEGORICAL_FILTER ||
-        filter.type === CLUSTER_FILTER ||
-        filter.type === TEXT_FILTER
-      "
-    >
-      {{ filter.categories.join(",") }}
-    </span>
-
+  <div class="filter-badge" :class="{ active: activeFilter }">
+    {{ name }} {{ content }}
     <b-button class="remove-button" size="sm" @click="onClick">
-      <i class="fa fa-times"></i>
+      <i class="fa fa-times" />
     </b-button>
   </div>
 </template>
@@ -53,26 +32,32 @@ export default Vue.extend({
   },
 
   computed: {
-    filterName(): string {
+    name(): string {
       return this.filter.displayName;
     },
-    NUMERICAL_FILTER(): string {
-      return NUMERICAL_FILTER;
-    },
-    DATETIME_FILTER(): string {
-      return DATETIME_FILTER;
-    },
-    CATEGORICAL_FILTER(): string {
-      return CATEGORICAL_FILTER;
-    },
-    TEXT_FILTER(): string {
-      return TEXT_FILTER;
-    },
-    CLUSTER_FILTER(): string {
-      return CLUSTER_FILTER;
-    },
-    GEOBOUNDS_FILTER(): string {
-      return GEOBOUNDS_FILTER;
+
+    content(): string {
+      if (this.filter.type === NUMERICAL_FILTER) {
+        const min = this.filter.min.toFixed(2);
+        const max = this.filter.max.toFixed(2);
+        return `${min} : ${max}`;
+      } else if (this.filter.type === DATETIME_FILTER) {
+        const min = this.formatDate(this.filter.min * 1000);
+        const max = this.formatDate(this.filter.max * 1000);
+        return `${min} : ${max}`;
+      } else if (this.filter.type === GEOBOUNDS_FILTER) {
+        const minX = this.filter.minX.toFixed(2);
+        const minY = this.filter.minY.toFixed(2);
+        const maxX = this.filter.maxX.toFixed(2);
+        const maxY = this.filter.maxY.toFixed(2);
+        return `[${minX}, ${minY}] to [${maxX}, ${maxY}]`;
+      } else if (
+        [CATEGORICAL_FILTER, CLUSTER_FILTER, TEXT_FILTER].includes(
+          this.filter.type
+        )
+      ) {
+        return this.filter.categories.join(",");
+      }
     },
   },
 
@@ -92,7 +77,7 @@ export default Vue.extend({
 });
 </script>
 
-<style>
+<style scoped>
 .filter-badge {
   position: relative;
   height: 28px;
@@ -107,7 +92,7 @@ export default Vue.extend({
   background-color: #255dcc;
 }
 
-button.remove-button {
+.remove-button {
   color: #fff;
   margin-left: 8px;
   background: none;
@@ -117,14 +102,15 @@ button.remove-button {
   border: none;
   border-left: 1px solid #fff;
 }
-button.remove-button:hover {
+
+.remove-button:hover {
   color: #fff;
   background-color: #3d70d3;
   border: none;
   border-left: 1px solid #fff;
 }
 
-.active button.remove-button:hover {
+.active .remove-button:hover {
   background-color: #3d70d3;
 }
 </style>

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -21,19 +21,12 @@
     </view-type-toggle>
 
     <div class="fake-search-input">
-      <div>
-        <filter-badge
-          v-if="activeFilter"
-          active-filter
-          :filter="activeFilter"
-        />
-        <filter-badge
-          v-if="filter.type !== 'row'"
-          v-for="filter in filters"
-          :key="filterHash(filter)"
-          :filter="filter"
-        />
-      </div>
+      <filter-badge v-if="activeFilter" active-filter :filter="activeFilter" />
+      <filter-badge
+        v-for="(filter, index) in filters"
+        :key="index"
+        :filter="filter"
+      />
     </div>
 
     <div class="table-title-container">
@@ -97,15 +90,15 @@
 <script lang="ts">
 import Vue from "vue";
 import { spinnerHTML } from "../util/spinner";
-import DataSize from "../components/buttons/DataSize";
-import SelectDataTable from "./SelectDataTable";
-import ImageMosaic from "./ImageMosaic";
-import SelectTimeseriesView from "./SelectTimeseriesView";
-import SelectGeoPlot from "./SelectGeoPlot";
-import SelectGraphView from "./SelectGraphView";
-import FilterBadge from "./FilterBadge";
-import ViewTypeToggle from "./ViewTypeToggle";
-import LayerSelection from "./LayerSelection";
+import DataSize from "../components/buttons/DataSize.vue";
+import SelectDataTable from "./SelectDataTable.vue";
+import ImageMosaic from "./ImageMosaic.vue";
+import SelectTimeseriesView from "./SelectTimeseriesView.vue";
+import SelectGeoPlot from "./SelectGeoPlot.vue";
+import SelectGraphView from "./SelectGraphView.vue";
+import FilterBadge from "./FilterBadge.vue";
+import ViewTypeToggle from "./ViewTypeToggle.vue";
+import LayerSelection from "./LayerSelection.vue";
 import { overlayRouteEntry } from "../util/routes";
 import {
   actions as datasetActions,
@@ -268,7 +261,9 @@ export default Vue.extend({
     },
 
     filters(): Filter[] {
-      return routeGetters.getDecodedFilters(this.$store);
+      return routeGetters
+        .getDecodedFilters(this.$store)
+        .filter((f) => f.type !== "row");
     },
 
     rowSelection(): RowSelection {
@@ -306,10 +301,6 @@ export default Vue.extend({
   },
 
   methods: {
-    filterHash(filter: Filter) {
-      return JSON.stringify(filter);
-    },
-
     onExcludeClick() {
       let filter = null;
       if (this.isFilteringHighlights) {
@@ -449,15 +440,17 @@ table tr {
 }
 
 .fake-search-input {
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-  flex-grow: 1;
   background-color: var(--gray-300);
-  border: 1px solid var(--gray-500); /* #ccc */
+  border: 1px solid var(--gray-500);
   border-radius: 0.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  min-height: 2.5rem;
   padding: 3px;
-  height: 38px;
+}
+
+.fake-search-input > .filter-badge {
+  margin: 2px;
 }
 
 .pending {
@@ -475,6 +468,11 @@ table tr {
 
 .layer-select-dropdown {
   margin-right: 6px;
+}
+
+/* Make firsts element of this component unsquishable. */
+.select-data-slot > *:not(:last-child) {
+  flex-shrink: 0;
 }
 
 .selection-data-slot-summary {

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -78,7 +78,7 @@
       v-model="currentPage"
       :per-page="perPage"
       :total-rows="itemCount"
-    ></b-pagination>
+    />
   </div>
 </template>
 
@@ -320,5 +320,14 @@ table tr {
 .table-hover tbody .table-selected-row:hover {
   border-left: 4px solid #ff0067;
   background-color: rgba(255, 0, 103, 0.4);
+}
+
+/* 
+  This keep the pagination from being squished by the table. 
+  The double _.distil-table-container is to increase 
+  specificity over the <b-pagination> component style.
+*/
+.distil-table-container.distil-table-container > .pagination {
+  flex-shrink: 0;
 }
 </style>


### PR DESCRIPTION
closes #2016 

- Clean up a bit the filter badges and input by removing extra markup.
- Tuned the flex settings to avoid overflowing and collapse of the filter input component.
- Re-adjusted the table-container and pagination to be displayed properly.
