### PR TITLE
Adds env vars for remote sensing gpu batch size + num jobs

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	IngestOverwrite                    bool    `env:"INGEST_OVERWRITE" envDefault:"false"`
 	IngestSampleRowLimit               int     `env:"INGEST_SAMPLE_ROW_LIMIT" envDefault:"25000"`
 	InitialDataset                     string  `env:"INITIAL_DATASET" envDefault:""`
+	MapAPIKey                          string  `env:"MAP_API_KEY" envDefault:""` // can be empty
 	MaxTrainingRows                    int     `env:"MAX_TRAINING_ROWS" envDefault:"100000"`
 	MaxTestRows                        int     `env:"MAX_TEST_ROWS" envDefault:"100000"`
 	MinTrainingRows                    int     `env:"MIN_TRAINING_ROWS" envDefault:"100"`
@@ -74,6 +75,8 @@ type Config struct {
 	PostgresUser                       string  `env:"PG_USER" envDefault:"distil"`
 	RankingOutputPath                  string  `env:"RANKING_OUTPUT_PATH" envDefault:"importance.json"`
 	RankingRowLimit                    int     `env:"RANKING_ROW_LIMIT" envDefault:"1000"`
+	RemoteSensingGPUBatchSize          int     `env:"REMOTE_SENSING_GPU_BATCH_SIZE" envDefault:"32"`
+	RemoteSensingNumJobs               int     `env:"REMOTE_SENSING_NUM_JOBS" envDefault:"-1"` // -1 sets num jobs = num cpus
 	SchemaPath                         string  `env:"SCHEMA_PATH" envDefault:"datasetDoc.json"`
 	SkipIngest                         bool    `env:"SKIP_INGEST" envDefault:"false"`
 	SkipPreprocessing                  bool    `env:"SKIP_PREPROCESSING" envDefault:"false"`
@@ -83,17 +86,16 @@ type Config struct {
 	SolutionComputePullMax             int     `env:"SOLUTION_COMPUTE_PULL_MAX" envDefault:"10"`
 	SolutionSearchMaxTime              int     `env:"SOLUTION_SEARCH_MAX_TIME" envDefault:"10"`
 	SolutionComputeTrace               bool    `env:"SOLUTION_COMPUTE_TRACE" envDefault:"false"`
+	Subdomains                         string  `env:"SUBDOMAINS" envDefault:"a,b,c"` // comma delimited array -- can be empty
 	SummaryPath                        string  `env:"SUMMARY_PATH" envDefault:"summary.txt"`
 	SummaryMachinePath                 string  `env:"SUMMARY_MACHINE_PATH" envDefault:"summary-machine.json"`
 	SummaryEnabled                     bool    `env:"SUMMARY_ENABLED" envDefault:"true"`
 	ServiceRetryCount                  int     `env:"SERVICE_RETRY_COUNT" envDefault:"10"`
+	TileRequestURL                     string  `env:"TILE_REQUEST_URL" envDefault:"https:/{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"` // s is subdomain does not have to be there, x,y is position z is zoom level. {t} is token The url must have the brackets around the data required.
 	TrainTestSplit                     float64 `env:"TRAIN_TEST_SPLIT" envDefault:"0.9"`
 	TrainTestSplitTimeSeries           float64 `env:"TRAIN_TEST_SPLIT_TIMESERIES" envDefault:"0.9"`
 	UserProblemPath                    string  `env:"USER_PROBLEM_PATH" envDefault:"outputs/problems"`
 	VerboseError                       bool    `env:"VERBOSE_ERROR" envDefault:"false"`
-	MapAPIKey                          string  `env:"MAP_API_KEY" envDefault:""`                                                                // can be empty
-	TileRequestURL                     string  `env:"TILE_REQUEST_URL" envDefault:"https:/{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"` // s is subdomain does not have to be there, x,y is position z is zoom level. {t} is token The url must have the brackets around the data required.
-	Subdomains                         string  `env:"SUBDOMAINS" envDefault:"a,b,c"`                                                            // comma delimited array -- can be empty
 }
 
 // LoadConfig loads the config from the environment if necessary and returns a copy.

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -141,8 +141,13 @@ func Cluster(dataset *api.Dataset, variable string, useKMeans bool) (bool, []*Cl
 					"remote_sensing_cluster", "k-means pre-featurized remote sensing clustering", variables, useKMeans)
 			}
 		} else {
-			rsg := clusterGroup.(*model.MultiBandImageGrouping)
-			step, err = description.CreateMultiBandImageClusteringPipeline("remote_sensing_cluster", "multiband image clustering", rsg, features, useKMeans)
+			var envConfig env.Config
+			envConfig, err = env.LoadConfig()
+			if err == nil {
+				rsg := clusterGroup.(*model.MultiBandImageGrouping)
+				step, err = description.CreateMultiBandImageClusteringPipeline("remote_sensing_cluster", "multiband image clustering",
+					rsg, features, useKMeans, envConfig.RemoteSensingGPUBatchSize, envConfig.RemoteSensingNumJobs)
+			}
 		}
 	} else if clusteringVar.DistilRole == model.VarDistilRoleGrouping {
 		// assume timeseries for now if distil role is grouping

--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -41,6 +41,11 @@ func submitForBatch(pip *description.FullySpecifiedPipeline) func(string) (strin
 // FeaturizeDataset creates a featurized output of the data that can be used
 // in simplified pipelines.
 func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset string, metaStorage api.MetadataStorage, config *IngestTaskConfig) (string, string, error) {
+	envConfig, err := env.LoadConfig()
+	if err != nil {
+		return "", "", err
+	}
+
 	// load the metadata from the metadata storage
 	ds, err := metaStorage.FetchDataset(dataset, true, true)
 	if err != nil {
@@ -48,7 +53,8 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 	}
 
 	// create & submit the featurize pipeline
-	pip, err := description.CreateMultiBandImageFeaturizationPipeline("Euler", "", ds.Variables)
+	pip, err := description.CreateMultiBandImageFeaturizationPipeline("Multiband image featurization", "", ds.Variables,
+		envConfig.RemoteSensingNumJobs, envConfig.RemoteSensingGPUBatchSize)
 	if err != nil {
 		return "", "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201031183438-dcf8a6bd94da
+	github.com/uncharted-distil/distil-compute v0.0.0-20201102223523-4986aad57b42
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201031183438-dcf8a6bd94da h1:TU9OBqvnEqTJGufSw5PSRk5P2c0lbmJDfoFdnQ9fF8c=
-github.com/uncharted-distil/distil-compute v0.0.0-20201031183438-dcf8a6bd94da/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
+github.com/uncharted-distil/distil-compute v0.0.0-20201102223523-4986aad57b42 h1:Jdwm7I37E9XbkM7FS90UezuJgBHN/KAFoI/0s4knGVg=
+github.com/uncharted-distil/distil-compute v0.0.0-20201102223523-4986aad57b42/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=


### PR DESCRIPTION
Fixes #2026 

Adds two new env vars and updates pipelines to accept them as args:

`REMOTE_SENSING_GPU_BATCH_SIZE` (default 32)
`REMOTE_SENSING_NUM_JOBS` (default -1, means 1 job per cpu)

