### PR TITLE
Add Dataset Cloning

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -170,7 +170,7 @@ type MetadataStorage interface {
 	UpdateDataset(dataset *Dataset) error
 
 	// CloneDataset creates a copy of an existing dataset
-	CloneDataset(dataset string, datasetNew string, storageNameNew string) error
+	CloneDataset(dataset string, datasetNew string, storageNameNew string, folderNew string) error
 }
 
 // ExportedModelStorageCtor represents a client constructor to instantiate a

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -96,6 +96,9 @@ type DataStorage interface {
 
 	// Property queries
 	GetStorageName(dataset string) (string, error)
+
+	// CloneDataset creates a copy of an existing dataset
+	CloneDataset(dataset string, storageName string, datasetNew string, storageNameNew string) error
 }
 
 // SolutionStorageCtor represents a client constructor to instantiate a
@@ -165,6 +168,9 @@ type MetadataStorage interface {
 	DeleteDataset(dataset string) error
 	IngestDataset(datasetSource metadata.DatasetSource, meta *model.Metadata) error
 	UpdateDataset(dataset *Dataset) error
+
+	// CloneDataset creates a copy of an existing dataset
+	CloneDataset(dataset string, datasetNew string, storageNameNew string) error
 }
 
 // ExportedModelStorageCtor represents a client constructor to instantiate a

--- a/api/model/storage/datamart/dataset.go
+++ b/api/model/storage/datamart/dataset.go
@@ -53,6 +53,11 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 	return s.download(s, id, uri)
 }
 
+// CloneDataset is not supported (ES datasets are already ingested).
+func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string) error {
+	return errors.Errorf("Not implemented")
+}
+
 // UpdateDataset updates a document consisting of the metadata to the datamart.
 func (s *Storage) UpdateDataset(dataset *api.Dataset) error {
 	return errors.Errorf("Not implemented")

--- a/api/model/storage/datamart/dataset.go
+++ b/api/model/storage/datamart/dataset.go
@@ -54,7 +54,7 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 }
 
 // CloneDataset is not supported (ES datasets are already ingested).
-func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string) error {
+func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string, folderNew string) error {
 	return errors.Errorf("Not implemented")
 }
 

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -49,6 +49,7 @@ func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew
 	ds.ID = datasetNew
 	ds.StorageName = storageNameNew
 	ds.Folder = folderNew
+	ds.Source = metadata.Augmented
 
 	return s.UpdateDataset(ds)
 }

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -39,7 +39,7 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 }
 
 // CloneDataset is not supported (ES datasets are already ingested).
-func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string) error {
+func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string, folderNew string) error {
 	ds, err := s.FetchDataset(dataset, true, true)
 	if err != nil {
 		return err
@@ -48,6 +48,7 @@ func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew
 	// update the id to match the new info
 	ds.ID = datasetNew
 	ds.StorageName = storageNameNew
+	ds.Folder = folderNew
 
 	return s.UpdateDataset(ds)
 }

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -38,6 +38,20 @@ func (s *Storage) ImportDataset(id string, uri string) (string, error) {
 	return "", errors.Errorf("Not Supported")
 }
 
+// CloneDataset is not supported (ES datasets are already ingested).
+func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string) error {
+	ds, err := s.FetchDataset(dataset, true, true)
+	if err != nil {
+		return err
+	}
+
+	// update the id to match the new info
+	ds.ID = datasetNew
+	ds.StorageName = storageNameNew
+
+	return s.UpdateDataset(ds)
+}
+
 // UpdateDataset updates a dataset already stored in ES.
 func (s *Storage) UpdateDataset(dataset *api.Dataset) error {
 	source := map[string]interface{}{

--- a/api/model/storage/file/dataset.go
+++ b/api/model/storage/file/dataset.go
@@ -44,6 +44,11 @@ func (s *Storage) IngestDataset(datasetSource metadata.DatasetSource, meta *mode
 	return errors.Errorf("Not implemented")
 }
 
+// CloneDataset is not supported (ES datasets are already ingested).
+func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string) error {
+	return errors.Errorf("Not implemented")
+}
+
 // UpdateDataset updates a document consisting of the metadata to the file system.
 func (s *Storage) UpdateDataset(dataset *api.Dataset) error {
 	return errors.Errorf("Not implemented")

--- a/api/model/storage/file/dataset.go
+++ b/api/model/storage/file/dataset.go
@@ -45,7 +45,7 @@ func (s *Storage) IngestDataset(datasetSource metadata.DatasetSource, meta *mode
 }
 
 // CloneDataset is not supported (ES datasets are already ingested).
-func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string) error {
+func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew string, folderNew string) error {
 	return errors.Errorf("Not implemented")
 }
 

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -39,6 +39,57 @@ type joinDefinition struct {
 	joinColumn    string
 }
 
+func getBaseTableName(storageName string) string {
+	return fmt.Sprintf("%s_base", storageName)
+}
+
+// CloneDataset clones an existing dataset.
+func (s *Storage) CloneDataset(dataset string, storageName string, datasetNew string, storageNameNew string) error {
+	// need to clone base, result, and weight tables
+	err := s.cloneTable(getBaseTableName(storageName), getBaseTableName(storageNameNew), true)
+	if err != nil {
+		return err
+	}
+
+	err = s.cloneTable(s.getResultTable(storageName), s.getResultTable(storageNameNew), false)
+	if err != nil {
+		return err
+	}
+
+	err = s.cloneTable(s.getSolutionFeatureWeightTable(storageName), s.getSolutionFeatureWeightTable(storageNameNew), false)
+	if err != nil {
+		return err
+	}
+
+	// need to create the view for the cloned dataset
+	fields, err := s.getExistingFields(dataset)
+	if err != nil {
+		return err
+	}
+
+	err = s.createView(storageNameNew, fields, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Storage) cloneTable(existingTable string, newTable string, copyData bool) error {
+	sql := fmt.Sprintf("CREATE TABLE %s AS TABLE %s", newTable, existingTable)
+	if !copyData {
+		sql = fmt.Sprintf("%s WITH NO DATA", sql)
+	}
+	sql = fmt.Sprintf("%s;", sql)
+
+	_, err := s.client.Exec(sql)
+	if err != nil {
+		return errors.Wrapf(err, "unable to clone table")
+	}
+
+	return nil
+}
+
 func (s *Storage) getViewField(fieldSelect string, displayName string, typ string, defaultValue interface{}) string {
 	viewField := fmt.Sprintf("COALESCE(CAST(%s AS %s), %v)", fieldSelect, typ, defaultValue)
 	if postgres.IsDatabaseFloatingPoint(typ) {

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -43,10 +43,19 @@ func getBaseTableName(storageName string) string {
 	return fmt.Sprintf("%s_base", storageName)
 }
 
+func getVariableTableName(storageName string) string {
+	return fmt.Sprintf("%s_variable", storageName)
+}
+
 // CloneDataset clones an existing dataset.
 func (s *Storage) CloneDataset(dataset string, storageName string, datasetNew string, storageNameNew string) error {
-	// need to clone base, result, and weight tables
+	// need to clone base, variable, result, and weight tables
 	err := s.cloneTable(getBaseTableName(storageName), getBaseTableName(storageNameNew), true)
+	if err != nil {
+		return err
+	}
+
+	err = s.cloneTable(getVariableTableName(storageName), getVariableTableName(storageNameNew), true)
 	if err != nil {
 		return err
 	}
@@ -158,7 +167,7 @@ func (s *Storage) createView(storageName string, fields map[string]*model.Variab
 
 	if overwrite {
 		// Drop the existing view.
-		_, err = s.client.Exec(fmt.Sprintf("DROP VIEW %s;", storageName))
+		_, err = s.client.Exec(fmt.Sprintf("DROP VIEW IF EXISTS %s;", storageName))
 		if err != nil {
 			return errors.Wrap(err, "Unable to drop existing view")
 		}

--- a/api/routes/clone.go
+++ b/api/routes/clone.go
@@ -1,0 +1,79 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"goji.io/v3/pat"
+
+	"github.com/uncharted-distil/distil/api/env"
+	api "github.com/uncharted-distil/distil/api/model"
+)
+
+// CloningHandler generates a route handler that enables cloning
+// of a dataset in the data storage and metadata storage.
+func CloningHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCtor, config env.Config) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		dataset := pat.Param(r, "dataset")
+
+		metaStorage, err := metaCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		dataStorage, err := dataCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		ds, err := metaStorage.FetchDataset(dataset, false, false)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// TODO: MAKE SURE CLONE NAME IS UNIQUE
+		datasetClone := fmt.Sprintf("%s_clone", dataset)
+		storageNameClone, err := dataStorage.GetStorageName(datasetClone)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		err = metaStorage.CloneDataset(dataset, datasetClone, storageNameClone)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		err = dataStorage.CloneDataset(dataset, ds.StorageName, datasetClone, storageNameClone)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// marshal output into JSON
+		err = handleJSON(w, map[string]interface{}{"success": true})
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal clustering result into JSON"))
+			return
+		}
+	}
+}

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -58,7 +58,7 @@ func CreateDataset(dataset string, datasetCtor DatasetConstructor, outputPath st
 
 	// save the csv file in the file system datasets folder
 	if !config.IngestOverwrite {
-		datasetUnique, err := getUniqueOutputFolder(dataset, outputPath)
+		datasetUnique, err := GetUniqueOutputFolder(dataset, outputPath)
 		if err != nil {
 			return "", "", err
 		}
@@ -175,7 +175,8 @@ func UpdateExtremas(dataset string, metaStorage api.MetadataStorage, dataStorage
 	return nil
 }
 
-func getUniqueOutputFolder(dataset string, outputPath string) (string, error) {
+// GetUniqueOutputFolder produces a unique name for a dataset in a folder.
+func GetUniqueOutputFolder(dataset string, outputPath string) (string, error) {
 	// read the folders in the output path
 	files, err := ioutil.ReadDir(outputPath)
 	if err != nil {

--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -66,7 +66,7 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 
 	// create the dataset folder
 	featurizedDatasetID := fmt.Sprintf("%s-featurized", dataset)
-	featurizedDatasetID, err = getUniqueOutputFolder(featurizedDatasetID, env.GetAugmentedPath())
+	featurizedDatasetID, err = GetUniqueOutputFolder(featurizedDatasetID, env.GetAugmentedPath())
 	if err != nil {
 		return "", "", err
 	}

--- a/main.go
+++ b/main.go
@@ -286,6 +286,7 @@ func main() {
 	registerRoutePost(mux, "/distil/cluster/:dataset/:variable", routes.ClusteringHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/cluster/:result-id", routes.ClusteringExplainHandler(pgSolutionStorageCtor, esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/upload/:dataset", routes.UploadHandler(&config))
+	registerRoutePost(mux, "/distil/clone/:dataset", routes.CloningHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/join", routes.JoinHandler(esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries/:dataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:invert", routes.TimeseriesHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries-forecast/:truthDataset/:forecastDataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:result-uuid", routes.TimeseriesForecastHandler(esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor, config.TrainTestSplitTimeSeries))


### PR DESCRIPTION
Before we can work on user annotations, we need to be able to clone existing datasets. The original dataset would remain unchanged, and the cloned dataset would be used for user annotations. This PR covers the addition of dataset cloning.

Cloning datasets requires the cloning of the metadata (ES), data (PG) and dataset on disk. A route for cloning was added for now, but given the unclear use case implementation, it is was done fairly quickly since it may be temporary in nature. Some of the code may end up being put in the task package or dropped entirely. Once we solidify exactly how a user will label data, then we will revisit the dataset cloning implementation to better meet the requirements.