### PR TITLE
Result drill down

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -220,6 +220,7 @@ export default Vue.extend({
     quadOpacity: { type: Number, default: 0.8 },
     pointOpacity: { type: Number, default: 0.8 },
     zoomThreshold: { type: Number, default: 8 },
+    maxZoom: { type: Number, default: 18 },
   },
 
   data() {
@@ -596,7 +597,7 @@ export default Vue.extend({
         continuousZoom: true,
         inertia: true,
         wraparound: true,
-        zoom: 3,
+        zoom: this.maxZoom,
         maxZoom: 11,
       });
       // WebGL CARTO Image Layer

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -187,6 +187,13 @@ interface LumoPoint {
   x: number;
   y: number;
 }
+export interface TileClickData {
+  bounds: number[][];
+  key: string;
+  displayName: string;
+  type: string;
+  callback: (inner: TableRow[], outer: TableRow[]) => void;
+}
 // Minimum pixels size of clickable target displayed on the map.
 const TARGETSIZE = 6;
 
@@ -778,24 +785,16 @@ export default Vue.extend({
         key: this.summaries[0].key,
         displayName: this.summaries[0].label,
         type: this.summaries[0].type,
-        callback: (isIncluded: boolean) => {
-          const innerGetter = isIncluded
-            ? datasetGetters.getAreaOfInterestIncludeInnerItems(this.$store)
-            : datasetGetters.getAreaOfInterestExcludeInnerItems(this.$store);
-          const inner = this.tableDataToAreas(innerGetter) as any[];
-          inner.forEach((i) => {
+        callback: (inner: TableRow[], outer: TableRow[]) => {
+          const innerArea = this.tableDataToAreas(inner) as any[];
+          innerArea.forEach((i) => {
             i.gray = 0;
           });
-          const outerGetter = isIncluded
-            ? datasetGetters.getAreaOfInterestIncludeOuterItems(this.$store)
-            : datasetGetters.getAreaOfInterestExcludeOuterItems(this.$store);
-
-          const outer = this.tableDataToAreas(outerGetter) as any[];
-          outer.forEach((i) => {
+          const outerArea = this.tableDataToAreas(outer) as any[];
+          outerArea.forEach((i) => {
             i.gray = 100;
           });
-          console.table([innerGetter, outerGetter]);
-          this.drillDownState.tiles = inner.concat(outer);
+          this.drillDownState.tiles = innerArea.concat(outerArea);
           this.isImageDrilldown = true;
         },
       });

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -449,6 +449,11 @@ export const actions = {
       filterParams.size = args.size;
     }
     filterParams.filters.push(args.filter);
+    // if highlight is null there is nothing to invert so return null
+    if (filterParams.highlight === null) {
+      mutations.setAreaOfInterestOuter(context, createEmptyTableData());
+      return;
+    }
     try {
       const response = await axios.post(
         `/distil/results/${args.dataset}/${encodeURIComponent(

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import _ from "lodash";
 import { Dictionary } from "vue-router/types/router";
+import { filter } from "vue/types/umd";
 import { ActionContext } from "vuex";
 import {
   createEmptyTableData,
@@ -11,7 +12,7 @@ import {
   minimumRouteKey,
   validateArgs,
 } from "../../util/data";
-import { EXCLUDE_FILTER } from "../../util/filters";
+import { EXCLUDE_FILTER, Filter } from "../../util/filters";
 import { addHighlightToFilterParams } from "../../util/highlights";
 import {
   getSolutionById,
@@ -357,7 +358,112 @@ export const actions = {
       mutations.setExcludedResultTableData(context, createEmptyTableData());
     }
   },
+  // fetches
+  async fetchAreaOfInterestInner(
+    context: ResultsContext,
+    args: {
+      solutionId: string;
+      dataset: string;
+      highlight: Highlight;
+      dataMode: DataMode;
+      size?: number;
+      filter: Filter; // the area of interest
+    }
+  ) {
+    const solution = getSolutionById(
+      context.rootState.requestsModule.solutions,
+      args.solutionId
+    );
+    if (!solution || !solution.resultId) {
+      // no results ready to pull
+      return null;
+    }
 
+    const filterParamsBlank = {
+      highlight: null,
+      variables: [],
+      filters: [],
+    };
+    const filterParams = addHighlightToFilterParams(
+      filterParamsBlank,
+      args.highlight
+    );
+
+    const dataModeDefault = args.dataMode ? args.dataMode : DataMode.Default;
+    filterParams.dataMode = dataModeDefault; // Add the size limit to results if provided.
+    if (_.isInteger(args.size)) {
+      filterParams.size = args.size;
+    }
+    filterParams.filters.push(args.filter);
+    try {
+      const response = await axios.post(
+        `/distil/results/${args.dataset}/${encodeURIComponent(
+          args.solutionId
+        )}`,
+        filterParams
+      );
+      mutations.setAreaOfInterestInner(context, response.data);
+    } catch (error) {
+      console.error(
+        `Failed to fetch results from ${args.solutionId} with error ${error}`
+      );
+      mutations.setAreaOfInterestInner(context, createEmptyTableData());
+    }
+  },
+  // fetches the tiles that are within the bounds but are filtered by another highlight
+  async fetchAreaOfInterestOuter(
+    context: ResultsContext,
+    args: {
+      solutionId: string;
+      dataset: string;
+      highlight: Highlight;
+      dataMode: DataMode;
+      size?: number;
+      filter: Filter;
+    }
+  ) {
+    const solution = getSolutionById(
+      context.rootState.requestsModule.solutions,
+      args.solutionId
+    );
+    if (!solution || !solution.resultId) {
+      // no results ready to pull
+      return null;
+    }
+
+    const filterParamsBlank = {
+      highlight: null,
+      variables: [],
+      filters: [],
+    };
+    const filterParams = addHighlightToFilterParams(
+      filterParamsBlank,
+      args.highlight,
+      EXCLUDE_FILTER
+    );
+
+    const dataModeDefault = args.dataMode ? args.dataMode : DataMode.Default;
+    filterParams.dataMode = dataModeDefault;
+    // Add the size limit to results if provided.
+    if (_.isInteger(args.size)) {
+      filterParams.size = args.size;
+    }
+    filterParams.filters.push(args.filter);
+    try {
+      const response = await axios.post(
+        `/distil/results/${args.dataset}/${encodeURIComponent(
+          args.solutionId
+        )}`,
+        filterParams
+      );
+      mutations.setAreaOfInterestOuter(context, response.data);
+    } catch (error) {
+      console.error(
+        `Failed to fetch results from ${args.solutionId} with error ${error}`
+      );
+      mutations.setAreaOfInterestOuter(context, createEmptyTableData());
+    }
+  },
   fetchResultTableData(
     context: ResultsContext,
     args: {

--- a/public/store/results/getters.ts
+++ b/public/store/results/getters.ts
@@ -65,6 +65,12 @@ export const getters = {
     return state.includedResultTableData;
   },
 
+  getAreaOfInterestInnerDataItems(state: ResultsState): TableRow[] {
+    return getTableDataItems(state.areaOfInterestInner);
+  },
+  getAreaOfInterestOuterDataItems(state: ResultsState): TableRow[] {
+    return getTableDataItems(state.areaOfInterestOuter);
+  },
   getIncludedResultTableDataItems(
     state: ResultsState,
     getters: any

--- a/public/store/results/index.ts
+++ b/public/store/results/index.ts
@@ -22,6 +22,9 @@ export interface ResultsState {
   // table data
   includedResultTableData: TableData;
   excludedResultTableData: TableData;
+  // areaOfInteres
+  areaOfInterestInner: TableData;
+  areaOfInterestOuter: TableData;
   // training / target
   trainingSummaries: Dictionary<Dictionary<VariableSummary>>;
   targetSummary: VariableSummary;
@@ -49,6 +52,9 @@ export const state: ResultsState = {
   // table data
   includedResultTableData: null,
   excludedResultTableData: null,
+  // area of interest for tiles clicks in geo map
+  areaOfInterestInner: null,
+  areaOfInterestOuter: null,
   // training / target
   trainingSummaries: {},
   targetSummary: null,

--- a/public/store/results/module.ts
+++ b/public/store/results/module.ts
@@ -54,7 +54,12 @@ export const getters = {
   hasResultTableDataItemsWeight: read(
     moduleGetters.hasResultTableDataItemsWeight
   ),
-
+  getAreaOfInterestInnerDataItems: read(
+    moduleGetters.getAreaOfInterestInnerDataItems
+  ),
+  getAreaOfInterestOuterDataItems: read(
+    moduleGetters.getAreaOfInterestOuterDataItems
+  ),
   // predicted
   getPredictedSummaries: read(moduleGetters.getPredictedSummaries),
   // residual
@@ -105,6 +110,9 @@ export const actions = {
   fetchFeatureImportanceRanking: dispatch(
     moduleActions.fetchFeatureImportanceRanking
   ),
+  // area of interest for tile clicks
+  fetchAreaOfInterestInner: dispatch(moduleActions.fetchAreaOfInterestInner),
+  fetchAreaOfInterestOuter: dispatch(moduleActions.fetchAreaOfInterestOuter),
 };
 
 // Typed mutations
@@ -121,6 +129,8 @@ export const mutations = {
   setExcludedResultTableData: commit(
     moduleMutations.setExcludedResultTableData
   ),
+  setAreaOfInterestInner: commit(moduleMutations.setAreaOfInterestInner),
+  setAreaOfInterestOuter: commit(moduleMutations.setAreaOfInterestOuter),
   // predicted
   updatePredictedSummaries: commit(moduleMutations.updatePredictedSummaries),
   // residuals

--- a/public/store/results/mutations.ts
+++ b/public/store/results/mutations.ts
@@ -43,7 +43,12 @@ export const mutations = {
     // freezing the return to prevent slow, unnecessary deep reactivity.
     state.excludedResultTableData = Object.freeze(resultData);
   },
-
+  setAreaOfInterestInner(state: ResultsState, resultData: TableData) {
+    state.areaOfInterestInner = Object.freeze(resultData);
+  },
+  setAreaOfInterestOuter(state: ResultsState, resultData: TableData) {
+    state.areaOfInterestOuter = Object.freeze(resultData);
+  },
   // predicted
 
   updatePredictedSummaries(state: ResultsState, summary: VariableSummary) {

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -575,7 +575,33 @@ export const actions = {
 
     return actions.updateResultsSolution(context);
   },
+  async updateResultAreaOfInterest(context: ViewContext, filter: Filter) {
+    // fetch new state
+    const dataset = routeGetters.getRouteDataset(store);
+    const solutionId = routeGetters.getRouteSolutionId(store);
+    const highlight = routeGetters.getDecodedHighlight(store);
+    const dataMode = context.getters.getDataMode;
+    const size = routeGetters.getRouteDataSize(store);
 
+    return Promise.all([
+      resultActions.fetchAreaOfInterestInner(store, {
+        dataset: dataset,
+        solutionId: solutionId,
+        highlight: highlight,
+        dataMode: dataMode,
+        size,
+        filter: filter,
+      }),
+      resultActions.fetchAreaOfInterestOuter(store, {
+        dataset: dataset,
+        solutionId: solutionId,
+        highlight: highlight,
+        dataMode: dataMode,
+        size,
+        filter: filter,
+      }),
+    ]);
+  },
   updateResultsSummaries(context: ViewContext) {
     const dataset = routeGetters.getRouteDataset(store);
     const trainingVariables = requestGetters.getActiveSolutionTrainingVariables(

--- a/public/store/view/module.ts
+++ b/public/store/view/module.ts
@@ -40,6 +40,9 @@ export const actions = {
   updateResultsSummaries: dispatch(moduleActions.updateResultsSummaries),
   updateResultsSolution: dispatch(moduleActions.updateResultsSolution),
   fetchPredictionsData: dispatch(moduleActions.fetchPredictionsData),
+  updateResultAreaOfInterest: dispatch(
+    moduleActions.updateResultAreaOfInterest
+  ),
   updatePredictionTrainingSummaries: dispatch(
     moduleActions.updatePredictionTrainingSummaries
   ),


### PR DESCRIPTION
closes #1992 
- Added result clustered drill down support
- Ignores the fact that there is two geoplots and treats them exactly like the select view (one geoplot with a highlighted set and greyed out set. The reason is the second geoplot is getting removed and is going to be treated like the select view)
- Added some types
- Added support to hold area of interest in result section of the store