### PR TITLE
fix for data not loading

### DIFF
--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -390,6 +390,13 @@ export default Vue.extend({
       viewActions.updateSelectTrainingData(this.$store);
     },
   },
+  watch: {
+    numRows(newVal: number) {
+      const entry = overlayRouteEntry(this.$route, { dataSize: newVal });
+      this.$router.push(entry).catch((err) => console.warn(err));
+      viewActions.updateSelectTrainingData(this.$store);
+    },
+  },
 });
 </script>
 


### PR DESCRIPTION
- Fixes issue with clustered drill down popping up tiles that were not rendered. The datasize was not updating the url on mount.

Should probably get rid of the datasize feature. 