### PR TITLE
Use different folder for server ingest

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -73,6 +73,7 @@ type Config struct {
 	PostgresPort                       int     `env:"PG_PORT" envDefault:"5432"`
 	PostgresRandomSeed                 float64 `env:"PG_RANDOM_SEED" envDefault:"0.2"`
 	PostgresUser                       string  `env:"PG_USER" envDefault:"distil"`
+	PublicSubFolder                    string  `env:"PUBLIC_SUBFOLDER" envDefault:"public"`
 	RankingOutputPath                  string  `env:"RANKING_OUTPUT_PATH" envDefault:"importance.json"`
 	RankingRowLimit                    int     `env:"RANKING_ROW_LIMIT" envDefault:"1000"`
 	RemoteSensingGPUBatchSize          int     `env:"REMOTE_SENSING_GPU_BATCH_SIZE" envDefault:"32"`

--- a/api/env/path.go
+++ b/api/env/path.go
@@ -37,6 +37,7 @@ var (
 	seedSubPath   = ""
 	augmentedPath = ""
 	batchPath     = ""
+	publicPath    = ""
 
 	initialized = false
 	isTask      = false
@@ -61,6 +62,7 @@ func Initialize(config *Config) error {
 	contribPath = config.DatamartImportFolder
 	augmentedPath = path.Join(config.D3MOutputDir, config.AugmentedSubFolder)
 	batchPath = path.Join(config.D3MOutputDir, config.BatchSubFolder)
+	publicPath = path.Join(config.D3MOutputDir, config.PublicSubFolder)
 
 	log.Infof("using '%s' as seed path", seedPath)
 	log.Infof("using '%s' as seed sub path", seedSubPath)
@@ -68,6 +70,7 @@ func Initialize(config *Config) error {
 	log.Infof("using '%s' as contrib path", contribPath)
 	log.Infof("using '%s' as augmented path", augmentedPath)
 	log.Infof("using '%s' as batch path", batchPath)
+	log.Infof("using '%s' as public path", publicPath)
 
 	initialized = true
 
@@ -146,6 +149,11 @@ func GetBatchPath() string {
 	return batchPath
 }
 
+// GetPublicPath returns the batch path as initialized.
+func GetPublicPath() string {
+	return publicPath
+}
+
 // ResolvePath returns an absolute path based on the dataset source.
 func ResolvePath(datasetSource metadata.DatasetSource, relativePath string) string {
 	switch datasetSource {
@@ -157,6 +165,8 @@ func ResolvePath(datasetSource metadata.DatasetSource, relativePath string) stri
 		return resolveAugmentedPath(relativePath)
 	case metadata.Batch:
 		return resolveBatchPath(relativePath)
+	case metadata.Public:
+		return resolvePublicPath(relativePath)
 	}
 	return resolveTmpPath(relativePath)
 }
@@ -179,6 +189,10 @@ func resolveAugmentedPath(relativePath string) string {
 
 func resolveBatchPath(relativePath string) string {
 	return path.Join(batchPath, relativePath)
+}
+
+func resolvePublicPath(relativePath string) string {
+	return path.Join(publicPath, relativePath)
 }
 
 func resolveTmpPath(relativePath string) string {

--- a/api/routes/datasets.go
+++ b/api/routes/datasets.go
@@ -165,11 +165,11 @@ func DatasetsHandler(metaCtors map[string]model.MetadataStorageCtor) func(http.R
 // files & folders that can be imported.
 func AvailableDatasetsHandler(metaCtor model.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// restrict to augmented folder
-		rootFolder := env.GetAugmentedPath()
+		// restrict to the public folder
+		rootFolder := env.GetPublicPath()
 		files, err := ioutil.ReadDir(rootFolder)
 		if err != nil {
-			handleError(w, errors.Wrap(err, "unable to read augmented folder contents"))
+			handleError(w, errors.Wrap(err, "unable to read public folder contents"))
 			return
 		}
 

--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -48,7 +48,7 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 
 		var origins []*model.DatasetOrigin
 		var rawGroupings []map[string]interface{}
-		if source == metadata.Augmented && provenance == "local" {
+		if (source == metadata.Augmented || source == metadata.Public) && provenance == "local" {
 			// parse POST params
 			params, err := getPostParameters(r)
 			if err != nil {
@@ -105,6 +105,12 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 				rawGroupings = creationResult.groups
 				log.Infof("Created dataset '%s' from local source '%s'", datasetID, datasetPath)
 			}
+		}
+
+		// If the source is Public, the dataset has been imported in the augmented folder,
+		// from now on, the ES and database ingestion are done from the augmented folder files.
+		if source == metadata.Public {
+			source = metadata.Augmented
 		}
 
 		meta, err := createMetadataStorageForSource(source, provenance, datamartCtors, fileMetaCtor, esMetaCtor)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201102223523-4986aad57b42
+	github.com/uncharted-distil/distil-compute v0.0.0-20201104153249-f5c647ca8e0e
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201102223523-4986aad57b42 h1:Jdwm7I37E9XbkM7FS90UezuJgBHN/KAFoI/0s4knGVg=
-github.com/uncharted-distil/distil-compute v0.0.0-20201102223523-4986aad57b42/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
+github.com/uncharted-distil/distil-compute v0.0.0-20201104153249-f5c647ca8e0e h1:qUBv2Z9Vp4/iZZPmkUL/OV8qzKwT6Qz0qUxJ7920VGU=
+github.com/uncharted-distil/distil-compute v0.0.0-20201104153249-f5c647ca8e0e/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/main.go
+++ b/main.go
@@ -341,4 +341,10 @@ func createOutputFolders(config *env.Config) {
 	if err := os.MkdirAll(augmentPath, os.ModePerm); err != nil {
 		log.Error(errors.Wrap(err, "failed to created output folder"))
 	}
+
+	// create the public data folder
+	publicPath := env.GetPublicPath()
+	if err := os.MkdirAll(publicPath, os.ModePerm); err != nil {
+		log.Error(errors.Wrap(err, "failed to created public folder"))
+	}
 }

--- a/public/components/AddDataset.vue
+++ b/public/components/AddDataset.vue
@@ -19,23 +19,25 @@
       />
     </b-form-group>
 
-    <strong>OR</strong>
+    <template v-if="isAvailableDatasets">
+      <strong>OR</strong>
 
-    <!-- Available Datasets -->
-    <b-form-group label="Select an available dataset">
-      <b-form-select
-        v-model="availableDatasetSelected"
-        :options="availableDatasets"
-        :select-size="Math.min(availableDatasets.length, 10)"
-      />
-      <i
-        slot="description"
-        class="fa fa-question-circle-o"
-        title="Lookup datasets already available in $D3MOUTPUTDIR/augmented."
-      />
-    </b-form-group>
+      <!-- Available Datasets -->
+      <b-form-group label="Select an available dataset">
+        <b-form-select
+          v-model="availableDatasetSelected"
+          :options="availableDatasets"
+          :select-size="Math.min(availableDatasets.length, 10)"
+        />
+        <i
+          slot="description"
+          class="fa fa-question-circle-o"
+          title="Lookup datasets available in $D3MOUTPUTDIR/PUBLIC_SUBFOLDER."
+        />
+      </b-form-group>
 
-    <hr />
+      <hr />
+    </template>
 
     <!-- Dataset Name -->
     <b-form-group
@@ -63,6 +65,7 @@ import {
   generateUniqueDatasetName,
 } from "../util/uploads";
 import { actions as datasetActions } from "../store/dataset/module";
+import { isEmpty } from "lodash";
 
 export default Vue.extend({
   name: "AddDataset",
@@ -95,6 +98,11 @@ export default Vue.extend({
         : !this.availableDatasetSelected;
       return noDataset || this.name?.length <= 0;
     },
+
+    // Check if we have any available datasets in the public folder
+    isAvailableDatasets(): boolean {
+      return !isEmpty(this.availableDatasets);
+    },
   },
 
   watch: {
@@ -124,10 +132,6 @@ export default Vue.extend({
         this.nameState = !!this.name;
       }
     },
-  },
-
-  beforeMount() {
-    this.getAvailableDatasets();
   },
 
   methods: {
@@ -171,8 +175,10 @@ export default Vue.extend({
 
     async importAvailableDataset() {
       // Make sure that the arguments are sound.
-      const { selectedName, selectedPath } = this.availableDatasetSelected;
-      const path = selectedPath + "/" + selectedName;
+      const path =
+        this.availableDatasetSelected.path +
+        "/" +
+        this.availableDatasetSelected.name;
       if (!path) return;
 
       // Notify external listeners that the file upload is starting

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -382,14 +382,14 @@ export const actions = {
     });
   },
 
-  // Import a Dataset that is available in $D3MOUTPUTDIR/augmented folder
+  // Import a Dataset that is available in $D3MOUTPUTDIR/PUBLIC_SUBFOLDER folder
   async importAvailableDataset(
     context: DatasetContext,
     args: { datasetID: string; path: string }
   ) {
     const response = await actions.importDataset(context, {
       datasetID: args.datasetID,
-      source: "augmented",
+      source: "public",
       provenance: "local",
       terms: args.datasetID,
       originalDataset: null,


### PR DESCRIPTION
closes #2042

Created a new _public_ folder under `$D3MOUTPUTDIR`.

- Updated distil-compute to add a folder as a dataset source.
- New ENV variable `PUBLIC_SUBFOLDER` to specify the folder.
- Updated the _AddDataset_ component and the _importAvailableDataset()_ to use the folder.