### PR TITLE
#2028 Model Selection Updates

### DIFF
--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -234,7 +234,7 @@ export enum TaskTypes {
   OBJECT_DETECTION = "objectDetection",
   SEMISUPERVISED = "semiSupervised",
   BINARY = "binary",
-  MULTICLASS = "multiclass",
+  MULTICLASS = "multiClass",
   MULTILABEL = "multilabel",
   UNIVARIATE = "univariate",
   MULTIVARIATE = "multivariate",


### PR DESCRIPTION
Closes #2028. Modified option section of the dom to allow for options to be tracked by a ID string (instead of an object) such that we could then easily preset an ID based on current task type on initial mount using logic similar to the go code that sends over the metric options. To ensure reuse and alignment with the back end, I updated the multiclass task constant dataset/index.ts as well.