### PR TITLE
Data update route

### DIFF
--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -17,6 +17,7 @@ package model
 
 import (
 	"github.com/pkg/errors"
+	log "github.com/unchartedsoftware/plog"
 
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
@@ -80,6 +81,45 @@ type JoinSuggestion struct {
 	JoinScore     float64              `json:"joinScore"`
 	DatasetOrigin *model.DatasetOrigin `json:"datasetOrigin"`
 	Index         int                  `json:"index"`
+}
+
+// VariableUpdate captures the information to update the dataset data.
+type VariableUpdate struct {
+	Index string `json:"index"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// ParseVariableUpdateList returns a list of parsed variable updates.
+func ParseVariableUpdateList(data map[string]interface{}) ([]*VariableUpdate, error) {
+	updatesRaw, ok := json.Array(data, "updates")
+	if !ok {
+		log.Infof("no variable updates to parse")
+		return nil, nil
+	}
+
+	updatesParsed := make([]*VariableUpdate, len(updatesRaw))
+	for i, update := range updatesRaw {
+		index, ok := json.String(update, "index")
+		if !ok {
+			return nil, errors.Errorf("no index provided for variable update")
+		}
+		name, ok := json.String(update, "name")
+		if !ok {
+			return nil, errors.Errorf("no feature name provided for variable update")
+		}
+		value, ok := json.String(update, "value")
+		if !ok {
+			return nil, errors.Errorf("no feature value provided for variable update")
+		}
+		updatesParsed[i] = &VariableUpdate{
+			Index: index,
+			Name:  name,
+			Value: value,
+		}
+	}
+
+	return updatesParsed, nil
 }
 
 // FetchDataset builds a QueriedDataset from the needed parameters.

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -508,28 +508,41 @@ func (s *Storage) UpdateVariableBatch(storageName string, varName string, update
 		params = append(params, []interface{}{i, v})
 	}
 
+	tx, err := s.batchClient.Begin()
+	if err != nil {
+		tx.Rollback(context.Background())
+		return errors.Wrap(err, "unable to create transaction")
+	}
+
 	// loop through the updates, building batches to minimize overhead
 	tableNameTmp := fmt.Sprintf("%s_utmp", storageName)
-	dataSQL := fmt.Sprintf("CREATE TEMP TABLE \"%s\" (\"%s\" TEXT NOT NULL, \"%s\" TEXT);",
+	dataSQL := fmt.Sprintf("CREATE TEMP TABLE \"%s\" (\"%s\" TEXT NOT NULL, \"%s\" TEXT) ON COMMIT DROP;",
 		tableNameTmp, model.D3MIndexName, varName)
-	_, err := s.batchClient.Exec(dataSQL)
+	_, err = tx.Exec(context.Background(), dataSQL)
 	if err != nil {
+		tx.Rollback(context.Background())
 		return errors.Wrap(err, "unable to create temp table")
 	}
 
-	err = s.insertBulkCopy(tableNameTmp, []string{model.D3MIndexName, varName}, params)
+	err = s.insertBulkCopyTransaction(tx, tableNameTmp, []string{model.D3MIndexName, varName}, params)
 	if err != nil {
+		tx.Rollback(context.Background())
 		return errors.Wrap(err, "unable to insert into temp table")
 	}
 
 	// run the update
 	updateSQL := fmt.Sprintf("UPDATE %s.%s.\"%s_base\" AS b SET \"%s\" = t.\"%s\" FROM \"%s\" AS t WHERE t.\"%s\" = b.\"%s\";",
 		"distil", "public", storageName, varName, varName, tableNameTmp, model.D3MIndexName, model.D3MIndexName)
-	_, err = s.batchClient.Exec(updateSQL)
+	_, err = tx.Exec(context.Background(), updateSQL)
 	if err != nil {
+		tx.Rollback(context.Background())
 		return errors.Wrap(err, "unable to update base data")
 	}
-	s.batchClient.Exec(fmt.Sprintf("DROP TABLE \"%s\"", tableNameTmp))
+
+	err = tx.Commit(context.Background())
+	if err != nil {
+		return errors.Wrap(err, "unable to commit bulk update")
+	}
 
 	return nil
 }
@@ -551,7 +564,7 @@ func (s *Storage) UpdateData(dataset string, storageName string, varName string,
 	}
 
 	tableNameTmp := fmt.Sprintf("%s_utmp", storageName)
-	dataSQL := fmt.Sprintf("CREATE TEMP TABLE \"%s\" (\"%s\" TEXT NOT NULL, \"%s\" TEXT);",
+	dataSQL := fmt.Sprintf("CREATE TEMP TABLE \"%s\" (\"%s\" TEXT NOT NULL, \"%s\" TEXT) ON COMMIT DROP;",
 		tableNameTmp, model.D3MIndexName, varName)
 	_, err = tx.Exec(context.Background(), dataSQL)
 	if err != nil {

--- a/api/routes/update.go
+++ b/api/routes/update.go
@@ -1,0 +1,103 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"net/http"
+
+	"github.com/pkg/errors"
+	"goji.io/v3/pat"
+
+	"github.com/uncharted-distil/distil/api/env"
+	api "github.com/uncharted-distil/distil/api/model"
+)
+
+// UpdateHandler generates a route handler that enables clustering
+// of a variable and the creation of the new column to hold the cluster label.
+func UpdateHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCtor, config env.Config) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// get dataset name
+		dataset := pat.Param(r, "dataset")
+
+		// parse update list
+		params, err := getPostParameters(r)
+		if err != nil {
+			handleError(w, errors.Wrap(err, "Unable to parse post parameters"))
+			return
+		}
+
+		if params["updates"] == nil {
+			missingParamErr(w, "updates")
+			return
+		}
+
+		updates, err := api.ParseVariableUpdateList(params)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// get storage clients
+		metaStorage, err := metaCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		dataStorage, err := dataCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// need to update one variable at a time
+		mappedUpdates := map[string]map[string]string{}
+		for _, u := range updates {
+			if mappedUpdates[u.Name] == nil {
+				mappedUpdates[u.Name] = map[string]string{}
+			}
+
+			mappedUpdates[u.Name][u.Index] = u.Value
+		}
+
+		// need the storage name
+		ds, err := metaStorage.FetchDataset(dataset, false, false)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		storageName := ds.StorageName
+
+		updateCount := 0
+		for varName, mapped := range mappedUpdates {
+			err = dataStorage.UpdateVariableBatch(storageName, varName, mapped)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+			updateCount = updateCount + len(mapped)
+		}
+
+		// marshal output into JSON
+		err = handleJSON(w, map[string]interface{}{
+			"result": "success",
+			"count":  updateCount,
+		})
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal clustering result into JSON"))
+			return
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -286,6 +286,7 @@ func main() {
 	registerRoutePost(mux, "/distil/cluster/:dataset/:variable", routes.ClusteringHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/cluster/:result-id", routes.ClusteringExplainHandler(pgSolutionStorageCtor, esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/upload/:dataset", routes.UploadHandler(&config))
+	registerRoutePost(mux, "/distil/update/:dataset", routes.UpdateHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/clone/:dataset", routes.CloningHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/join", routes.JoinHandler(esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries/:dataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:invert", routes.TimeseriesHandler(esMetadataStorageCtor, pgDataStorageCtor))


### PR DESCRIPTION
Adds a new route which lets the client update the underlying data. There are currently no restrictions on what data can be updated and how it can be updated so the database could easily become unusable (ex: putting in data with the wrong format, updating an index, putting in empty data where it shouldnt go).

As it stands, this update combined with the previously added cloning and dataset extraction should give us all the pieces to support user labeling on the backend. The integration with the client will surely result in significant changes, but we can now build a basic implementation of the use case.

We will probably want to add the concept of mutable and immutable datasets & features. We would then check those properties on update calls to make sure they are allowed. But that should probably be done in a future PR once we play around a bit with labeling and determine exactly how the user will specify values and what they can do.