### PR TITLE
Color by confidence 2061

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lumo": "^0.20.17",
     "moment": "^2.27.0",
     "multimap": "^1.0.2",
+    "scale-color-perceptual": "^1.1.2",
     "sigma": "^1.2.1",
     "store": "^2.0.12",
     "ts-enum-util": "^4.0.1",

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -53,6 +53,7 @@
         :class="confidenceClass"
         title="confidence"
         aria-label="Color by Confidence"
+        :style="colorGradient"
       >
         C
       </a>
@@ -322,6 +323,29 @@ export default Vue.extend({
     },
     showDrillDown(): boolean {
       return this.isImageDrilldown;
+    },
+    colorGradient(): string {
+      return this.isColoringByConfidence
+        ? `background-image:linear-gradient(${[
+            0.0, // padding
+            0.0, // padding
+            1.0,
+            0.9,
+            0.8,
+            0.7,
+            0.6,
+            0.5,
+            0.4,
+            0.3,
+            0.2,
+            0.1,
+            0.0,
+            0.0, // padding
+            0.0, // padding
+          ]
+            .map(this.colorScale)
+            .join(",")})`
+        : "";
     },
     fieldSpecs(): GeoField[] {
       const variables = datasetGetters.getVariables(this.$store);
@@ -1092,7 +1116,7 @@ export default Vue.extend({
     tileColor(item: any) {
       let color = "#255DCC"; // Default
       if (this.isColoringByConfidence) {
-        return this.colorScale(item.confidence);
+        return this.colorScale(item.confidence.value);
       }
       if (item[this.targetField] && item[this.predictedField]) {
         color =
@@ -1241,7 +1265,7 @@ export default Vue.extend({
   position: absolute;
   white-space: nowrap;
   left: 30px;
-  top: 15px;
+  top: 15px; /*works out to 4 pixels from bottom (this is based off the font size)*/
   display: inline;
   position: absolute;
 }
@@ -1249,7 +1273,7 @@ export default Vue.extend({
   content: "----More Confidence";
   white-space: nowrap;
   left: 30px;
-  top: -10px;
+  top: -7px; /*works out to 4 pixels from top (this is based off the font size)*/
   display: inline;
   position: absolute;
 }

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -43,6 +43,20 @@
         <i class="fa fa-object-group fa-lg" aria-hidden="true" />
       </a>
     </div>
+    <div
+      v-if="dataHasConfidence"
+      class="confidence-toggle"
+      :class="{ active: isColoringByConfidence }"
+      @click="toggleConfidenceColoring"
+    >
+      <a
+        :class="confidenceClass"
+        title="confidence"
+        aria-label="Color by Confidence"
+      >
+        C
+      </a>
+    </div>
     <b-toast
       :id="toastId"
       :title="toastTitle"
@@ -203,7 +217,6 @@ export default Vue.extend({
   components: {
     IconBase,
     IconCropFree,
-    // ImageDrilldown,
     ImageLabel,
     ImagePreview,
     DrillDown,
@@ -265,6 +278,8 @@ export default Vue.extend({
       showExit: false,
       pointSize: 0.025,
       isClustering: false,
+      isColoringByConfidence: false,
+      confidenceIconClass: "confidence-icon",
     };
   },
 
@@ -279,7 +294,9 @@ export default Vue.extend({
     target(): string {
       return routeGetters.getRouteTargetVariable(this.$store);
     },
-
+    dataHasConfidence(): boolean {
+      return "confidence" in this.dataItems[0];
+    },
     getTopVariables(): string[] {
       const variables = datasetGetters
         .getVariables(this.$store)
@@ -586,6 +603,9 @@ export default Vue.extend({
         },
       };
     },
+    confidenceClass(): string {
+      return this.confidenceIconClass;
+    },
     exitStyle(): string {
       return `top:${this.selectionToolData.exit.top}px; right:${this.selectionToolData.exit.right}px;`;
     },
@@ -679,6 +699,17 @@ export default Vue.extend({
         this.currentState = this.pointState;
         this.updateMapState();
       }
+    },
+    /**
+     * toggles coloring tiles by confidence (only available in result screen)
+     */
+    toggleConfidenceColoring() {
+      this.isColoringByConfidence = !this.isColoringByConfidence;
+      if (this.isColoringByConfidence) {
+        this.confidenceIconClass = "toggled-confidence-icon";
+        return;
+      }
+      this.confidenceIconClass = "confidence-icon";
     },
     /**
      * on selection tool toggle disable or enable the quad interactions such as click or hover
@@ -1150,6 +1181,19 @@ export default Vue.extend({
   text-align: center;
   border-radius: 4px;
 }
+.confidence-toggle {
+  position: absolute;
+  z-index: 999;
+  top: 120px;
+  left: 10px;
+  width: 34px;
+  height: 34px;
+  background-color: #fff;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  background-clip: padding-box;
+  text-align: center;
+  border-radius: 4px;
+}
 .cluster-icon {
   width: 30px;
   height: 30px;
@@ -1158,7 +1202,43 @@ export default Vue.extend({
   align-items: center;
   cursor: pointer;
 }
+.confidence-icon {
+  width: 30px;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  font-weight: bolder;
+  font-size: xx-large;
+}
+.toggled-confidence-icon {
+  width: 30px;
+  height: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  font-weight: bolder;
+  font-size: xx-large;
+  background-size: 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -moz-background-clip: text;
+  background-image: linear-gradient(0deg, #f3ec78, #af4261);
+  -webkit-text-fill-color: transparent;
+  -moz-text-fill-color: transparent;
+}
+.toggled-confidence-icon:hover::after {
+  content: "----Less Confidence";
+}
+.toggled-confidence-icon:hover::before {
+  content: "----More Confidence";
+}
 .cluster-toggle:hover {
+  background-color: #f4f4f4;
+}
+.confidence-toggle:hover {
   background-color: #f4f4f4;
 }
 .cluster-toggle.active {

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -105,6 +105,7 @@ import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as requestGetters } from "../store/requests/module";
 import { getters as routeGetters } from "../store/route/module";
 import { Dictionary } from "../util/dict";
+import viridisScale from "scale-color-perceptual/viridis";
 import lumo from "lumo";
 import BatchQuadOverlay from "../util/rendering/BatchQuadOverlay";
 import {
@@ -201,6 +202,7 @@ interface LumoPoint {
   x: number;
   y: number;
 }
+
 export interface TileClickData {
   bounds: number[][];
   key: string;
@@ -234,6 +236,7 @@ export default Vue.extend({
     pointOpacity: { type: Number, default: 0.8 },
     zoomThreshold: { type: Number, default: 8 },
     maxZoom: { type: Number, default: 18 },
+    colorScale: { type: Function, default: viridisScale },
   },
 
   data() {
@@ -707,9 +710,11 @@ export default Vue.extend({
       this.isColoringByConfidence = !this.isColoringByConfidence;
       if (this.isColoringByConfidence) {
         this.confidenceIconClass = "toggled-confidence-icon";
+        this.updateMapState();
         return;
       }
       this.confidenceIconClass = "confidence-icon";
+      this.updateMapState();
     },
     /**
      * on selection tool toggle disable or enable the quad interactions such as click or hover
@@ -1086,7 +1091,9 @@ export default Vue.extend({
 
     tileColor(item: any) {
       let color = "#255DCC"; // Default
-
+      if (this.isColoringByConfidence) {
+        return this.colorScale(item.confidence);
+      }
       if (item[this.targetField] && item[this.predictedField]) {
         color =
           item[this.targetField].value === item[this.predictedField].value
@@ -1229,11 +1236,22 @@ export default Vue.extend({
   -webkit-text-fill-color: transparent;
   -moz-text-fill-color: transparent;
 }
-.toggled-confidence-icon:hover::after {
+.confidence-toggle.active:hover::after {
   content: "----Less Confidence";
+  position: absolute;
+  white-space: nowrap;
+  left: 30px;
+  top: 15px;
+  display: inline;
+  position: absolute;
 }
-.toggled-confidence-icon:hover::before {
+.confidence-toggle.active:hover::before {
   content: "----More Confidence";
+  white-space: nowrap;
+  left: 30px;
+  top: -10px;
+  display: inline;
+  position: absolute;
 }
 .cluster-toggle:hover {
   background-color: #f4f4f4;

--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -142,8 +142,8 @@
 // of prediction-truth residuals, and scoring information.
 
 import Vue from "vue";
-import FacetNumerical from "../components/facets/FacetNumerical";
-import FacetCategorical from "../components/facets/FacetCategorical";
+import FacetNumerical from "../components/facets/FacetNumerical.vue";
+import FacetCategorical from "../components/facets/FacetCategorical.vue";
 import {
   Extrema,
   VariableSummary,

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -69,12 +69,12 @@
 </template>
 
 <script lang="ts">
-import ResultFacets from "../components/ResultFacets";
-import PredictionsDataUploader from "../components/PredictionsDataUploader";
-import ForecastHorizon from "../components/ForecastHorizon";
-import ErrorThresholdSlider from "../components/ErrorThresholdSlider";
-import SaveModel from "../components/SaveModel";
-import ResultTargetVariable from "../components/ResultTargetVariable";
+import ResultFacets from "../components/ResultFacets.vue";
+import PredictionsDataUploader from "../components/PredictionsDataUploader.vue";
+import ForecastHorizon from "../components/ForecastHorizon.vue";
+import ErrorThresholdSlider from "../components/ErrorThresholdSlider.vue";
+import SaveModel from "../components/SaveModel.vue";
+import ResultTargetVariable from "../components/ResultTargetVariable.vue";
 import { getSolutionById } from "../util/solutions";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -122,7 +122,11 @@ export default Vue.extend({
     solutionId(): string {
       return this.solution?.solutionId;
     },
-
+    confidenceSummaries(): VariableSummary {
+      return resultsGetters.getConfidenceSummaries(this.$store).filter((cf) => {
+        return cf.solutionId === this.solutionId;
+      })[0];
+    },
     solutionHasErrored(): boolean {
       return this.solution
         ? this.solution.progress === SOLUTION_ERRORED

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -160,6 +160,7 @@ export interface VariableSummary {
   err?: string;
   weighted?: boolean;
   pending?: boolean;
+  solutionId?: string;
 }
 
 // Flags the display mode for a variable summary.  Generally Default is correct,

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -686,7 +686,6 @@ export function getTableDataItems(data: TableData): TableRow[] {
             row[colName].weight = colValue.weight;
           }
           if (colValue.confidence !== undefined) {
-            delete row[colName];
             const conKey = "confidence";
             row[conKey] = {};
             row[conKey].value = colValue.confidence;

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -685,15 +685,12 @@ export function getTableDataItems(data: TableData): TableRow[] {
           if (colValue.weight !== null && colValue.weight !== undefined) {
             row[colName].weight = colValue.weight;
           }
-
-          // confidence code, draft pending UX feedback
-          /*
           if (colValue.confidence !== undefined) {
-            const conKey = colName + "confidence";
+            delete row[colName];
+            const conKey = "confidence";
             row[conKey] = {};
             row[conKey].value = colValue.confidence;
           }
-          */
         } else {
           row[colName] = formatValue(colValue.value, colType);
         }
@@ -736,17 +733,14 @@ export function getTableDataFields(data: TableData): Dictionary<TableColumn> {
         label = variable.colDisplayName;
         description = `Model predicted value for ${variable.colName}`;
 
-        // confidence code, draft pending UX feedback
-        /*
-        result[col.key + "confidence"] = {
-          label: label + "_Confidence",
-          key: col.key + "confidence",
+        result["confidence"] = {
+          label: "Confidence",
+          key: "confidence",
           type: "numeric",
           weight: null,
           headerTitle: `Prediction confidence ${variable.colName}`,
           sortable: true,
         };
-        */
       } else if (isErrorCol(col.key)) {
         variable = requestGetters.getActiveSolutionTargetVariable(store)[0];
         label = "Error";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5587,6 +5587,11 @@ sax@~1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
+scale-color-perceptual@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/scale-color-perceptual/-/scale-color-perceptual-1.1.2.tgz#370fb1aa1fc48261d3048f34edfe6155fb0a52d5"
+  integrity sha1-Nw+xqh/EgmHTBI807f5hVfsKUtU=
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"


### PR DESCRIPTION
![Peek 2020-11-10 10-27](https://user-images.githubusercontent.com/25306965/98696355-aef3ed00-2341-11eb-9a48-13c401cf699c.gif)

- Added coloring by confidence. 
- Added color-scale-perceptual package that generates color scales
- Added prop to geoplot for color scales, defaults to viridis
- Added confidence to data tables
- Added icon/legend for toggling color by confidence
closes #2061  