### PR TITLE
Error handling fixes

### DIFF
--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -669,7 +669,9 @@ func (s *SolutionRequest) dispatchSolution(statusChan chan SolutionStatus, clien
 		}
 
 		// persist the scores
+		scored := false
 		for _, response := range solutionScoreResponses {
+
 			// only persist scores from COMPLETED responses
 			if response.Progress.State == pipeline.ProgressState_COMPLETED {
 				for _, score := range response.Scores {
@@ -685,7 +687,13 @@ func (s *SolutionRequest) dispatchSolution(statusChan chan SolutionStatus, clien
 						return
 					}
 				}
+				scored = true
 			}
+		}
+		// handle as error state if no successful scores returned
+		if !scored {
+			s.persistSolutionError(statusChan, solutionStorage, initialSearchID, initialSearchSolutionID, errors.New("all scores errored"))
+			return
 		}
 
 		// persist solution running status

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -190,15 +190,10 @@ func handleCreateSolutions(conn *Connection, client *compute.Client, metadataCto
 	requestFinished := make(chan api.SolutionStatus, 1)
 	defer close(requestFinished)
 	err = request.Listen(func(status api.SolutionStatus) {
-		// check for error from ta2
-		if status.Progress == api.SolutionErroredStatus {
-			handleErr(conn, msg, errors.Wrap(status.Error, "received error from TA2 system"))
-			return
-		}
-		// send status to client
+		// send status to client - this includes any error status we encountered
 		handleSuccess(conn, msg, jutil.StructToMap(status))
 
-		// flag request as finished
+		// flag request as finished if it completed normally, or an error occurred
 		if status.Progress == api.RequestCompletedStatus || status.Progress == api.RequestErroredStatus {
 			requestFinished <- status
 		}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201104153249-f5c647ca8e0e
+	github.com/uncharted-distil/distil-compute v0.0.0-20201109142549-9fa174f15fa5
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201104153249-f5c647ca8e0e h1:qUBv2Z9Vp4/iZZPmkUL/OV8qzKwT6Qz0qUxJ7920VGU=
-github.com/uncharted-distil/distil-compute v0.0.0-20201104153249-f5c647ca8e0e/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
+github.com/uncharted-distil/distil-compute v0.0.0-20201109142549-9fa174f15fa5 h1:mC1y2tTBGqPB6NlZOX7AWsl+n/mr9ANdqN6T2AgLB7o=
+github.com/uncharted-distil/distil-compute v0.0.0-20201109142549-9fa174f15fa5/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=


### PR DESCRIPTION
The TA2 is now reporting _most_ errors back to the server after uncharted-distil/distil-auto-ml#117 was fixed.  This exposed a couple of tweaks we had to make to ensure that the client was appropriately notified.