### PR TITLE
#2034 - train test split ux & api updates

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -363,6 +363,7 @@ type persistedDataParams struct {
 	TaskType           []string
 	TmpDataFolder      string
 	Quality            string
+	TrainTestSplit     float64
 }
 
 type rowLimits struct {
@@ -503,10 +504,10 @@ func persistOriginalData(params *persistedDataParams) (string, string, error) {
 
 	if hasForecasting {
 		err = splitTrainTestTimeseries(dataPath, trainDataFile, testDataFile, true,
-			params.GroupingFieldIndex, config.TrainTestSplitTimeSeries)
+			params.GroupingFieldIndex, params.TrainTestSplit)
 	} else {
 		err = splitTrainTest(dataPath, trainDataFile, testDataFile, true, params.TargetFieldIndex,
-			params.GroupingFieldIndex, params.Stratify, limits, config.TrainTestSplit)
+			params.GroupingFieldIndex, params.Stratify, limits, params.TrainTestSplit)
 	}
 	if err != nil {
 		return "", "", err

--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -502,12 +502,24 @@ func persistOriginalData(params *persistedDataParams) (string, string, error) {
 		}
 	}
 
+	var trainTestSplit float64
+
+	if params.TrainTestSplit != 0 {
+		trainTestSplit = params.TrainTestSplit
+	} else {
+		if hasForecasting {
+			trainTestSplit = config.TrainTestSplitTimeSeries
+		} else {
+			trainTestSplit = config.TrainTestSplit
+		}
+	}
+
 	if hasForecasting {
 		err = splitTrainTestTimeseries(dataPath, trainDataFile, testDataFile, true,
-			params.GroupingFieldIndex, params.TrainTestSplit)
+			params.GroupingFieldIndex, trainTestSplit)
 	} else {
 		err = splitTrainTest(dataPath, trainDataFile, testDataFile, true, params.TargetFieldIndex,
-			params.GroupingFieldIndex, params.Stratify, limits, params.TrainTestSplit)
+			params.GroupingFieldIndex, params.Stratify, limits, trainTestSplit)
 	}
 	if err != nil {
 		return "", "", err

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -113,7 +113,7 @@ type SolutionRequest struct {
 	Metrics              []string
 	Filters              *api.FilterParams
 	DatasetAugmentations []*model.DatasetOrigin
-	MLSplit              float64
+	TrainTestSplit       float64
 
 	mu               *sync.Mutex
 	wg               *sync.WaitGroup
@@ -162,7 +162,7 @@ func NewSolutionRequest(variables []*model.Variable, data []byte) (*SolutionRequ
 	req.Quality = json.StringDefault(j, defaultQuality, "quality")
 	req.ProblemType = json.StringDefault(j, "", "problemType")
 	req.Metrics, _ = json.StringArray(j, "metrics")
-	req.MLSplit = json.FloatDefault(j, 0.9, "mlSplit")
+	req.TrainTestSplit = json.FloatDefault(j, 0.9, "trainTestSplit")
 
 	filters, ok := json.Get(j, "filters")
 	if ok {

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -113,6 +113,7 @@ type SolutionRequest struct {
 	Metrics              []string
 	Filters              *api.FilterParams
 	DatasetAugmentations []*model.DatasetOrigin
+	MLSplit              float64
 
 	mu               *sync.Mutex
 	wg               *sync.WaitGroup
@@ -161,6 +162,7 @@ func NewSolutionRequest(variables []*model.Variable, data []byte) (*SolutionRequ
 	req.Quality = json.StringDefault(j, defaultQuality, "quality")
 	req.ProblemType = json.StringDefault(j, "", "problemType")
 	req.Metrics, _ = json.StringArray(j, "metrics")
+	req.MLSplit = json.FloatDefault(j, 0.9, "mlSplit")
 
 	filters, ok := json.Get(j, "filters")
 	if ok {

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -766,6 +766,7 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 		TargetFieldIndex:   targetIndex,
 		Stratify:           stratify,
 		Quality:            s.Quality,
+		TrainTestSplit:     s.TrainTestSplit,
 	}
 	datasetPathTrain, datasetPathTest, err := persistOriginalData(params)
 	if err != nil {

--- a/api/routes/config.go
+++ b/api/routes/config.go
@@ -33,13 +33,15 @@ func ConfigHandler(config env.Config, version string, timestamp string, problemP
 
 		// marshal version
 		err := handleJSON(w, map[string]interface{}{
-			"version":    version,
-			"timestamp":  timestamp,
-			"dataset":    dataset,
-			"target":     target,
-			"metrics":    metrics,
-			"help":       config.HelpURL,
-			"ta2version": ta2Version,
+			"version":                  version,
+			"timestamp":                timestamp,
+			"dataset":                  dataset,
+			"target":                   target,
+			"metrics":                  metrics,
+			"help":                     config.HelpURL,
+			"ta2version":               ta2Version,
+			"trainTestSplit":           config.TrainTestSplit,
+			"trainTestSplitTimeSeries": config.TrainTestSplitTimeSeries,
 		})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal version into JSON and write response"))

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -134,6 +134,8 @@ export default Vue.extend({
       // flag as pending
       this.pending = true;
       // dispatch action that triggers request send to server
+      const routeSplit = routeGetters.getRouteTrainTestSplit(this.$store);
+      const defaultSplit = appGetters.getTrainTestSplit(this.$store);
       requestActions
         .createSolutionRequest(this.$store, {
           dataset: this.dataset,
@@ -143,7 +145,7 @@ export default Vue.extend({
           maxSolutions: routeGetters.getModelLimit(this.$store),
           maxTime: routeGetters.getModelTimeLimit(this.$store),
           quality: routeGetters.getModelQuality(this.$store),
-          trainTestSplit: routeGetters.getRouteTrainTestSplit(this.$store),
+          trainTestSplit: !!routeSplit ? routeSplit : defaultSplit,
         })
         .then((res: Solution) => {
           this.pending = false;

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -143,7 +143,7 @@ export default Vue.extend({
           maxSolutions: routeGetters.getModelLimit(this.$store),
           maxTime: routeGetters.getModelTimeLimit(this.$store),
           quality: routeGetters.getModelQuality(this.$store),
-          mlSplit: routeGetters.getModelDataSplit(this.$store),
+          trainTestSplit: routeGetters.getModelDataSplit(this.$store),
         })
         .then((res: Solution) => {
           this.pending = false;

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -143,6 +143,7 @@ export default Vue.extend({
           maxSolutions: routeGetters.getModelLimit(this.$store),
           maxTime: routeGetters.getModelTimeLimit(this.$store),
           quality: routeGetters.getModelQuality(this.$store),
+          mlSplit: routeGetters.getModelDataSplit(this.$store),
         })
         .then((res: Solution) => {
           this.pending = false;

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -143,7 +143,7 @@ export default Vue.extend({
           maxSolutions: routeGetters.getModelLimit(this.$store),
           maxTime: routeGetters.getModelTimeLimit(this.$store),
           quality: routeGetters.getModelQuality(this.$store),
-          trainTestSplit: routeGetters.getModelDataSplit(this.$store),
+          trainTestSplit: routeGetters.getRouteTrainTestSplit(this.$store),
         })
         .then((res: Solution) => {
           this.pending = false;

--- a/public/components/SettingsModal.vue
+++ b/public/components/SettingsModal.vue
@@ -29,6 +29,27 @@
       />
     </b-form-group>
     <b-form-group
+      label="Training/Testing Data Split:"
+      label-for="model-train-test-split"
+      description="Modify the ratio of data used to train the model vs. the amount of data saved to verify the model for later."
+    >
+      <div class="d-flex justify-content-between mt-1">
+        <div>Training: {{ trainingCount }}</div>
+        <div>Testing: {{ testingCount }}</div>
+      </div>
+      <b-form-input
+        v-model="trainingCount"
+        type="range"
+        min="1"
+        :max="totalDataCount"
+        class="mt-1"
+      />
+      <div class="d-flex justify-content-between mt-1">
+        <div>{{ parseFloat(trainingRatio).toFixed(2) }}%</div>
+        <div>{{ parseFloat(testingRatio).toFixed(2) }}%</div>
+      </div>
+    </b-form-group>
+    <b-form-group
       label="Model Training:"
       label-for="model-training-ratios"
       description="Selects faster model training or higher quality models."
@@ -82,6 +103,7 @@ import {
 import { overlayRouteEntry } from "../util/routes";
 import { MetricDropdownItem, TaskTypes } from "../store/dataset";
 import { getters as routeGetters } from "../store/route/module";
+import { getters as appGetters } from "../store/app/module";
 
 // Dialog for setting model creation preferences.  The results are saved to the route to ensure
 // that users don't have to set them for each run.
@@ -98,6 +120,7 @@ export default Vue.extend({
       // fill this from the API later, first posting back the target's type
       // then getting a list of allowed scoring methods with keys, description
       selectedMetric: null,
+      trainingCount: 1,
     };
   },
 
@@ -118,20 +141,56 @@ export default Vue.extend({
         };
       });
     },
+    task(): string {
+      return routeGetters.getRouteTask(this.$store);
+    },
+    totalDataCount(): number {
+      return routeGetters.getRouteDataSize(this.$store);
+    },
+    trainTestSplit(): number {
+      return appGetters.getTrainTestSplit(this.$store);
+    },
+    trainTestSplitTimeSeries(): number {
+      return appGetters.getTrainTestSplitTimeSeries(this.$store);
+    },
+    testingCount(): number {
+      return this.totalDataCount - this.trainingCount;
+    },
+    testingRatio(): number {
+      return 1 - this.trainingRatio;
+    },
+    trainingRatio(): number {
+      return this.trainingCount / this.totalDataCount;
+    },
+    baseSplit(): number {
+      return this.task.includes(TaskTypes.TIME_SERIES)
+        ? this.trainTestSplit
+        : this.trainTestSplitTimeSeries;
+    },
+  },
+
+  watch: {
+    baseSplit() {
+      this.trainingCount =
+        Math.floor(this.totalDataCount * this.baseSplit) || 1;
+    },
+    totalDataCount() {
+      this.trainingCount =
+        Math.floor(this.totalDataCount * this.baseSplit) || 1;
+    },
   },
 
   async beforeMount() {
-    const task = routeGetters.getRouteTask(this.$store);
     await datasetActions.fetchModelingMetrics(this.$store, {
-      task: task,
+      task: this.task,
     });
-    if (task.includes(TaskTypes.CLASSIFICATION)) {
-      if (task.includes(TaskTypes.MULTICLASS)) {
+    if (this.task.includes(TaskTypes.CLASSIFICATION)) {
+      if (this.task.includes(TaskTypes.MULTICLASS)) {
         this.selectedMetric = "f1Macro";
       } else {
         this.selectedMetric = "f1";
       }
-    } else if (task.includes(TaskTypes.REGRESSION)) {
+    } else if (this.task.includes(TaskTypes.REGRESSION)) {
       this.selectedMetric = "meanAbsoluteError";
     } else {
       this.selectedMetric = null;
@@ -145,6 +204,7 @@ export default Vue.extend({
         modelTimeLimit: this.timeLimit,
         modelQuality: this.speedQuality,
         metrics: this.selectedMetric,
+        mlSplit: this.trainingRatio,
       });
       this.$router.push(entry).catch((err) => console.warn(err));
     },

--- a/public/components/SettingsModal.vue
+++ b/public/components/SettingsModal.vue
@@ -204,7 +204,7 @@ export default Vue.extend({
         modelTimeLimit: this.timeLimit,
         modelQuality: this.speedQuality,
         metrics: this.selectedMetric,
-        mlSplit: this.trainingRatio,
+        trainTestSplit: this.trainingRatio,
       });
       this.$router.push(entry).catch((err) => console.warn(err));
     },

--- a/public/components/SettingsModal.vue
+++ b/public/components/SettingsModal.vue
@@ -163,7 +163,10 @@ export default Vue.extend({
       return this.trainingCount / this.totalDataCount;
     },
     baseSplit(): number {
-      return this.task.includes(TaskTypes.TIME_SERIES)
+      const routeSplit = routeGetters.getRouteTrainTestSplit(this.$store);
+      return !!routeSplit
+        ? routeSplit
+        : this.task.includes(TaskTypes.TIME_SERIES)
         ? this.trainTestSplit
         : this.trainTestSplitTimeSeries;
     },
@@ -195,6 +198,7 @@ export default Vue.extend({
     } else {
       this.selectedMetric = null;
     }
+    this.trainingCount = Math.floor(this.totalDataCount * this.baseSplit) || 1;
   },
 
   methods: {

--- a/public/store/app/actions.ts
+++ b/public/store/app/actions.ts
@@ -5,7 +5,6 @@ import { ActionContext } from "vuex";
 import { mutations } from "./module";
 import { FilterParams } from "../../util/filters";
 import { Feature, Activity, SubActivity } from "../../util/userEvents";
-import { resultsModule } from "../results/module";
 
 export type AppContext = ActionContext<AppState, DistilState>;
 
@@ -95,6 +94,11 @@ export const actions = {
       mutations.setProblemTarget(context, response.data.target);
       mutations.setProblemMetrics(context, response.data.metrics);
       mutations.setTA2VersionNumber(context, response.data.ta2version);
+      mutations.setTrainTestSplit(context, response.data.trainTestSplit);
+      mutations.setTrainTestSplitTimeSeries(
+        context,
+        response.data.trainTestSplitTimeSeries
+      );
     } catch (err) {
       console.warn(err);
     }

--- a/public/store/app/getters.ts
+++ b/public/store/app/getters.ts
@@ -40,4 +40,10 @@ export const getters = {
       state.versionTimestamp !== "unset" ? state.versionTimestamp : "";
     return `TA2 version ${ta2Version}\nTA3 version ${ta3Version} ${ta3Timestamp}`.trim();
   },
+  getTrainTestSplit(state: AppState): number {
+    return state.trainTestSplit;
+  },
+  getTrainTestSplitTimeSeries(state: AppState): number {
+    return state.trainTestSplitTimeSeries;
+  },
 };

--- a/public/store/app/index.ts
+++ b/public/store/app/index.ts
@@ -9,6 +9,8 @@ export interface AppState {
   problemMetrics: string[];
   statusPanelState: StatusPanelState;
   ta2Version: string;
+  trainTestSplit: number;
+  trainTestSplitTimeSeries: number;
 }
 
 export interface StatusPanelState {
@@ -29,6 +31,8 @@ export const state: AppState = {
     isOpen: false,
   },
   ta2Version: "unknown",
+  trainTestSplit: null,
+  trainTestSplitTimeSeries: null,
 };
 
 export type StatusPanelContentType = DatasetPendingRequestType;

--- a/public/store/app/module.ts
+++ b/public/store/app/module.ts
@@ -28,6 +28,8 @@ export const getters = {
   getStatusPanelState: read(moduleGetters.getStatusPanelState),
   getTA2VersionNumber: read(moduleGetters.getTA2VersionNumber),
   getAllSystemVersions: read(moduleGetters.getAllSystemVersions),
+  getTrainTestSplit: read(moduleGetters.getTrainTestSplit),
+  getTrainTestSplitTimeSeries: read(moduleGetters.getTrainTestSplitTimeSeries),
 };
 
 // typed actions
@@ -55,4 +57,8 @@ export const mutations = {
   setTA2VersionNumber: commit(moduleMutations.setTA2VersionNumber),
   openStatusPanel: commit(moduleMutations.openStatusPanel),
   closeStatusPanel: commit(moduleMutations.closeStatusPanel),
+  setTrainTestSplit: commit(moduleMutations.setTrainTestSplit),
+  setTrainTestSplitTimeSeries: commit(
+    moduleMutations.setTrainTestSplitTimeSeries
+  ),
 };

--- a/public/store/app/mutations.ts
+++ b/public/store/app/mutations.ts
@@ -37,6 +37,17 @@ export const mutations = {
     state.ta2Version = ta2Version;
   },
 
+  setTrainTestSplit(state: AppState, trainTestSplit: string) {
+    state.trainTestSplit = parseFloat(trainTestSplit);
+  },
+
+  setTrainTestSplitTimeSeries(
+    state: AppState,
+    trainTestSplitTimeSeries: string
+  ) {
+    state.trainTestSplitTimeSeries = parseFloat(trainTestSplitTimeSeries);
+  },
+
   openStatusPanel(state: AppState) {
     Vue.set(state.statusPanelState, "isOpen", true);
   },

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -46,6 +46,7 @@ interface SolutionRequestMsg {
   maxTime: number;
   quality: ModelQuality;
   filters: FilterParams;
+  mlSplit: number;
 }
 
 // Solution status message used in web socket context
@@ -497,6 +498,7 @@ export const actions = {
         maxTime: request.maxTime,
         quality: request.quality,
         filters: request.filters,
+        mlSplit: request.mlSplit,
       });
     });
   },

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -46,7 +46,7 @@ interface SolutionRequestMsg {
   maxTime: number;
   quality: ModelQuality;
   filters: FilterParams;
-  mlSplit: number;
+  trainTestSplit: number;
 }
 
 // Solution status message used in web socket context
@@ -498,7 +498,7 @@ export const actions = {
         maxTime: request.maxTime,
         quality: request.quality,
         filters: request.filters,
-        mlSplit: request.mlSplit,
+        trainTestSplit: request.trainTestSplit,
       });
     });
   },

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -609,7 +609,7 @@ export const getters = {
   getRouteTrainTestSplit(state: Route): number {
     const trainTestSplit = <string>state.query.trainTestSplit;
     if (!trainTestSplit) {
-      return 0.9;
+      return null;
     }
     return parseFloat(trainTestSplit);
   },

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -607,11 +607,11 @@ export const getters = {
   },
 
   getModelDataSplit(state: Route): number {
-    const mlSplit = <string>state.query.mlSplit;
-    if (!mlSplit) {
+    const trainTestSplit = <string>state.query.trainTestSplit;
+    if (!trainTestSplit) {
       return 0.9;
     }
-    return parseFloat(mlSplit);
+    return parseFloat(trainTestSplit);
   },
 
   /* Check if the current page is SELECT_TARGET_ROUTE. */

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -606,7 +606,7 @@ export const getters = {
     return metrics.split(",");
   },
 
-  getModelDataSplit(state: Route): number {
+  getRouteTrainTestSplit(state: Route): number {
     const trainTestSplit = <string>state.query.trainTestSplit;
     if (!trainTestSplit) {
       return 0.9;

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -605,6 +605,15 @@ export const getters = {
     }
     return metrics.split(",");
   },
+
+  getModelDataSplit(state: Route): number {
+    const mlSplit = <string>state.query.mlSplit;
+    if (!mlSplit) {
+      return 0.9;
+    }
+    return parseFloat(mlSplit);
+  },
+
   /* Check if the current page is SELECT_TARGET_ROUTE. */
   isPageSelectTarget(state: Route): Boolean {
     return state.path === SELECT_TARGET_ROUTE;

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -113,6 +113,7 @@ export const getters = {
   getModelTimeLimit: read(moduleGetters.getModelTimeLimit),
   getModelQuality: read(moduleGetters.getModelQuality),
   getModelMetrics: read(moduleGetters.getModelMetrics),
+  getModelDataSplit: read(moduleGetters.getModelDataSplit),
   isPageSelectTarget: read(moduleGetters.isPageSelectTarget),
   isPageSelectTraining: read(moduleGetters.isPageSelectTraining),
 };

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -113,7 +113,7 @@ export const getters = {
   getModelTimeLimit: read(moduleGetters.getModelTimeLimit),
   getModelQuality: read(moduleGetters.getModelQuality),
   getModelMetrics: read(moduleGetters.getModelMetrics),
-  getModelDataSplit: read(moduleGetters.getModelDataSplit),
+  getRouteTrainTestSplit: read(moduleGetters.getRouteTrainTestSplit),
   isPageSelectTarget: read(moduleGetters.isPageSelectTarget),
   isPageSelectTraining: read(moduleGetters.isPageSelectTraining),
 };

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -56,7 +56,7 @@ export interface RouteArgs {
   modelQuality?: string;
   dataSize?: number;
   metrics?: string;
-  mlSplit?: number;
+  trainTestSplit?: number;
 }
 
 /**

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -56,6 +56,7 @@ export interface RouteArgs {
   modelQuality?: string;
   dataSize?: number;
   metrics?: string;
+  mlSplit?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #2034. New UX in settings modal plus supporting store, component and utility updates now send back the mlSplit percentage split to the API/backend while retrieving the the default split from the config thanks to changes to the config.go to pass those fields down in the config grab in the front end with fallbacks and guard rails on both the API and UX code to make sure things leverage default when not otherwise set. Updates to dataset_persist & solution_request to leverage the posted back trainTestSplit field as well, and fall back to the config when that's undefined.