### PR TITLE
Added separate data arrays for the map on result view.

### DIFF
--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -171,11 +171,11 @@ export default Vue.extend({
     dataItems(): TableRow[] {
       if (this.isGeoView) {
         const excluded = resultsGetters
-          .getExcludedResultTableDataItems(this.$store)
+          .getFullExcludedResultTableDataItems(this.$store)
           .map((i) => {
             return { ...i, isExcluded: true };
           });
-        const included = resultsGetters.getIncludedResultTableDataItems(
+        const included = resultsGetters.getFullIncludedResultTableDataItems(
           this.$store
         );
         return [...excluded, ...included];

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -105,6 +105,7 @@ function updateCurrentSolutionResults(
     solutionId: res.solutionId,
     highlight: context.getters.getDecodedHighlight,
     dataMode: dataMode,
+    isMapData: false,
     size,
   });
   resultsActions.fetchFeatureImportanceRanking(store, {

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -262,6 +262,7 @@ export const actions = {
       dataset: string;
       highlight: Highlight;
       dataMode: DataMode;
+      isMapData: boolean;
       size?: number;
     }
   ) {
@@ -283,7 +284,9 @@ export const actions = {
       filterParamsBlank,
       args.highlight
     );
-
+    const mutator = args.isMapData
+      ? mutations.setFullIncludedResultTableData
+      : mutations.setIncludedResultTableData;
     const dataModeDefault = args.dataMode ? args.dataMode : DataMode.Default;
     filterParams.dataMode = dataModeDefault; // Add the size limit to results if provided.
     if (_.isInteger(args.size)) {
@@ -297,12 +300,12 @@ export const actions = {
         )}`,
         filterParams
       );
-      mutations.setIncludedResultTableData(context, response.data);
+      mutator(context, response.data);
     } catch (error) {
       console.error(
         `Failed to fetch results from ${args.solutionId} with error ${error}`
       );
-      mutations.setIncludedResultTableData(context, createEmptyTableData());
+      mutator(context, createEmptyTableData());
     }
   },
 
@@ -313,6 +316,7 @@ export const actions = {
       dataset: string;
       highlight: Highlight;
       dataMode: DataMode;
+      isMapData: boolean;
       size?: number;
     }
   ) {
@@ -338,6 +342,9 @@ export const actions = {
 
     const dataModeDefault = args.dataMode ? args.dataMode : DataMode.Default;
     filterParams.dataMode = dataModeDefault;
+    const mutator = args.isMapData
+      ? mutations.setFullExcludedResultTableData
+      : mutations.setExcludedResultTableData;
     // Add the size limit to results if provided.
     if (_.isInteger(args.size)) {
       filterParams.size = args.size;
@@ -350,12 +357,12 @@ export const actions = {
         )}`,
         filterParams
       );
-      mutations.setExcludedResultTableData(context, response.data);
+      mutator(context, response.data);
     } catch (error) {
       console.error(
         `Failed to fetch results from ${args.solutionId} with error ${error}`
       );
-      mutations.setExcludedResultTableData(context, createEmptyTableData());
+      mutator(context, createEmptyTableData());
     }
   },
   // fetches
@@ -476,6 +483,7 @@ export const actions = {
       dataset: string;
       highlight: Highlight;
       dataMode: DataMode;
+      isMapData: boolean;
       size?: number;
     }
   ) {

--- a/public/store/results/getters.ts
+++ b/public/store/results/getters.ts
@@ -64,7 +64,17 @@ export const getters = {
   getIncludedResultTableData(state: ResultsState): TableData {
     return state.includedResultTableData;
   },
-
+  getFullIncludedResultTableDataItems(state: ResultsState): TableRow[] {
+    return getTableDataItems(state.fullIncludedResultTableData);
+  },
+  getFullExcludedResultTableDataItems(state: ResultsState): TableRow[] {
+    return getTableDataItems(state.fullExcludedResultTableData);
+  },
+  getNumOfRecords(state: ResultsState) {
+    const table = state.includedResultTableData ??
+      state.excludedResultTableData ?? { numRows: 0 };
+    return table.numRows;
+  },
   getAreaOfInterestInnerDataItems(state: ResultsState): TableRow[] {
     return getTableDataItems(state.areaOfInterestInner);
   },

--- a/public/store/results/index.ts
+++ b/public/store/results/index.ts
@@ -22,7 +22,10 @@ export interface ResultsState {
   // table data
   includedResultTableData: TableData;
   excludedResultTableData: TableData;
-  // areaOfInteres
+  // excluded data without datasize applied (for the map)
+  fullExcludedResultTableData: TableData;
+  fullIncludedResultTableData: TableData;
+  // areaOfInterest
   areaOfInterestInner: TableData;
   areaOfInterestOuter: TableData;
   // training / target
@@ -52,6 +55,8 @@ export const state: ResultsState = {
   // table data
   includedResultTableData: null,
   excludedResultTableData: null,
+  fullExcludedResultTableData: null,
+  fullIncludedResultTableData: null,
   // area of interest for tiles clicks in geo map
   areaOfInterestInner: null,
   areaOfInterestOuter: null,

--- a/public/store/results/module.ts
+++ b/public/store/results/module.ts
@@ -51,6 +51,12 @@ export const getters = {
   getExcludedResultTableDataCount: read(
     moduleGetters.getExcludedResultTableDataCount
   ),
+  getFullExcludedResultTableDataItems: read(
+    moduleGetters.getFullExcludedResultTableDataItems
+  ),
+  getFullIncludedResultTableDataItems: read(
+    moduleGetters.getFullIncludedResultTableDataItems
+  ),
   hasResultTableDataItemsWeight: read(
     moduleGetters.hasResultTableDataItemsWeight
   ),
@@ -76,6 +82,8 @@ export const getters = {
   getPredictedForecasts: read(moduleGetters.getPredictedForecasts),
   // rankings
   getFeatureImportanceRanking: read(moduleGetters.getFeatureImportanceRanking),
+  // gets the number of records in db
+  getNumOfRecords: read(moduleGetters.getNumOfRecords),
 };
 
 // Typed actions
@@ -128,6 +136,12 @@ export const mutations = {
   ),
   setExcludedResultTableData: commit(
     moduleMutations.setExcludedResultTableData
+  ),
+  setFullExcludedResultTableData: commit(
+    moduleMutations.setFullExcludeResultTableData
+  ),
+  setFullIncludedResultTableData: commit(
+    moduleMutations.setFullIncludeResultTableData
   ),
   setAreaOfInterestInner: commit(moduleMutations.setAreaOfInterestInner),
   setAreaOfInterestOuter: commit(moduleMutations.setAreaOfInterestOuter),

--- a/public/store/results/mutations.ts
+++ b/public/store/results/mutations.ts
@@ -43,6 +43,12 @@ export const mutations = {
     // freezing the return to prevent slow, unnecessary deep reactivity.
     state.excludedResultTableData = Object.freeze(resultData);
   },
+  setFullExcludeResultTableData(state: ResultsState, resultData: TableData) {
+    state.fullExcludedResultTableData = Object.freeze(resultData);
+  },
+  setFullIncludeResultTableData(state: ResultsState, resultData: TableData) {
+    state.fullIncludedResultTableData = Object.freeze(resultData);
+  },
   setAreaOfInterestInner(state: ResultsState, resultData: TableData) {
     state.areaOfInterestInner = Object.freeze(resultData);
   },

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -40,9 +40,9 @@
 <script lang="ts">
 import Vue from "vue";
 import VariableFacets from "../components/facets/VariableFacets.vue";
-import ResultsComparison from "../components/ResultsComparison";
-import ResultSummaries from "../components/ResultSummaries";
-import ResultTargetVariable from "../components/ResultTargetVariable";
+import ResultsComparison from "../components/ResultsComparison.vue";
+import ResultSummaries from "../components/ResultSummaries.vue";
+import ResultTargetVariable from "../components/ResultTargetVariable.vue";
 import { Variable, VariableSummary } from "../store/dataset/index";
 import { actions as viewActions } from "../store/view/module";
 import {


### PR DESCRIPTION
closes #2082 

- On the result view the dataSize sliders were impacting the map view.
- The map view is intended to always visualize the entire dataset regardless of the dataSize limit.
- Added two arrays to contain the include and exclude results to the result store.
- The arrays always contain the full dataset.