### PR TITLE
Demo tweaks 2 ranks

### DIFF
--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -156,6 +156,7 @@ type FilteredDataValue struct {
 	Value      interface{}     `json:"value"`
 	Weight     float64         `json:"weight,omitempty"`
 	Confidence NullableFloat64 `json:"confidence,omitempty"`
+	Rank       NullableFloat64 `json:"rank,omitempty"`
 }
 
 // FilteredData provides the metadata and raw data values that match a supplied

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -117,6 +117,7 @@ type SolutionExplainValues struct {
 	LowConfidence  float64     `json:"lowConfidence,omitempty"`
 	HighConfidence float64     `json:"highConfidence,omitempty"`
 	GradCAM        [][]float64 `json:"gradCAM,omitempty"`
+	Rank           float64     `json:"rank,omitempty"`
 }
 
 // SolutionResultExplainOutput captures the explainable output from a produce call.

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -72,7 +72,7 @@ type DataStorage interface {
 	FetchPredictedSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, extrema *Extrema, mode SummaryMode) (*VariableSummary, error)
 	FetchResultsExtremaByURI(dataset string, storageName string, resultURI string) (*Extrema, error)
 	FetchCorrectnessSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, mode SummaryMode) (*VariableSummary, error)
-	FetchConfidenceSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, mode SummaryMode) (*VariableSummary, error)
+	FetchConfidenceSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, mode SummaryMode) (map[string]*VariableSummary, error)
 	FetchResidualsSummary(dataset string, storageName string, resultURI string, filterParams *FilterParams, extrema *Extrema, mode SummaryMode) (*VariableSummary, error)
 	FetchResidualsExtremaByURI(dataset string, storageName string, resultURI string) (*Extrema, error)
 	FetchExtrema(storageName string, variable *model.Variable) (*Extrema, error)

--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -17,6 +17,7 @@ package postgres
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/jackc/pgx/v4"
@@ -25,9 +26,9 @@ import (
 	api "github.com/uncharted-distil/distil/api/model"
 )
 
-// FetchConfidenceSummary fetches a histogram of the confidence associated with a set of classification predictions.
-func (s *Storage) FetchConfidenceSummary(dataset string, storageName string, resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (*api.VariableSummary, error) {
-
+// FetchConfidenceSummary fetches a histogram of the confidence and explanations associated with a set of classification predictions.
+func (s *Storage) FetchConfidenceSummary(dataset string, storageName string, resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (map[string]*api.VariableSummary, error) {
+	explainFields := s.listExplainFields()
 	storageNameResult := s.getResultTable(storageName)
 	targetName, err := s.getResultTargetName(storageNameResult, resultURI)
 	if err != nil {
@@ -39,6 +40,32 @@ func (s *Storage) FetchConfidenceSummary(dataset string, storageName string, res
 		return nil, err
 	}
 
+	explainedSummaries := map[string]*api.VariableSummary{}
+	for _, explainName := range explainFields {
+		var baseline *api.Histogram
+		var filtered *api.Histogram
+		baseline, err = s.fetchExplainHistogram(dataset, storageName, targetName, explainName, resultURI, nil, mode)
+		if err != nil {
+			return nil, err
+		}
+		if !filterParams.Empty() {
+			filtered, err = s.fetchExplainHistogram(dataset, storageName, targetName, explainName, resultURI, filterParams, mode)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		explainedSummaries[explainName] = &api.VariableSummary{
+			Label:    variable.DisplayName,
+			Key:      variable.Name,
+			Type:     model.NumericalType,
+			VarType:  variable.Type,
+			Baseline: baseline,
+			Filtered: filtered,
+		}
+	}
+
+	// TODO: FOLD CONFIDENCES INTO THE SAME JSON FIELD IN THE DATABASE AND THEN DELETE THIS!!!!!
 	var baseline *api.Histogram
 	var filtered *api.Histogram
 	baseline, err = s.fetchConfidenceHistogram(dataset, storageName, variable, targetName, resultURI, nil, mode)
@@ -52,14 +79,40 @@ func (s *Storage) FetchConfidenceSummary(dataset string, storageName string, res
 		}
 	}
 
-	return &api.VariableSummary{
+	explainedSummaries["confidence"] = &api.VariableSummary{
 		Label:    variable.DisplayName,
 		Key:      variable.Name,
 		Type:     model.NumericalType,
 		VarType:  variable.Type,
 		Baseline: baseline,
 		Filtered: filtered,
-	}, nil
+	}
+
+	return explainedSummaries, nil
+}
+
+func (s *Storage) fetchHistograms(dataset string, storageName string, variable *model.Variable, targetName string,
+	resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (map[string]*api.Histogram, error) {
+	explainFields := s.listExplainFields()
+
+	explainedSummaries := map[string]*api.Histogram{}
+	for _, explainName := range explainFields {
+		// get the histogram for that explaination field
+		histo, err := s.fetchExplainHistogram(dataset, storageName, targetName, explainName, resultURI, filterParams, mode)
+		if err != nil {
+			return nil, err
+		}
+		explainedSummaries[explainName] = histo
+	}
+
+	return explainedSummaries, nil
+}
+
+func (s *Storage) fetchExplainHistogram(dataset string, storageName string, targetName string, explainFieldName string,
+	resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (*api.Histogram, error) {
+	// use a numerical sub select
+	field := NewNumericalFieldSubSelect(s, dataset, storageName, explainFieldName, explainFieldName, model.IntegerType, "", s.explainSubSelect(storageName, explainFieldName))
+	return field.fetchHistogram(filterParams, false, 20)
 }
 
 func (s *Storage) fetchConfidenceHistogram(dataset string, storageName string, variable *model.Variable, targetName string, resultURI string, filterParams *api.FilterParams, mode api.SummaryMode) (*api.Histogram, error) {
@@ -144,4 +197,21 @@ func (s *Storage) parseConfidenceHistogram(rows pgx.Rows, variable *model.Variab
 			Max: float64(1),
 		},
 	}, nil
+}
+
+func (s *Storage) listExplainFields() []string {
+	v := reflect.TypeOf(api.SolutionExplainValues{}).Elem()
+	jsonNames := []string{}
+	for j := 0; j < v.NumField(); j++ {
+		f := v.Field(j)
+		jsonNames = append(jsonNames, f.Tag.Get("json"))
+	}
+
+	return jsonNames
+}
+
+func (s *Storage) explainSubSelect(storageName string, fieldName string) func() string {
+	return func() string {
+		return fmt.Sprintf("(SELECT (explain_values ->> '%s')::double precision, index::text as \"%s\" from %s)", fieldName, model.D3MIndexFieldName, storageName)
+	}
 }

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
+	log "github.com/unchartedsoftware/plog"
 )
 
 // NumericalField defines behaviour for the numerical field type.
@@ -139,6 +140,10 @@ func (f *NumericalField) fetchHistogramWithJoins(filterParams *api.FilterParams,
 	extrema, err := f.fetchExtrema()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch variable extrema for summary")
+	}
+	if extrema == nil {
+		log.Warnf("no extrema retrieved for variable summary")
+		return nil, nil
 	}
 
 	// for each returned aggregation, create a histogram aggregation. Bucket
@@ -369,7 +374,8 @@ func (f *NumericalField) parseExtrema(rows pgx.Rows) (*api.Extrema, error) {
 	}
 	// check values exist
 	if minValue == nil || maxValue == nil {
-		return nil, errors.Errorf("no min / max aggregation values found")
+		log.Warnf("no min / max aggregation values found")
+		return nil, nil
 	}
 	// assign attributes
 	return &api.Extrema{

--- a/api/routes/confidence.go
+++ b/api/routes/confidence.go
@@ -104,13 +104,18 @@ func ConfidenceSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api
 			return
 		}
 
-		summary.Key = api.GetConfidenceKey(res.SolutionID)
-		summary.Label = "Confidence"
+		//summary.Key = api.GetConfidenceKey(res.SolutionID)
+		//summary.Label = "Confidence"
 
 		// marshal data and sent the response back
-		err = handleJSON(w, SummaryResult{
-			Summary: summary,
-		})
+		//err = handleJSON(w, SummaryResult{
+		//	Summary: summary,
+		//})
+		//if err != nil {
+		//	handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
+		//	return
+		//}
+		err = handleJSON(w, summary)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
 			return


### PR DESCRIPTION
Confidence ranks now get stored in postgres using that same explain_values field as gradcam, high/low confidences. The confidence summary route has been modified to return all numerical explain values stored in postgres. Currently hack heavy!