### PR TITLE
Explain Call Subset

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -342,12 +342,12 @@ func SplitTimeSeries(timeseries []*api.TimeseriesObservation, trainPercentage fl
 // the raw byte data of the sampled dataset.
 func SampleData(rawData [][]string, maxRows int, stratify bool) [][]string {
 
-	sampler := createSampler(stratify, -1)
+	sampler := createSampler(stratify, -1, -1)
 	return sampler.sample(rawData, maxRows)
 }
 
 // SampleDataset shuffles a dataset's rows and stores a subsample, the schema doc URI.
-func SampleDataset(schemaFile string, outputFolder string, maxRows int, stratify bool, targetCol int) (string, error) {
+func SampleDataset(schemaFile string, outputFolder string, maxRows int, stratify bool, targetCol int, groupingCol int) (string, error) {
 	schemaFile = strings.TrimPrefix(schemaFile, "file://")
 	log.Infof("sampling a maximum row count of %d from '%s' (stratify=%v)", maxRows, schemaFile, stratify)
 	// read metadata
@@ -356,7 +356,7 @@ func SampleDataset(schemaFile string, outputFolder string, maxRows int, stratify
 		return "", err
 	}
 	sourceFilename := model.GetResourcePathFromFolder(path.Dir(schemaFile), meta.GetMainDataResource())
-	sampler := createSampler(stratify, targetCol)
+	sampler := createSampler(stratify, targetCol, groupingCol)
 
 	// check if already sampled (write in the same parent folder as the schema file!)
 	hash, err := sampler.hash(schemaFile, maxRows)

--- a/api/compute/dataset_persist_test.go
+++ b/api/compute/dataset_persist_test.go
@@ -145,8 +145,16 @@ func createTestSplitter(stratify bool, quality string) datasetSplitter {
 		Sample:          0.2,
 		Quality:         quality,
 	}
+
+	if stratify {
+		return &stratifiedSplitter{
+			rowLimits:      limits,
+			targetCol:      2,
+			groupingCol:    -1,
+			trainTestSplit: 0.9,
+		}
+	}
 	return &basicSplitter{
-		stratify:       stratify,
 		rowLimits:      limits,
 		targetCol:      2,
 		groupingCol:    -1,

--- a/api/compute/dataset_persist_test.go
+++ b/api/compute/dataset_persist_test.go
@@ -18,6 +18,7 @@ package compute
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -30,16 +31,16 @@ import (
 
 func TestPersistOriginalDataUnstratified(t *testing.T) {
 	assert.NoError(t, removeTestFiles())
-	params := createTestParams(false, ModelQualityHigh)
-	limits, err := createLimits(ModelQualityHigh)
-	assert.NoError(t, err)
+	params := createTestParams(false, ModelQualityHigh, "test_data")
+	splitter := createTestSplitter(false, ModelQualityHigh)
+	initializeTestConfig()
 
-	splitDatasetName, err := generateSplitDatasetName(params, limits)
+	splitDatasetName, err := generateSplitDatasetName("test_data", path.Join("./test/test_dataset", "datasetDoc.json"), splitter)
 	assert.NoError(t, err)
 	trainPath := fmt.Sprintf("test/tmp_data/%s/train/datasetDoc.json", splitDatasetName)
 	testPath := fmt.Sprintf("test/tmp_data/%s/test/datasetDoc.json", splitDatasetName)
 
-	trainFolder, testFolder, err := persistOriginalData(params)
+	trainFolder, testFolder, err := SplitDataset(path.Join(params.SourceDataFolder, params.SchemaFile), splitter)
 	assert.NoError(t, err)
 	assert.Equal(t, trainPath, trainFolder)
 	assert.Equal(t, testPath, testFolder)
@@ -57,16 +58,16 @@ func TestPersistOriginalDataUnstratified(t *testing.T) {
 
 func TestPersistOriginalDataStratified(t *testing.T) {
 	assert.NoError(t, removeTestFiles())
-	params := createTestParams(true, ModelQualityHigh)
-	limits, err := createLimits(ModelQualityHigh)
-	assert.NoError(t, err)
+	params := createTestParams(true, ModelQualityHigh, "test_data")
+	splitter := createTestSplitter(true, ModelQualityHigh)
+	initializeTestConfig()
 
-	splitDatasetName, err := generateSplitDatasetName(params, limits)
+	splitDatasetName, err := generateSplitDatasetName("test_data", path.Join("./test/test_dataset", "datasetDoc.json"), splitter)
 	assert.NoError(t, err)
 	trainPath := fmt.Sprintf("test/tmp_data/%s/train/datasetDoc.json", splitDatasetName)
 	testPath := fmt.Sprintf("test/tmp_data/%s/test/datasetDoc.json", splitDatasetName)
 
-	trainFolder, testFolder, err := persistOriginalData(params)
+	trainFolder, testFolder, err := SplitDataset(path.Join(params.SourceDataFolder, params.SchemaFile), splitter)
 	assert.NoError(t, err)
 	assert.Equal(t, trainPath, trainFolder)
 	assert.Equal(t, testPath, testFolder)
@@ -91,59 +92,29 @@ func TestPersistOriginalDataStratified(t *testing.T) {
 	assert.Equal(t, 1, categoricalValues["d"])
 }
 
-func TestParamChange(t *testing.T) {
-	assert.NoError(t, removeTestFiles())
-
-	params := createTestParams(false, ModelQualityHigh)
-	limits, err := createLimits(ModelQualityHigh)
-	assert.NoError(t, err)
-	splitDatasetName0, err := generateSplitDatasetName(params, limits)
-	assert.NoError(t, err)
-
-	_, _, err = persistOriginalData(params)
-	assert.NoError(t, err)
-	trainPath := fmt.Sprintf("test/tmp_data/%s/train/datasetDoc.json", splitDatasetName0)
-	assert.FileExists(t, trainPath)
-	testPath := fmt.Sprintf("test/tmp_data/%s/test/datasetDoc.json", splitDatasetName0)
-	assert.FileExists(t, testPath)
-
-	params = createTestParams(true, ModelQualityHigh)
-	splitDatasetName1, err := generateSplitDatasetName(params, limits)
-	assert.NoError(t, err)
-	assert.NotEqual(t, splitDatasetName0, splitDatasetName1)
-
-	_, _, err = persistOriginalData(params)
-	assert.NoError(t, err)
-	trainPath = fmt.Sprintf("test/tmp_data/%s/train/datasetDoc.json", splitDatasetName1)
-	assert.FileExists(t, trainPath)
-	testPath = fmt.Sprintf("test/tmp_data/%s/test/datasetDoc.json", splitDatasetName1)
-	assert.FileExists(t, testPath)
-}
-
 func TestLimitChange(t *testing.T) {
 	assert.NoError(t, removeTestFiles())
+	params := createTestParams(false, ModelQualityHigh, "test_data")
+	splitter := createTestSplitter(false, ModelQualityHigh)
+	initializeTestConfig()
 
-	params := createTestParams(false, ModelQualityHigh)
-	limits, err := createLimits(ModelQualityHigh)
-	assert.NoError(t, err)
-	splitDatasetName0, err := generateSplitDatasetName(params, limits)
+	splitDatasetName0, err := generateSplitDatasetName("test_data", path.Join("./test/test_dataset", "datasetDoc.json"), splitter)
 	assert.NoError(t, err)
 
-	_, _, err = persistOriginalData(params)
+	_, _, err = SplitDataset(path.Join(params.SourceDataFolder, params.SchemaFile), splitter)
 	assert.NoError(t, err)
 	trainPath := fmt.Sprintf("test/tmp_data/%s/train/datasetDoc.json", splitDatasetName0)
 	assert.FileExists(t, trainPath)
 	testPath := fmt.Sprintf("test/tmp_data/%s/test/datasetDoc.json", splitDatasetName0)
 	assert.FileExists(t, testPath)
 
-	params = createTestParams(false, ModelQualityFast)
-	limits, err = createLimits(ModelQualityFast)
-	assert.NoError(t, err)
-	splitDatasetName1, err := generateSplitDatasetName(params, limits)
+	params = createTestParams(true, ModelQualityFast, "test_data")
+	splitter = createTestSplitter(true, ModelQualityFast)
+	splitDatasetName1, err := generateSplitDatasetName("test_data", path.Join("./test/test_dataset", "datasetDoc.json"), splitter)
 	assert.NoError(t, err)
 	assert.NotEqual(t, splitDatasetName0, splitDatasetName1)
 
-	_, _, err = persistOriginalData(params)
+	_, _, err = SplitDataset(path.Join(params.SourceDataFolder, params.SchemaFile), splitter)
 	assert.NoError(t, err)
 	trainPath = fmt.Sprintf("test/tmp_data/%s/train/datasetDoc.json", splitDatasetName1)
 	assert.FileExists(t, trainPath)
@@ -151,9 +122,9 @@ func TestLimitChange(t *testing.T) {
 	assert.FileExists(t, testPath)
 }
 
-func createTestParams(stratify bool, quality string) *persistedDataParams {
+func createTestParams(stratify bool, quality string, name string) *persistedDataParams {
 	return &persistedDataParams{
-		DatasetName:        "test_dataset",
+		DatasetName:        name,
 		SchemaFile:         compute.D3MDataSchema,
 		SourceDataFolder:   "./test/test_dataset",
 		TmpDataFolder:      "./test/tmp_data",
@@ -165,20 +136,31 @@ func createTestParams(stratify bool, quality string) *persistedDataParams {
 	}
 }
 
-func createLimits(quality string) (*rowLimits, error) {
-	var config env.Config
-	config, err := env.LoadConfig()
-	if err != nil {
-		return nil, err
-	}
-	return &rowLimits{
-		MinTrainingRows: config.MinTrainingRows,
-		MinTestRows:     config.MinTestRows,
-		MaxTrainingRows: config.MaxTestRows,
-		MaxTestRows:     config.MaxTestRows,
-		Sample:          config.FastDataPercentage,
+func createTestSplitter(stratify bool, quality string) datasetSplitter {
+	limits := rowLimits{
+		MinTrainingRows: 100,
+		MinTestRows:     100,
+		MaxTrainingRows: 100000,
+		MaxTestRows:     100000,
+		Sample:          0.2,
 		Quality:         quality,
-	}, nil
+	}
+	return &basicSplitter{
+		stratify:       stratify,
+		rowLimits:      limits,
+		targetCol:      2,
+		groupingCol:    -1,
+		trainTestSplit: 0.9,
+	}
+}
+
+func initializeTestConfig() {
+	config := &env.Config{
+		D3MOutputDir: "./test/tmp_data",
+		D3MInputDir:  "./test/test_dataset",
+	}
+
+	env.Initialize(config)
 }
 
 func removeTestFiles() error {

--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -30,6 +30,7 @@ import (
 	log "github.com/unchartedsoftware/plog"
 
 	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/util"
 )
 
@@ -456,7 +457,8 @@ func readDatasetData(uri string) ([][]string, error) {
 		dataPath = path.Join(path.Dir(uriRaw), mainDR.ResPath)
 	}
 
-	res, err := util.ReadCSVFile(dataPath, false)
+	storage := serialization.GetStorage(dataPath)
+	res, err := storage.ReadData(dataPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read raw input data")
 	}

--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -228,8 +228,7 @@ func ExplainFeatureOutput(resultURI string, outputURI string) (*api.SolutionExpl
 	return parsed, nil
 }
 
-func (s *SolutionRequest) explainSolutionOutput(resultURI string, outputURI string,
-	solutionID string, variables []*model.Variable) ([]*api.SolutionWeight, error) {
+func (s *SolutionRequest) explainSolutionOutput(outputURI string, solutionID string, variables []*model.Variable) ([]*api.SolutionWeight, error) {
 
 	// parse the output for the explanations
 	parsed, err := s.parseSolutionWeight(solutionID, outputURI)
@@ -472,4 +471,9 @@ func extractOutputKeys(outputs map[string]*pipelineOutput) []string {
 	}
 
 	return keys
+}
+
+func getExplainDatasetMaxRows(variables []*model.Variable) int {
+	// TODO: we probably want a better way to get this value
+	return 15000 / len(variables)
 }

--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -454,7 +454,7 @@ func readDatasetData(uri string) ([][]string, error) {
 		}
 		mainDR := meta.GetMainDataResource()
 
-		dataPath = path.Join(path.Dir(uriRaw), mainDR.ResPath)
+		dataPath = model.GetResourcePathFromFolder(path.Dir(dataPath), mainDR)
 	}
 
 	storage := serialization.GetStorage(dataPath)

--- a/api/compute/search.go
+++ b/api/compute/search.go
@@ -17,6 +17,8 @@ package compute
 
 import (
 	"context"
+	"path"
+	"strings"
 
 	"github.com/pkg/errors"
 	log "github.com/unchartedsoftware/plog"
@@ -36,7 +38,7 @@ type searchResult struct {
 
 func (s *SolutionRequest) dispatchSolutionExplainPipeline(client *compute.Client, solutionStorage api.SolutionStorage,
 	dataStorage api.DataStorage, searchResult *searchResult, searchID string, searchSolutionID string, dataset string,
-	storageName string, produceDatasetURI string, variables []*model.Variable) error {
+	storageName string, produceDatasetURI string, variables []*model.Variable, targetCol int) error {
 
 	// get solution description
 	desc, err := describeSolution(client, searchSolutionID)
@@ -52,8 +54,9 @@ func (s *SolutionRequest) dispatchSolutionExplainPipeline(client *compute.Client
 	}
 
 	// create a subset of the dataset for the explain call
+	outputFolder := path.Dir(path.Dir(strings.TrimPrefix(produceDatasetURI, "file://")))
 	maxRows := getExplainDatasetMaxRows(variables)
-	explainDatasetURI, err := SampleDataset(produceDatasetURI, maxRows, true)
+	explainDatasetURI, err := SampleDataset(produceDatasetURI, outputFolder, maxRows, true, targetCol)
 	if err != nil {
 		return err
 	}

--- a/api/compute/search.go
+++ b/api/compute/search.go
@@ -38,7 +38,7 @@ type searchResult struct {
 
 func (s *SolutionRequest) dispatchSolutionExplainPipeline(client *compute.Client, solutionStorage api.SolutionStorage,
 	dataStorage api.DataStorage, searchResult *searchResult, searchID string, searchSolutionID string, dataset string,
-	storageName string, produceDatasetURI string, variables []*model.Variable, targetCol int) error {
+	storageName string, produceDatasetURI string, variables []*model.Variable, targetCol int, groupingCol int) error {
 
 	// get solution description
 	desc, err := describeSolution(client, searchSolutionID)
@@ -56,7 +56,7 @@ func (s *SolutionRequest) dispatchSolutionExplainPipeline(client *compute.Client
 	// create a subset of the dataset for the explain call
 	outputFolder := path.Dir(path.Dir(strings.TrimPrefix(produceDatasetURI, "file://")))
 	maxRows := getExplainDatasetMaxRows(variables)
-	explainDatasetURI, err := SampleDataset(produceDatasetURI, outputFolder, maxRows, true, targetCol)
+	explainDatasetURI, err := SampleDataset(produceDatasetURI, outputFolder, maxRows, true, targetCol, groupingCol)
 	if err != nil {
 		return err
 	}
@@ -103,6 +103,7 @@ func (s *SolutionRequest) dispatchSolutionExplainPipeline(client *compute.Client
 				log.Infof("explaining feature output from URI '%s'", explainURI)
 				explainDatasetURI = compute.BuildSchemaFileURI(explainDatasetURI)
 				parsedExplainResult, err := ExplainFeatureOutput(explainDatasetURI, explainURI)
+				parsedExplainResult.ResultURI = searchResult.resultURI
 				if err != nil {
 					log.Warnf("failed to fetch output explanation - %v", err)
 					continue

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -755,21 +755,9 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 
 	// when dealing with categorical data we want to stratify
 	stratify := model.IsCategorical(s.TargetFeature.Type)
-
-	// perist the datasets and get URI
-	params := &persistedDataParams{
-		DatasetName:        s.DatasetInput,
-		SchemaFile:         compute.D3MDataSchema,
-		SourceDataFolder:   datasetInputDir,
-		TmpDataFolder:      datasetDir,
-		TaskType:           s.Task,
-		GroupingFieldIndex: groupingVariableIndex,
-		TargetFieldIndex:   targetIndex,
-		Stratify:           stratify,
-		Quality:            s.Quality,
-		TrainTestSplit:     s.TrainTestSplit,
-	}
-	datasetPathTrain, datasetPathTest, err := persistOriginalData(params)
+	// create the splitter to use for the train / test split
+	splitter := createSplitter(s.Task, targetIndex, groupingVariableIndex, stratify, s.Quality, s.TrainTestSplit)
+	datasetPathTrain, datasetPathTest, err := SplitDataset(path.Join(datasetInputDir, compute.D3MDataSchema), splitter)
 	if err != nil {
 		return err
 	}

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -574,55 +574,43 @@ func describeSolution(client *compute.Client, initialSearchSolutionID string) (*
 }
 
 func (s *SolutionRequest) dispatchRequest(client *compute.Client, solutionStorage api.SolutionStorage,
-	dataStorage api.DataStorage, searchID string, dataset string, storageName string, datasetURI string,
-	datasetURITrain string, datasetURITest string, variables []*model.Variable, targetCol int, groupingCol int) {
+	dataStorage api.DataStorage, searchContext pipelineSearchContext) {
 
 	// update request status
-	err := s.persistRequestStatus(s.requestChannel, solutionStorage, searchID, dataset, RequestRunningStatus)
+	err := s.persistRequestStatus(s.requestChannel, solutionStorage, searchContext.searchID, searchContext.dataset, RequestRunningStatus)
 	if err != nil {
 		s.finished <- err
 		return
 	}
 
-	// generate predictions -  for timeseries we want to use the entire source dataset, for anything else
-	// we only want the test data predictions.
-	produceDatasetURI := datasetURITest
-	for _, task := range s.Task {
-		if task == compute.ForecastingTask {
-			produceDatasetURI = compute.BuildSchemaFileURI(datasetURI)
-			break
-		}
-	}
-
 	// search for solutions, this wont return until the search finishes or it times out
-	err = client.SearchSolutions(context.Background(), searchID, func(solution *pipeline.GetSearchSolutionsResultsResponse) {
+	err = client.SearchSolutions(context.Background(), searchContext.searchID, func(solution *pipeline.GetSearchSolutionsResultsResponse) {
+		searchContext.searchSolutionID = solution.SolutionId
 		// create a new status channel for the solution
 		c := newStatusChannel()
 		// add the solution to the request
 		s.addSolution(c)
 		// persist the solution
-		s.persistSolution(c, solutionStorage, searchID, solution.SolutionId, "")
-		s.persistSolutionStatus(c, solutionStorage, searchID, solution.SolutionId, SolutionPendingStatus)
+		s.persistSolution(c, solutionStorage, searchContext.searchID, solution.SolutionId, "")
+		s.persistSolutionStatus(c, solutionStorage, searchContext.searchID, solution.SolutionId, SolutionPendingStatus)
 		// dispatch it
-		searchResult, err := s.dispatchSolutionSearchPipeline(c, client, solutionStorage, dataStorage, searchID,
-			solution.SolutionId, dataset, storageName, produceDatasetURI, datasetURITrain, datasetURITest)
+		searchContext.searchResult, err = s.dispatchSolutionSearchPipeline(c, client, solutionStorage, dataStorage, searchContext)
 		if err != nil {
-			s.persistSolutionError(c, solutionStorage, searchID, solution.SolutionId, err)
+			s.persistSolutionError(c, solutionStorage, searchContext.searchID, solution.SolutionId, err)
 			return
 		}
 
-		err = s.dispatchSolutionExplainPipeline(client, solutionStorage, dataStorage, searchResult, searchID,
-			solution.SolutionId, dataset, storageName, produceDatasetURI, variables, targetCol, groupingCol)
+		err = s.dispatchSolutionExplainPipeline(client, solutionStorage, dataStorage, searchContext)
 		if err != nil {
-			s.persistSolutionError(c, solutionStorage, searchID, solution.SolutionId, err)
+			s.persistSolutionError(c, solutionStorage, searchContext.searchID, solution.SolutionId, err)
 			return
 		}
 
 		// notify client of update
 		c <- SolutionStatus{
-			RequestID:  searchID,
+			RequestID:  searchContext.searchID,
 			SolutionID: solution.SolutionId,
-			ResultID:   searchResult.resultID,
+			ResultID:   searchContext.searchResult.resultID,
 			Progress:   SolutionCompletedStatus,
 			Timestamp:  time.Now(),
 		}
@@ -636,9 +624,9 @@ func (s *SolutionRequest) dispatchRequest(client *compute.Client, solutionStorag
 
 	// update request status
 	if err != nil {
-		s.persistRequestError(s.requestChannel, solutionStorage, searchID, dataset, err)
+		s.persistRequestError(s.requestChannel, solutionStorage, searchContext.searchID, searchContext.dataset, err)
 	} else {
-		s.persistRequestStatus(s.requestChannel, solutionStorage, searchID, dataset, RequestCompletedStatus)
+		s.persistRequestStatus(s.requestChannel, solutionStorage, searchContext.searchID, searchContext.dataset, RequestCompletedStatus)
 	}
 	close(s.requestChannel)
 
@@ -836,8 +824,30 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 	}
 
 	// dispatch search request
-	go s.dispatchRequest(client, solutionStorage, dataStorage, requestID, dataset.ID, datasetInput.StorageName,
-		datasetInputDir, datasetPathTrain, datasetPathTest, dataVariables, s.TargetFeature.Index, groupingVariableIndex)
+	searchContext := pipelineSearchContext{
+		searchID:          requestID,
+		dataset:           dataset.ID,
+		storageName:       datasetInput.StorageName,
+		sourceDatasetURI:  datasetInputDir,
+		trainDatasetURI:   datasetPathTrain,
+		testDatasetURI:    datasetPathTest,
+		produceDatasetURI: datasetPathTest,
+		variables:         dataVariables,
+		targetCol:         s.TargetFeature.Index,
+		groupingCol:       groupingVariableIndex,
+		sample:            true,
+	}
+
+	// generate predictions -  for timeseries we want to use the entire source dataset, for anything else
+	// we only want the test data predictions.
+	for _, task := range s.Task {
+		if task == compute.ForecastingTask {
+			searchContext.produceDatasetURI = compute.BuildSchemaFileURI(searchContext.sourceDatasetURI)
+			searchContext.sample = false
+			break
+		}
+	}
+	go s.dispatchRequest(client, solutionStorage, dataStorage, searchContext)
 
 	return nil
 }

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -573,8 +573,9 @@ func describeSolution(client *compute.Client, initialSearchSolutionID string) (*
 	return desc, nil
 }
 
-func (s *SolutionRequest) dispatchRequest(client *compute.Client, solutionStorage api.SolutionStorage, dataStorage api.DataStorage,
-	searchID string, dataset string, storageName string, datasetURI string, datasetURITrain string, datasetURITest string, variables []*model.Variable) {
+func (s *SolutionRequest) dispatchRequest(client *compute.Client, solutionStorage api.SolutionStorage,
+	dataStorage api.DataStorage, searchID string, dataset string, storageName string, datasetURI string,
+	datasetURITrain string, datasetURITest string, variables []*model.Variable, targetCol int) {
 
 	// update request status
 	err := s.persistRequestStatus(s.requestChannel, solutionStorage, searchID, dataset, RequestRunningStatus)
@@ -611,7 +612,7 @@ func (s *SolutionRequest) dispatchRequest(client *compute.Client, solutionStorag
 		}
 
 		err = s.dispatchSolutionExplainPipeline(client, solutionStorage, dataStorage, searchResult, searchID,
-			solution.SolutionId, dataset, storageName, produceDatasetURI, variables)
+			solution.SolutionId, dataset, storageName, produceDatasetURI, variables, targetCol)
 		if err != nil {
 			s.persistSolutionError(c, solutionStorage, searchID, solution.SolutionId, err)
 			return
@@ -835,8 +836,8 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 	}
 
 	// dispatch search request
-	go s.dispatchRequest(client, solutionStorage, dataStorage, requestID, dataset.ID,
-		datasetInput.StorageName, datasetInputDir, datasetPathTrain, datasetPathTest, dataVariables)
+	go s.dispatchRequest(client, solutionStorage, dataStorage, requestID, dataset.ID, datasetInput.StorageName,
+		datasetInputDir, datasetPathTrain, datasetPathTest, dataVariables, s.TargetFeature.Index)
 
 	return nil
 }

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -575,7 +575,7 @@ func describeSolution(client *compute.Client, initialSearchSolutionID string) (*
 
 func (s *SolutionRequest) dispatchRequest(client *compute.Client, solutionStorage api.SolutionStorage,
 	dataStorage api.DataStorage, searchID string, dataset string, storageName string, datasetURI string,
-	datasetURITrain string, datasetURITest string, variables []*model.Variable, targetCol int) {
+	datasetURITrain string, datasetURITest string, variables []*model.Variable, targetCol int, groupingCol int) {
 
 	// update request status
 	err := s.persistRequestStatus(s.requestChannel, solutionStorage, searchID, dataset, RequestRunningStatus)
@@ -589,7 +589,7 @@ func (s *SolutionRequest) dispatchRequest(client *compute.Client, solutionStorag
 	produceDatasetURI := datasetURITest
 	for _, task := range s.Task {
 		if task == compute.ForecastingTask {
-			produceDatasetURI = datasetURI
+			produceDatasetURI = compute.BuildSchemaFileURI(datasetURI)
 			break
 		}
 	}
@@ -612,7 +612,7 @@ func (s *SolutionRequest) dispatchRequest(client *compute.Client, solutionStorag
 		}
 
 		err = s.dispatchSolutionExplainPipeline(client, solutionStorage, dataStorage, searchResult, searchID,
-			solution.SolutionId, dataset, storageName, produceDatasetURI, variables, targetCol)
+			solution.SolutionId, dataset, storageName, produceDatasetURI, variables, targetCol, groupingCol)
 		if err != nil {
 			s.persistSolutionError(c, solutionStorage, searchID, solution.SolutionId, err)
 			return
@@ -837,7 +837,7 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 
 	// dispatch search request
 	go s.dispatchRequest(client, solutionStorage, dataStorage, requestID, dataset.ID, datasetInput.StorageName,
-		datasetInputDir, datasetPathTrain, datasetPathTest, dataVariables, s.TargetFeature.Index)
+		datasetInputDir, datasetPathTrain, datasetPathTest, dataVariables, s.TargetFeature.Index, groupingVariableIndex)
 
 	return nil
 }

--- a/api/compute/split.go
+++ b/api/compute/split.go
@@ -264,7 +264,7 @@ func (s *stratifiedSplitter) split(data [][]string) ([][]string, [][]string, err
 	// subsets by category, and then sampling the subsets using the supplied train/test ratio.
 
 	// first pass - create subsets by category
-	categoryRowData := s.splitCategories(s.targetCol, data)
+	categoryRowData := s.splitCategories(s.targetCol, inputData)
 
 	// second pass - randomly sample each category to generate train/test split
 	for _, data := range categoryRowData {

--- a/api/compute/split.go
+++ b/api/compute/split.go
@@ -45,7 +45,7 @@ type datasetSplitter interface {
 }
 
 type datasetSampler interface {
-	sample(data [][]string, maxRows int) ([][]string, error)
+	sample(data [][]string, maxRows int) [][]string
 	hash(schemaFile string, params ...interface{}) (uint64, error)
 }
 
@@ -180,11 +180,11 @@ func (b *basicSplitter) split(data [][]string) ([][]string, [][]string, error) {
 	return outputTrain, outputTest, nil
 }
 
-func (b *basicSplitter) sample(data [][]string, maxRows int) ([][]string, error) {
+func (b *basicSplitter) sample(data [][]string, maxRows int) [][]string {
 	output := [][]string{}
 	output, _ = shuffleAndWrite(data[1:], -1, maxRows, 0, false, output, nil, float64(1))
 
-	return output, nil
+	return output
 }
 
 func (s *stratifiedSplitter) hash(schemaFile string, params ...interface{}) (uint64, error) {
@@ -213,7 +213,7 @@ func (s *stratifiedSplitter) hash(schemaFile string, params ...interface{}) (uin
 	return hash, nil
 }
 
-func (s *stratifiedSplitter) sample(data [][]string, maxRows int) ([][]string, error) {
+func (s *stratifiedSplitter) sample(data [][]string, maxRows int) [][]string {
 	// create the output
 	output := [][]string{data[0]}
 
@@ -230,10 +230,9 @@ func (s *stratifiedSplitter) sample(data [][]string, maxRows int) ([][]string, e
 		maxRowsCat := int(math.Max(1, float64(len(catData))/float64(totalRows)*float64(maxRows)))
 		outputCat, _ := shuffleAndWrite(catData, -1, maxRowsCat, 0, false, catData, nil, 1.0)
 		output = append(output, outputCat...)
-
 	}
 
-	return output, nil
+	return output
 }
 
 func (s *stratifiedSplitter) splitCategories(colIndex int, data [][]string) map[string][][]string {

--- a/api/compute/split.go
+++ b/api/compute/split.go
@@ -1,0 +1,270 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package compute
+
+import (
+	"math"
+	"path"
+	"sort"
+
+	"github.com/mitchellh/hashstructure"
+	"github.com/pkg/errors"
+
+	"github.com/uncharted-distil/distil-compute/metadata"
+	"github.com/uncharted-distil/distil-compute/model"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
+	"github.com/uncharted-distil/distil/api/env"
+	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/serialization"
+)
+
+var (
+	splitterBasic      *basicSplitter
+	splitterTimeseries *timeseriesSplitter
+)
+
+type datasetSplitter interface {
+	split(data [][]string) ([][]string, [][]string, error)
+	hash(schemaFile string) (uint64, error)
+}
+
+type timeseriesSplitter struct {
+	timeseriesCol  int
+	trainTestSplit float64
+}
+
+type basicSplitter struct {
+	stratify       bool
+	rowLimits      rowLimits
+	targetCol      int
+	groupingCol    int
+	trainTestSplit float64
+}
+
+func (t *timeseriesSplitter) hash(schemaFile string) (uint64, error) {
+	// generate the hash from the params
+	hashStruct := struct {
+		Schema         string
+		TimeseriesCol  int
+		TrainTestSplit float64
+	}{
+		Schema:         schemaFile,
+		TimeseriesCol:  t.timeseriesCol,
+		TrainTestSplit: t.trainTestSplit,
+	}
+	hash, err := hashstructure.Hash(hashStruct, nil)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to generate persisted data hash")
+	}
+	return hash, nil
+}
+
+func (t *timeseriesSplitter) split(data [][]string) ([][]string, [][]string, error) {
+	// training data
+	outputTrain := [][]string{}
+
+	// test data
+	outputTest := [][]string{}
+
+	// handle the header
+	inputData, outputTrain, outputTest := splitTrainTestHeader(data, outputTrain, outputTest, true)
+
+	// find the desired timeseries threshold
+	// load the parsed timestamp into a list and read all raw data in memory
+	timestamps := make([]float64, 0)
+	for _, line := range inputData {
+		// attempt to parse as float
+		t, err := parseTimeColValue(line[t.timeseriesCol])
+		if err != nil {
+			return nil, nil, err
+		}
+		timestamps = append(timestamps, t)
+	}
+
+	// find the time threshold by sorting and taking the value that gives
+	// the right split (ie value where we would send roughly 90% of
+	// the data to train and 10% to test)
+	sort.Slice(timestamps, func(i int, j int) bool {
+		return timestamps[i] <= timestamps[j]
+	})
+	timestampSplit := SplitTimeStamps(timestamps, t.trainTestSplit)
+
+	// output the values based on if before threshold or after threshold
+	for _, line := range inputData {
+		// since we parsed it above, then the parsing here should succeed
+		// TODO: the timestamps list is already sorted but we really should
+		// reuse it to not double parse things
+		t, _ := parseTimeColValue(line[t.timeseriesCol])
+
+		// !After == Before || Equal
+		if t <= timestampSplit.SplitValue {
+			outputTrain = append(outputTrain, line)
+		} else {
+			outputTest = append(outputTest, line)
+		}
+	}
+
+	return outputTrain, outputTest, nil
+}
+
+func (b *basicSplitter) hash(schemaFile string) (uint64, error) {
+	// generate the hash from the params
+	hashStruct := struct {
+		Schema         string
+		Stratify       bool
+		RowLimits      rowLimits
+		TargetCol      int
+		GroupingCol    int
+		TrainTestSplit float64
+	}{
+		Schema:         schemaFile,
+		Stratify:       b.stratify,
+		RowLimits:      b.rowLimits,
+		TargetCol:      b.targetCol,
+		GroupingCol:    b.groupingCol,
+		TrainTestSplit: b.trainTestSplit,
+	}
+	hash, err := hashstructure.Hash(hashStruct, nil)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to generate persisted data hash")
+	}
+	return hash, nil
+}
+
+func (b *basicSplitter) split(data [][]string) ([][]string, [][]string, error) {
+	// create the output
+	outputTrain := [][]string{}
+	outputTest := [][]string{}
+
+	// handle the header
+	inputData, outputTrain, outputTest := splitTrainTestHeader(data, outputTrain, outputTest, true)
+
+	numDatasetRows := len(inputData)
+	numTrainingRows := b.rowLimits.trainingRows(numDatasetRows)
+	numTestRows := b.rowLimits.testRows(numDatasetRows)
+	if b.stratify {
+		// For statification we use a proportionate allocation strategy, dividing the dataset up into
+		// subsets by category, and then sampling the subsets using the supplied train/test ratio.
+
+		// first pass - create subsets by category
+		categoryRowData := map[string][][]string{}
+		for _, row := range inputData {
+			key := row[b.targetCol]
+			if _, ok := categoryRowData[key]; !ok {
+				categoryRowData[key] = [][]string{}
+			}
+			categoryRowData[key] = append(categoryRowData[key], row)
+		}
+
+		// second pass - randomly sample each category to generate train/test split
+		for _, data := range categoryRowData {
+			maxCategoryTrainingRows := int(math.Max(1, float64(len(data))/float64(len(inputData))*float64(numTrainingRows)))
+			maxCategoryTestRows := int(math.Max(1, float64(len(data))/float64(len(inputData))*float64(numTestRows)))
+			outputTrain, outputTest = shuffleAndWrite(data, b.groupingCol, maxCategoryTrainingRows, maxCategoryTestRows, true, outputTrain, outputTest, b.trainTestSplit)
+		}
+	} else {
+		// randomly select from dataset based on row limits
+		outputTrain, outputTest = shuffleAndWrite(inputData, b.groupingCol, numTrainingRows, numTestRows, true, outputTrain, outputTest, b.trainTestSplit)
+	}
+
+	return outputTrain, outputTest, nil
+}
+
+// SplitDataset splits a dataset into train and test, using an approach to splitting
+// suitable to the task performed.
+func SplitDataset(schemaFile string, splitter datasetSplitter) (string, string, error) {
+	// load the metadata to get the data resource
+	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)
+	if err != nil {
+		return "", "", err
+	}
+
+	// load data to split
+	data, err := loadData(path.Dir(schemaFile), meta)
+	if err != nil {
+		return "", "", err
+	}
+
+	// split the data
+	trainData, testData, err := splitter.split(data)
+	if err != nil {
+		return "", "", err
+	}
+
+	// determine output location
+	splitDatasetName, err := generateSplitDatasetName(meta.Name, schemaFile, splitter)
+	if err != nil {
+		return "", "", err
+	}
+	trainFolder := path.Join(env.GetTmpPath(), splitDatasetName, trainFilenamePrefix)
+	testFolder := path.Join(env.GetTmpPath(), splitDatasetName, testFilenamePrefix)
+	outputFilename := path.Base(meta.GetMainDataResource().ResPath)
+
+	trainOutput := path.Join(trainFolder, compute.D3MDataFolder, outputFilename)
+	testOutput := path.Join(testFolder, compute.D3MDataFolder, outputFilename)
+
+	// output the train and test data
+	mainDR := meta.GetMainDataResource()
+	outputStore := serialization.GetStorage(mainDR.ResPath)
+	mainDR.ResPath = trainOutput
+	outputTrain := &api.RawDataset{
+		ID:       meta.ID,
+		Name:     meta.Name,
+		Metadata: meta,
+		Data:     trainData,
+	}
+	err = outputStore.WriteDataset(trainFolder, outputTrain)
+	if err != nil {
+		return "", "", err
+	}
+
+	mainDR.ResPath = testOutput
+	outputTest := &api.RawDataset{
+		ID:       meta.ID,
+		Name:     meta.Name,
+		Metadata: meta,
+		Data:     testData,
+	}
+	err = outputStore.WriteDataset(testFolder, outputTest)
+	if err != nil {
+		return "", "", err
+	}
+
+	return path.Join(trainFolder, compute.D3MDataSchema), path.Join(testFolder, compute.D3MDataSchema), nil
+}
+
+func loadData(sourceFolder string, meta *model.Metadata) ([][]string, error) {
+	// use the path to determine how to load the data
+	mainDR := meta.GetMainDataResource()
+	filename := model.GetResourcePathFromFolder(sourceFolder, mainDR)
+
+	storage := serialization.GetStorage(filename)
+	data, err := storage.ReadData(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func getSplitter(taskType []string, targetIndex int) datasetSplitter {
+	for _, task := range taskType {
+		if task == compute.ForecastingTask {
+			return splitterTimeseries
+		}
+	}
+	return splitterBasic
+}

--- a/api/compute/split.go
+++ b/api/compute/split.go
@@ -324,8 +324,15 @@ func SplitDataset(schemaFile string, splitter datasetSplitter) (string, string, 
 	trainOutput := path.Join(trainFolder, compute.D3MDataFolder, outputFilename)
 	testOutput := path.Join(testFolder, compute.D3MDataFolder, outputFilename)
 
-	// output the train and test data
+	// update the referenced data resource paths
 	mainDR := meta.GetMainDataResource()
+	for _, dr := range meta.DataResources {
+		if dr != mainDR {
+			dr.ResPath = model.GetResourcePath(schemaFile, dr)
+		}
+	}
+
+	// output the train and test data
 	outputStore := serialization.GetStorage(mainDR.ResPath)
 	mainDR.ResPath = trainOutput
 	outputTrain := &api.RawDataset{

--- a/api/compute/split.go
+++ b/api/compute/split.go
@@ -407,7 +407,15 @@ func createSplitter(taskType []string, targetFieldIndex int, groupingFieldIndex 
 	}
 }
 
-func createSampler(stratify bool, targetCol int) datasetSampler {
+func createSampler(stratify bool, targetCol int, groupingCol int) datasetSampler {
+	// if grouped, stratified splitter works but on the group rather than the label
+	if groupingCol >= 0 {
+		return &stratifiedSplitter{
+			targetCol:   groupingCol,
+			groupingCol: groupingCol,
+		}
+	}
+
 	if stratify {
 		return &stratifiedSplitter{
 			targetCol:   targetCol,

--- a/api/compute/split_test.go
+++ b/api/compute/split_test.go
@@ -1,0 +1,64 @@
+//
+//   Copyright © 2019 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package compute
+
+import (
+	"fmt"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uncharted-distil/distil/api/util"
+)
+
+func TestSampleStratified(t *testing.T) {
+	assert.NoError(t, removeTestFiles())
+	params := createTestParams(false, ModelQualityHigh, "test_data")
+	initializeTestConfig()
+	expectedSamplePath := fmt.Sprintf("test/tmp_data/sample-6f5d2a90aff56355/datasetDoc.json")
+
+	sampleURI, err := SampleDataset(path.Join(params.SourceDataFolder, params.SchemaFile), "./test/tmp_data", 10, true, 2)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedSamplePath, sampleURI)
+
+	lines, err := util.ReadCSVFile(path.Join(path.Dir(sampleURI), "tables", "learningData.csv"), true)
+	assert.NoError(t, err)
+	assert.Equal(t, 11, len(lines))
+	assert.NoError(t, removeTestFiles())
+
+	categoricalValues := map[string]int{}
+	for _, rowData := range lines {
+		categoricalValues[rowData[2]]++
+	}
+	assert.Equal(t, 6, categoricalValues["a"])
+	assert.Equal(t, 3, categoricalValues["b"])
+	assert.Equal(t, 1, categoricalValues["c"])
+	assert.Equal(t, 1, categoricalValues["d"])
+}
+
+func createTestSampler(stratify bool) datasetSplitter {
+
+	if stratify {
+		return &stratifiedSplitter{
+			targetCol:   2,
+			groupingCol: -1,
+		}
+	}
+	return &basicSplitter{
+		targetCol:   2,
+		groupingCol: -1,
+	}
+}

--- a/api/compute/split_test.go
+++ b/api/compute/split_test.go
@@ -30,7 +30,7 @@ func TestSampleStratified(t *testing.T) {
 	initializeTestConfig()
 	expectedSamplePath := fmt.Sprintf("test/tmp_data/sample-6f5d2a90aff56355/datasetDoc.json")
 
-	sampleURI, err := SampleDataset(path.Join(params.SourceDataFolder, params.SchemaFile), "./test/tmp_data", 10, true, 2)
+	sampleURI, err := SampleDataset(path.Join(params.SourceDataFolder, params.SchemaFile), "./test/tmp_data", 10, true, 2, -1)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSamplePath, sampleURI)
 

--- a/api/compute/test/test_dataset/datasetDoc.json
+++ b/api/compute/test/test_dataset/datasetDoc.json
@@ -1,45 +1,40 @@
 {
-    "about": {
-        "datasetID": "test_data",
-        "datasetName": "test_data",
-        "license": "CC-BY license",
-        "approximateSize": "",
-        "datasetSchemaVersion": "3.0",
-        "redacted": true,
-        "datasetVersion": "1.0"
-    },
-    "dataResources": [{
-        "resID": "learningData",
-        "resPath": "tables/learningData.csv",
-        "resType": "table",
-        "resFormat": [
-            "text/csv"
-        ],
-        "isCollection": false,
-        "columns": [{
-                "colIndex": 0,
-                "colName": "d3mIndex",
-                "colType": "integer",
-                "role": [
-                    "index"
-                ]
-            },
-            {
-                "colIndex": 1,
-                "colName": "alpha",
-                "colType": "real",
-                "role": [
-                    "attribute"
-                ]
-            },
-            {
-                "colIndex": 2,
-                "colName": "bravo",
-                "colType": "categorical",
-                "role": [
-                    "attribute"
-                ]
-            }
-        ]
-    }]
+  "about": {
+    "datasetID": "test_data",
+    "datasetName": "test_data",
+    "license": "CC-BY license",
+    "approximateSize": "",
+    "datasetSchemaVersion": "3.0",
+    "redacted": true,
+    "datasetVersion": "1.0"
+  },
+  "dataResources": [
+    {
+      "resID": "learningData",
+      "resPath": "tables/learningData.csv",
+      "resType": "table",
+      "resFormat": ["text/csv"],
+      "isCollection": false,
+      "columns": [
+        {
+          "colIndex": 0,
+          "colName": "d3mIndex",
+          "colType": "integer",
+          "role": ["index"]
+        },
+        {
+          "colIndex": 1,
+          "colName": "alpha",
+          "colType": "real",
+          "role": ["attribute"]
+        },
+        {
+          "colIndex": 2,
+          "colName": "bravo",
+          "colType": "categorical",
+          "role": ["attribute"]
+        }
+      ]
+    }
+  ]
 }

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -53,6 +53,12 @@ func GetStorage(uri string) Storage {
 	return csvStorage
 }
 
+// WriteData writes data to storage using the specified URI.
+func WriteData(uri string, data [][]string) error {
+	store := GetStorage(uri)
+	return store.WriteData(uri, data)
+}
+
 // GetCSVStorage returns the instantiated csv storage.
 func GetCSVStorage() Storage {
 	return csvStorage

--- a/api/task/sample.go
+++ b/api/task/sample.go
@@ -51,7 +51,7 @@ func Sample(originalSchemaFile string, schemaFile string, dataset string, config
 		return schemaFile, false, len(csvData), nil
 	}
 
-	sampledData := compute.SampleDataset(csvData, config.SampleRowLimit, true)
+	sampledData := compute.SampleData(csvData, config.SampleRowLimit, true)
 
 	// copy the full csv to keep it if needed
 	err = util.CopyFile(originalCSVFilePath, path.Join(path.Dir(originalCSVFilePath), "learningData-full.csv"))


### PR DESCRIPTION
Fixes #1878 

Refactored the split and sampling calls to abstract them into an interface. Should let us easily expand splitting and sampling strategies. Also cleaned up the solution search code a bit to not pass around as many parameters.

There are some follow on fixes that should be done. Most importantly, the maximum rows is currently set to 15000/# of dataset variables. We most likely want to change that to something much more flexible. We will also have to add the necessary code to prioritize rows with explanations over those without when pulling data for the client. We may also want to explore batching of the test dataset for the explain call and process them successively.