### PR TITLE
#2023 - variables listed by rank score in model summaries

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -36,14 +36,15 @@ var (
 
 // ExportedModel represents a description of an exported model.
 type ExportedModel struct {
-	ModelName        string   `json:"modelName"`
-	ModelDescription string   `json:"modelDescription"`
-	FilePath         string   `json:"filePath"`
-	FittedSolutionID string   `json:"fittedSolutionId"`
-	DatasetID        string   `json:"datasetId"`
-	DatasetName      string   `json:"datasetName"`
-	Target           string   `json:"target"`
-	Variables        []string `json:"variables"`
+	ModelName        string              `json:"modelName"`
+	ModelDescription string              `json:"modelDescription"`
+	FilePath         string              `json:"filePath"`
+	FittedSolutionID string              `json:"fittedSolutionId"`
+	DatasetID        string              `json:"datasetId"`
+	DatasetName      string              `json:"datasetName"`
+	Target           string              `json:"target"`
+	Variables        []string            `json:"variables"`
+	VariableDetails  []*SolutionVariable `json:"variableDetails"`
 }
 
 // Request represents the request metadata.
@@ -163,6 +164,13 @@ type SolutionScore struct {
 	Label          string  `json:"label"`
 	Score          float64 `json:"value"`
 	SortMultiplier float64 `json:"sortMultiplier"`
+}
+
+// SolutionVariable represents the basic variable data for a solution
+type SolutionVariable struct {
+	Name string  `json:"name"`
+	Rank float64 `json:"rank"`
+	Type string  `json:"type"`
 }
 
 // PredictionResult represents the output from a model prediction.

--- a/api/routes/add_field.go
+++ b/api/routes/add_field.go
@@ -13,6 +13,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+
 package routes
 
 import (

--- a/api/task/solution.go
+++ b/api/task/solution.go
@@ -60,6 +60,12 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 		}
 	}
 
+	types := make(map[string]string)
+
+	for _, vt := range dataset.Variables {
+		types[vt.Name] = vt.Type
+	}
+
 	vars := make([]string, len(request.Features)-1)
 	varDetails := make([]*api.SolutionVariable, len(request.Features)-1)
 	target := ""
@@ -72,7 +78,7 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 			varDetails[c] = &api.SolutionVariable{
 				Name: v.FeatureName,
 				Rank: ranks[v.FeatureName],
-				Type: v.FeatureType,
+				Type: types[v.FeatureName],
 			}
 			c = c + 1
 		}

--- a/api/task/solution.go
+++ b/api/task/solution.go
@@ -34,12 +34,34 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 		return nil, err
 	}
 
-	metadata, err := metadataStorage.FetchDataset(request.Dataset, false, false)
+	dataset, err := metadataStorage.FetchDataset(request.Dataset, false, false)
 	if err != nil {
 		return nil, err
 	}
 
+	weights, err := solutionStorage.FetchSolutionWeights(fittedSolutionID)
+	if err != nil {
+		return nil, err
+	}
+
+	ranks := make(map[string]float64)
+	for _, fw := range weights {
+		ranks[fw.FeatureName] = fw.Weight
+	}
+
+	if len(ranks) == 0 {
+		summaryVariables, err := api.FetchSummaryVariables(dataset.ID, metadataStorage)
+		if err != nil {
+			return nil, err
+		}
+		ranks, err = TargetRank(dataset.Folder, request.TargetFeature(), summaryVariables, dataset.Source)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	vars := make([]string, len(request.Features)-1)
+	varDetails := make([]*api.SolutionVariable, len(request.Features)-1)
 	target := ""
 	c := 0
 	for _, v := range request.Features {
@@ -47,6 +69,11 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 			target = v.FeatureName
 		} else {
 			vars[c] = v.FeatureName
+			varDetails[c] = &api.SolutionVariable{
+				Name: v.FeatureName,
+				Rank: ranks[v.FeatureName],
+				Type: v.FeatureType,
+			}
 			c = c + 1
 		}
 	}
@@ -55,8 +82,9 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 		FilePath:         uri,
 		FittedSolutionID: fittedSolutionID,
 		DatasetID:        request.Dataset,
-		DatasetName:      metadata.Name,
+		DatasetName:      dataset.Name,
 		Variables:        vars,
+		VariableDetails:  varDetails,
 		Target:           target,
 		ModelName:        modelName,
 		ModelDescription: modelDescription,

--- a/public/components/ModelPreview.vue
+++ b/public/components/ModelPreview.vue
@@ -44,8 +44,10 @@
         <div v-if="expanded" class="col-12">
           <span><b>All Variables:</b></span>
           <p>
-            <span v-for="(variable, i) in model.variables" :key="variable">
-              {{ variable + (i !== model.variables.length - 1 ? ", " : ".") }}
+            <span v-for="(variable, i) in sortedVariables" :key="variable.name">
+              {{
+                variable.name + (i !== model.variables.length - 1 ? ", " : ".")
+              }}
             </span>
           </p>
           <b-button
@@ -64,7 +66,7 @@
 <script lang="ts">
 import _ from "lodash";
 import Vue from "vue";
-import { Model } from "../store/model/index";
+import { Model, VariableDetail } from "../store/model/index";
 import { openModelSolution } from "../util/solutions";
 
 const NUM_TOP_FEATURES = 5;
@@ -83,8 +85,11 @@ export default Vue.extend({
   },
 
   computed: {
+    sortedVariables(): VariableDetail[] {
+      return this.model.variableDetails.slice().sort((a, b) => b.rank - a.rank);
+    },
     topVariables(): string[] {
-      return this.model.variables.slice(0, NUM_TOP_FEATURES);
+      return this.sortedVariables.slice(0, NUM_TOP_FEATURES).map((a) => a.name);
     },
   },
 

--- a/public/store/model/index.ts
+++ b/public/store/model/index.ts
@@ -9,6 +9,7 @@ export interface Model {
   datasetName: string;
   target: string;
   variables: string[];
+  variableDetails: VariableDetail[];
 }
 
 export interface ModelState {
@@ -16,6 +17,12 @@ export interface ModelState {
   models: Dictionary<Model>;
   // fitted solution id of models that are currently being filtered
   filteredModelIds: string[];
+}
+
+export interface VariableDetail {
+  name: string;
+  rank: number;
+  type: string;
 }
 
 export const state: ModelState = {


### PR DESCRIPTION
Updates to api calls to save models and retrieve them with variable name, rank and data type to/from elastic and updates to the front end to consume that information into the store and display that data on the page, sorted such that the top variables are listed in order of significance to the model. We may want to consider later deprecating the old variables array in the model struct which only contained strings, but for now, I've left it be both to get this running and in case it's leveraged elsewhere in the code.