### PR TITLE
Demo fixes

### DIFF
--- a/api/compute/predictions_request.go
+++ b/api/compute/predictions_request.go
@@ -1,7 +1,6 @@
 package compute
 
 import (
-	"encoding/base64"
 	"time"
 
 	"github.com/pkg/errors"
@@ -11,7 +10,7 @@ import (
 // PredictRequest defines a request to generate new predictions from a fitted model and input data.
 type PredictRequest struct {
 	DatasetID        string
-	Dataset          string
+	DatasetPath      string
 	FittedSolutionID string
 	TimestampField   string
 	MaxTime          int
@@ -58,9 +57,9 @@ func NewPredictRequest(data []byte) (*PredictRequest, error) {
 	}
 
 	// the dataset contents as a base 64 encded string
-	req.Dataset, ok = json.String(jsonMap, "dataset")
+	req.DatasetPath, ok = json.String(jsonMap, "datasetPath")
 	if !ok {
-		req.Dataset = ""
+		req.DatasetPath = ""
 	}
 
 	// timeseries prediction fields
@@ -75,26 +74,4 @@ func NewPredictRequest(data []byte) (*PredictRequest, error) {
 	}
 
 	return req, nil
-}
-
-// ExtractDatasetEncodedFromRawRequest extracts the dataset name from the raw message.
-func ExtractDatasetEncodedFromRawRequest(data []byte) (string, error) {
-	jsonMap, err := json.Unmarshal(data)
-	if err != nil {
-		return "", err
-	}
-
-	var ok bool
-
-	encoded, ok := json.String(jsonMap, "dataset")
-	if !ok {
-		return "", errors.New("no `dataset` in predict request")
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(encoded)
-	if err != nil {
-		return "", errors.Wrap(err, "could not decoded `dataset`")
-	}
-
-	return string(decoded), nil
 }

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -344,10 +344,9 @@ func (s *SolutionRequest) createPreprocessingPipeline(featureVariables []*model.
 }
 
 // GeneratePredictions produces predictions using the specified.
-func GeneratePredictions(datasetURI string, explainedSolutionID string,
-	fittedSolutionID string, client *compute.Client) (*PredictionResult, error) {
+func GeneratePredictions(datasetURI string, solutionID string, fittedSolutionID string, client *compute.Client) (*PredictionResult, error) {
 	// check if the solution can be explained
-	desc, err := client.GetSolutionDescription(context.Background(), explainedSolutionID)
+	desc, err := client.GetSolutionDescription(context.Background(), solutionID)
 	if err != nil {
 		return nil, err
 	}

--- a/api/dataset/media.go
+++ b/api/dataset/media.go
@@ -64,14 +64,8 @@ type Media struct {
 }
 
 // NewMediaDataset creates a new media dataset from raw byte data, assuming json.
-func NewMediaDataset(dataset string, mediaType string, targetMediaType string, rawData []byte) (*Media, error) {
-	// store and expand raw data
-	zipPath, err := StoreZipDataset(dataset, rawData)
-	if err != nil {
-		return nil, err
-	}
-
-	expandedInfo, err := ExpandZipDataset(zipPath, dataset)
+func NewMediaDataset(dataset string, mediaType string, targetMediaType string, rawFilePath string) (*Media, error) {
+	expandedInfo, err := ExpandZipDataset(rawFilePath, dataset)
 	if err != nil {
 		return nil, err
 	}

--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -111,14 +111,8 @@ func (b *BoundingBox) pointToString(point *Point, separator string) string {
 }
 
 // NewSatelliteDataset creates a new satelitte dataset from geotiff files
-func NewSatelliteDataset(dataset string, imageType string, rawData []byte) (*Satellite, error) {
-	// store and expand raw data
-	zipPath, err := StoreZipDataset(dataset, rawData)
-	if err != nil {
-		return nil, err
-	}
-
-	expandedInfo, err := ExpandZipDataset(dataset, zipPath)
+func NewSatelliteDataset(dataset string, imageType string, rawFilePath string) (*Satellite, error) {
+	expandedInfo, err := ExpandZipDataset(rawFilePath, dataset)
 	if err != nil {
 		return nil, err
 	}

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -286,6 +286,29 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	}, nil
 }
 
+// IngestAndFeaturize is a temporary hack until I can decide what we should do here.
+func Featurize(originalSchemaFile string, schemaFile string, data api.DataStorage, storage api.MetadataStorage, dataset string, config *IngestTaskConfig) error {
+
+	// featurize dataset for downstream efficiencies
+	if config.FeaturizationEnabled && canFeaturize(dataset, storage) {
+		_, featurizedDatasetPath, err := FeaturizeDataset(originalSchemaFile, schemaFile, dataset, storage, config)
+		if err != nil {
+			return errors.Wrap(err, "unable to featurize dataset")
+		}
+		log.Infof("finished featurizing the dataset")
+		ingestedDataset, err := storage.FetchDataset(dataset, true, true)
+		if err != nil {
+			return errors.Wrap(err, "unable to load metadata")
+		}
+		ingestedDataset.LearningDataset = featurizedDatasetPath
+		err = storage.UpdateDataset(ingestedDataset)
+		if err != nil {
+			return errors.Wrap(err, "unable to store updated metadata")
+		}
+	}
+	return nil
+}
+
 // Ingest the metadata to ES and the data to Postgres.
 func Ingest(originalSchemaFile string, schemaFile string, data api.DataStorage, storage api.MetadataStorage, dataset string, source metadata.DatasetSource,
 	origins []*model.DatasetOrigin, datasetType api.DatasetType, config *IngestTaskConfig, checkMatch bool, verifyMetadata bool, fallbackMerged bool) (string, error) {

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -286,7 +286,7 @@ func IngestDataset(datasetSource metadata.DatasetSource, dataCtor api.DataStorag
 	}, nil
 }
 
-// IngestAndFeaturize is a temporary hack until I can decide what we should do here.
+// Featurize provides a separate step for featurzing data so that it can be called independently of the ingest step.
 func Featurize(originalSchemaFile string, schemaFile string, data api.DataStorage, storage api.MetadataStorage, dataset string, config *IngestTaskConfig) error {
 
 	// featurize dataset for downstream efficiencies

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -314,7 +314,7 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 
 	// submit the new dataset for predictions
 	log.Infof("generating predictions using data found at '%s'", datasetPath)
-	predictionResult, err := comp.GeneratePredictions(datasetPath, solution.ExplainedSolutionID, params.FittedSolutionID, client)
+	predictionResult, err := comp.GeneratePredictions(datasetPath, solution.SolutionID, params.FittedSolutionID, client)
 	if err != nil {
 		return nil, err
 	}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -240,6 +240,11 @@ func Predict(params *PredictParams) (*api.SolutionResult, error) {
 			return nil, errors.Wrap(err, "unable to ingest prediction data")
 		}
 		log.Infof("finished ingesting dataset '%s'", datasetName)
+
+		// we still may need to featurize
+		if err = Featurize(schemaPath, schemaPath, params.DataStorage, params.MetaStorage, datasetName, params.IngestConfig); err != nil {
+			return nil, errors.Wrap(err, "unabled to featurize prediction data")
+		}
 	}
 
 	// Apply the var types associated with the fitted solution to the inference data - the model types and input types should
@@ -430,7 +435,7 @@ func augmentPredictionDataset(csvData [][]string, sourceVariables []*model.Varia
 	outputData := [][]string{headerSource}
 	for _, line := range csvData[1:] {
 		// write the columns in the same order as the source dataset
-		output := make([]string, len(sourceVariableMap))
+		output := make([]string, len(predictionVariables))
 		for i, f := range line {
 			sourceIndex := predictVariablesMap[i]
 			if sourceIndex >= 0 {

--- a/api/util/file.go
+++ b/api/util/file.go
@@ -77,7 +77,7 @@ func WriteFormFileWithDirs(filename string, formFile multipart.File, perm os.Fil
 func Unzip(zipFile string, destination string) error {
 	r, err := zip.OpenReader(zipFile)
 	if err != nil {
-		return errors.Wrap(err, "unable to open archive")
+		return errors.Wrapf(err, "unable to open archive %s", zipFile)
 	}
 	defer func() {
 		if err := r.Close(); err != nil {

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -18,11 +18,6 @@ package util
 import (
 	"bytes"
 	"fmt"
-	lru "github.com/hashicorp/golang-lru"
-	"github.com/nfnt/resize"
-	"github.com/pkg/errors"
-	"github.com/uncharted-distil/gdal"
-	log "github.com/unchartedsoftware/plog"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -32,6 +27,12 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/nfnt/resize"
+	"github.com/pkg/errors"
+	"github.com/uncharted-distil/gdal"
+	log "github.com/unchartedsoftware/plog"
 )
 
 const (
@@ -433,7 +434,7 @@ func createRGBAFromRamp(xSize int, ySize int, bandImages []*image.Gray16, transf
 		grayValue1 := uint16(bandImage1.Pix[i])<<8 | uint16(bandImage1.Pix[i+1])
 
 		// compute NDVI ratio
-		transformedValue := -1.0
+		transformedValue := 0.0
 		if grayValue0 != 0 || grayValue1 != 0 {
 			transformedValue = transform(grayValue0, grayValue1)
 		}

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -385,9 +385,9 @@ func createPredictionDataset(requestTask *api.Task, request *api.PredictRequest,
 	var ds task.DatasetConstructor
 	var err error
 	if api.HasTaskType(requestTask, compute.RemoteSensingTask) {
-		ds, err = dataset.NewSatelliteDatasetFromExpanded(datasetID, "tif", "", datasetPath)
+		ds, err = dataset.NewSatelliteDataset(datasetID, "tif", datasetPath)
 	} else if api.HasTaskType(requestTask, compute.ImageTask) {
-		ds, err = dataset.NewMediaDatasetFromExpanded(datasetID, "png", "jpeg", "", datasetPath)
+		ds, err = dataset.NewMediaDataset(datasetID, "png", "jpeg", datasetPath)
 	} else if api.HasTaskType(requestTask, compute.TimeSeriesTask) && api.HasTaskType(requestTask, compute.ForecastingTask) {
 		ds, err = task.NewPredictionTimeseriesDataset(predictParams, request.IntervalLength, request.IntervalCount)
 	} else {

--- a/public/components/AddDataset.vue
+++ b/public/components/AddDataset.vue
@@ -209,7 +209,7 @@ export default Vue.extend({
 
       try {
         // Upload the file and notify when complete
-        const response = await datasetActions.uploadDataFile(this.$store, {
+        const response = await datasetActions.importDataFile(this.$store, {
           datasetID: this.deconflictedName,
           file: this.file,
         });

--- a/public/components/FileUploader.vue
+++ b/public/components/FileUploader.vue
@@ -103,8 +103,8 @@ export default Vue.extend({
       });
 
       try {
-        // Upload the file and notify when complete
-        const response = await datasetActions.uploadDataFile(this.$store, {
+        // Upload and import the data file and notify when complete
+        const response = await datasetActions.importDataFile(this.$store, {
           datasetID: deconflictedName,
           file: this.file,
         });
@@ -116,3 +116,4 @@ export default Vue.extend({
   },
 });
 </script>
+``

--- a/public/components/ForecastHorizon.vue
+++ b/public/components/ForecastHorizon.vue
@@ -111,7 +111,7 @@ export default Vue.extend({
       }
     },
 
-    intervalScaleTitle(): String {
+    intervalScaleTitle(): string {
       return this.intervalScale[this.intervalScaleSelected].caption;
     },
 
@@ -125,7 +125,7 @@ export default Vue.extend({
     */
 
     /* Test if all the current timeseries variables are DateTime. */
-    isDateTime(): Boolean {
+    isDateTime(): boolean {
       const timeseries = datasetGetters.getTimeseries(this.$store);
       if (!timeseries[this.dataset]) return false;
 

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -320,7 +320,7 @@ export const actions = {
       });
   },
 
-  async importDataFile(
+  async uploadDataFile(
     context: DatasetContext,
     args: {
       datasetID: string;
@@ -351,6 +351,23 @@ export const actions = {
         headers: { "Content-Type": "multipart/form-data" },
       }
     );
+    return uploadResponse;
+  },
+
+  async importDataFile(
+    context: DatasetContext,
+    args: {
+      datasetID: string;
+      file: File;
+    }
+  ): Promise<any> {
+    if (!validateArgs(args, ["datasetID", "file"])) {
+      return null;
+    }
+    const uploadResponse = await actions.uploadDataFile(context, {
+      datasetID: args.datasetID,
+      file: args.file,
+    });
     const response = await actions.importDataset(context, {
       datasetID: args.datasetID,
       source: "augmented",
@@ -365,12 +382,13 @@ export const actions = {
     response.location = uploadResponse.data.location;
     return response;
   },
+
   async updateDataset(
     context: DatasetContext,
     args: { dataset: string; updateData: DatasetUpdate[] }
   ) {
     try {
-      const response = await axios.post(`/distil/update/${args.dataset}`, {
+      await axios.post(`/distil/update/${args.dataset}`, {
         updates: args.updateData,
       });
     } catch (error) {

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -320,7 +320,7 @@ export const actions = {
       });
   },
 
-  async uploadDataFile(
+  async importDataFile(
     context: DatasetContext,
     args: {
       datasetID: string;

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -109,6 +109,7 @@ export const actions = {
   removeGrouping: dispatch(moduleActions.removeGrouping),
   updateGrouping: dispatch(moduleActions.updateGrouping),
   importDataFile: dispatch(moduleActions.importDataFile),
+  uploadDataFile: dispatch(moduleActions.uploadDataFile),
   // variables
   fetchVariables: dispatch(moduleActions.fetchVariables),
   fetchVariableSummary: dispatch(moduleActions.fetchVariableSummary),

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -108,7 +108,7 @@ export const actions = {
   setGrouping: dispatch(moduleActions.setGrouping),
   removeGrouping: dispatch(moduleActions.removeGrouping),
   updateGrouping: dispatch(moduleActions.updateGrouping),
-  uploadDataFile: dispatch(moduleActions.uploadDataFile),
+  importDataFile: dispatch(moduleActions.importDataFile),
   // variables
   fetchVariables: dispatch(moduleActions.fetchVariables),
   fetchVariableSummary: dispatch(moduleActions.fetchVariableSummary),

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -61,7 +61,7 @@ interface SolutionStatusMsg {
 
 interface PredictRequestMsg {
   datasetId: string;
-  dataset?: string; // base64 encoded version of dataset
+  datasetPath?: string; // path to previously uploaded dataset
   fittedSolutionId: string;
   target: string;
   targetType: string;
@@ -570,7 +570,7 @@ export const actions = {
         type: CREATE_PREDICTIONS,
         fittedSolutionId: request.fittedSolutionId,
         datasetId: request.datasetId,
-        dataset: request.dataset,
+        datasetPath: request.datasetPath,
         targetType: request.targetType,
         intervalCount: request.intervalCount ?? null,
         intervalLength: request.intervalLength ?? null,


### PR DESCRIPTION
1. Moves predict data into a separate upload call, instead of pushing a base64 encoded version over the websocket
1. Fixes label counts being incorrect for remote sensing datasets
1. Fixes panics caused by out-of-range colour ramp indices when dealing with blank tiles