### PR TITLE
Parquet split path fixes

### DIFF
--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -79,7 +79,7 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 	featurizedOutputPath := path.Join(env.GetAugmentedPath(), featurizedDatasetID)
 
 	// copy the output to the folder as the data
-	dataOutputPath := path.Join(featurizedOutputPath, path.Join(compute.D3MDataFolder, "learningData.parquet"))
+	dataOutputPath := path.Join(featurizedOutputPath, path.Join(compute.D3MDataFolder, compute.DistilParquetLearningData))
 	featurizedDataWriter := serialization.GetStorage(dataOutputPath)
 	err = featurizedDataWriter.WriteData(dataOutputPath, featurizedData)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201124185205-d674ec65e714
+	github.com/uncharted-distil/distil-compute v0.0.0-20201203053332-047e86b174d9
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201124185205-d674ec65e714 h1:pbOapk2R1W6j28FEId3hzL5SEjhWaMsgM0Fvjz0t6LI=
-github.com/uncharted-distil/distil-compute v0.0.0-20201124185205-d674ec65e714/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
+github.com/uncharted-distil/distil-compute v0.0.0-20201203053332-047e86b174d9 h1:EOq4kxWdQKB1DL5nndlW2bdZHa5IyJKtEBkohyDzPxY=
+github.com/uncharted-distil/distil-compute v0.0.0-20201203053332-047e86b174d9/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=


### PR DESCRIPTION
1. Ensures file names for data and metadata are generated properly in the parquet case
1. Uses constants for parquet dataset doc defs in same fashion as csv
