### PR TITLE
Dataset Splitting Metadata Augmentation

### DIFF
--- a/api/compute/split.go
+++ b/api/compute/split.go
@@ -278,7 +278,7 @@ func (s *stratifiedSplitter) split(data [][]string) ([][]string, [][]string, err
 // suitable to the task performed.
 func SplitDataset(schemaFile string, splitter datasetSplitter) (string, string, error) {
 	// load the metadata to get the data resource
-	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, true)
+	meta, err := loadMetadataForSplit(schemaFile)
 	if err != nil {
 		return "", "", err
 	}
@@ -456,4 +456,16 @@ func deleteIfExists(folderName string) error {
 	}
 
 	return nil
+}
+
+func loadMetadataForSplit(schemaFile string) (*model.Metadata, error) {
+	// load the metadata with no augmentation
+	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaFile, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// use the main data resource to find the proper metadata loader
+	loader := serialization.GetStorage(meta.GetMainDataResource().ResPath)
+	return loader.ReadMetadata(schemaFile)
 }

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -84,7 +84,7 @@ func (s *Storage) parseTimeseries(rows pgx.Rows, timeSet *map[float64]float64, k
 			for i := range time {
 				k := time[i]
 				duplicateMap[k]++
-				if !math.IsNaN(cpyTimeSet[k]){
+				if !math.IsNaN(cpyTimeSet[k]) {
 					cpyTimeSet[k] = duplicateOperation(cpyTimeSet[k], vals[i], duplicateMap[k])
 					continue
 				}
@@ -256,7 +256,7 @@ func maxDuplicates(first float64, second float64, count int64) float64 {
 	return math.Max(first, second)
 }
 func averageDuplicates(sum float64, val float64, count int64) float64 {
-	return (sum * float64((count - 1)) + val) / float64(count)
+	return (sum*float64((count-1)) + val) / float64(count)
 }
 func (f *TimeSeriesField) fetchRepresentationTimeSeries(categoryBuckets []*api.Bucket, mode api.SummaryMode) ([]string, error) {
 

--- a/api/routes/timeseries.go
+++ b/api/routes/timeseries.go
@@ -54,7 +54,7 @@ func TimeseriesHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.DataSto
 			return
 		}
 		operation, ok := params["duplicateOperation"].(string)
-		if !ok{
+		if !ok {
 			operation = "add" //default
 		}
 		timeseriesURIs := []string{}

--- a/api/routes/timeseries_forecast.go
+++ b/api/routes/timeseries_forecast.go
@@ -57,7 +57,7 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 			return
 		}
 		operation, ok := params["duplicateOperation"].(string)
-		if !ok{
+		if !ok {
 			operation = "add" //default
 		}
 		timeseriesUris := []string{}

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -222,7 +222,8 @@ func (d *Parquet) ReadRawVariables(uri string) ([]string, error) {
 
 // ReadMetadata reads the dataset doc from disk.
 func (d *Parquet) ReadMetadata(uri string) (*model.Metadata, error) {
-	meta, err := metadata.LoadMetadataFromOriginalSchema(uri, true)
+	// assume the metadata has all variables already so no need to augment
+	meta, err := metadata.LoadMetadataFromOriginalSchema(uri, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When loading the metadata from disk for dataset splitting, check the backing file type before augmenting the variables since parquet can be assumed to be okay and does not read as a simple csv file.