### PR TITLE
Add immutable data

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -51,52 +51,6 @@ type FilteredDataProvider func(dataset string, index string, filters *api.Filter
 // VariablesProvider defines a function that will get the variables for a dataset.
 type VariablesProvider func(dataset string, index string) ([]*model.Variable, error)
 
-// DataSchema encapsulates the data schema json structure.
-type DataSchema struct {
-	About         *DataSchemaAbout `json:"about"`
-	DataResources []*DataResource  `json:"dataResources"`
-}
-
-// DataSchemaAbout contains the basic properties of a dataset.
-type DataSchemaAbout struct {
-	DatasetID       string `json:"datasetID"`
-	DatasetName     string `json:"datasetName"`
-	Description     string `json:"description"`
-	Citation        string `json:"citation"`
-	License         string `json:"license"`
-	Source          string `json:"source"`
-	SourceURI       string `json:"sourceURI"`
-	ApproximateSize string `json:"approximateSize"`
-	Redacted        bool   `json:"redacted"`
-	SchemaVersion   string `json:"datasetSchemaVersion"`
-	Digest          string `json:"digest"`
-}
-
-// DataResource represents a set of variables.
-type DataResource struct {
-	ResID        string          `json:"resID"`
-	ResPath      string          `json:"resPath"`
-	ResType      string          `json:"resType"`
-	ResFormat    []string        `json:"resFormat"`
-	IsCollection bool            `json:"isCollection"`
-	Variables    []*DataVariable `json:"columns,omitempty"`
-}
-
-// DataVariable captures the data schema representation of a variable.
-type DataVariable struct {
-	ColName  string         `json:"colName"`
-	Role     []string       `json:"role"`
-	ColType  string         `json:"colType"`
-	ColIndex int            `json:"colIndex"`
-	RefersTo *DataReference `json:"refersTo,omitempty"`
-}
-
-// DataReference captures the data schema representation of a resource reference.
-type DataReference struct {
-	ResID     string `json:"resID"`
-	ResObject string `json:"resObject"`
-}
-
 // Hash the filter set
 func getFilteredDatasetHash(dataset string, target string, filterParams *api.FilterParams, isTrain bool) (uint64, error) {
 	hash, err := hashstructure.Hash([]interface{}{dataset, target, *filterParams, isTrain}, nil)

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -63,6 +63,8 @@ type Dataset struct {
 	JoinScore       float64                `json:"joinScore"`
 	Type            DatasetType            `json:"type"`
 	LearningDataset string                 `json:"learningDataset"`
+	Clone           bool                   `json:"clone"`
+	Immutable       bool                   `json:"immutable"`
 }
 
 // QueriedDataset wraps dataset querying components into a single entity.
@@ -178,6 +180,8 @@ func (d *Dataset) ToMetadata() *model.Metadata {
 	meta.SummaryMachine = d.SummaryML
 	meta.Redacted = false
 	meta.Raw = false
+	meta.Clone = d.Clone
+	meta.Immutable = d.Immutable
 	meta.DataResources = []*model.DataResource{dr}
 
 	return meta

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -170,7 +170,7 @@ type SolutionScore struct {
 type SolutionVariable struct {
 	Name string  `json:"name"`
 	Rank float64 `json:"rank"`
-	Type string  `json:"type"`
+	Type string  `json:"varType"`
 }
 
 // PredictionResult represents the output from a model prediction.

--- a/api/model/storage/elastic/model.go
+++ b/api/model/storage/elastic/model.go
@@ -39,7 +39,7 @@ func (s *Storage) parseRawSolutionVariable(rsv map[string]interface{}) (*api.Sol
 		return nil, errors.New("unable to parse rank from variable data")
 	}
 
-	typ, ok := json.String(rsv, "type")
+	typ, ok := json.String(rsv, "varType")
 	if !ok {
 		return nil, errors.New("unable to parse type from variable data")
 	}

--- a/api/model/storage/elastic/storage.go
+++ b/api/model/storage/elastic/storage.go
@@ -383,9 +383,6 @@ func (s *Storage) InitializeModelStorage(overwrite bool) error {
 					"term_vector": "yes"
 				},
 				"variableDetails": {
-					"type": "text",
-					"analyzer": "search_analyzer",
-					"term_vector": "yes"
 					"properties": {
 						"name": {
 							"type": "text",

--- a/api/model/storage/elastic/storage.go
+++ b/api/model/storage/elastic/storage.go
@@ -207,6 +207,12 @@ func (s *Storage) InitializeMetadataStorage(overwrite bool) error {
 				"learningDataset": {
 					"type": "text"
 				},
+				"clone": {
+					"type": "boolean"
+				},
+				"immutable": {
+					"type": "boolean"
+				},
 				"variables": {
 					"properties": {
 						"varDescription": {
@@ -239,6 +245,9 @@ func (s *Storage) InitializeMetadataStorage(overwrite bool) error {
 						},
 						"importance": {
 							"type": "integer"
+						},
+						"immutable": {
+							"type": "boolean"
 						}
 					}
 				}
@@ -372,6 +381,24 @@ func (s *Storage) InitializeModelStorage(overwrite bool) error {
 					"type": "text",
 					"analyzer": "search_analyzer",
 					"term_vector": "yes"
+				},
+				"variableDetails": {
+					"type": "text",
+					"analyzer": "search_analyzer",
+					"term_vector": "yes"
+					"properties": {
+						"name": {
+							"type": "text",
+							"analyzer": "search_analyzer",
+							"term_vector": "yes"
+						},
+						"rank": {
+							"type": "integer"
+						},
+						"varType": {
+							"type": "text"
+						}
+					}
 				}
 			}
 		}

--- a/api/model/storage/elastic/variable.go
+++ b/api/model/storage/elastic/variable.go
@@ -79,6 +79,10 @@ func (s *Storage) parseRawVariable(child map[string]interface{}) (*model.Variabl
 	if !ok {
 		deleted = false
 	}
+	immutable, ok := json.Bool(child, model.VarImmutableField)
+	if !ok {
+		immutable = false
+	}
 	min, ok := json.Float(child, model.VarMinField)
 	if !ok {
 		min = 0
@@ -129,6 +133,7 @@ func (s *Storage) parseRawVariable(child map[string]interface{}) (*model.Variabl
 		Grouping:         grouping,
 		Min:              min,
 		Max:              max,
+		Immutable:        immutable,
 	}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201207172858-168f2db32895
+	github.com/uncharted-distil/distil-compute v0.0.0-20201209182648-9f88fc2cfd85
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201203165011-bb2831ef2897
+	github.com/uncharted-distil/distil-compute v0.0.0-20201207172858-168f2db32895
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201203165011-bb2831ef2897 h1:pldTgrtJGNdwDt9pT1aGYtZhN8wxUsIxcDWMjntdo+4=
-github.com/uncharted-distil/distil-compute v0.0.0-20201203165011-bb2831ef2897/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
+github.com/uncharted-distil/distil-compute v0.0.0-20201207172858-168f2db32895 h1:rd7yOHluf7RD2zDKRnGbWy8XZyfV0lKLAppE5qKe06s=
+github.com/uncharted-distil/distil-compute v0.0.0-20201207172858-168f2db32895/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201207172858-168f2db32895 h1:rd7yOHluf7RD2zDKRnGbWy8XZyfV0lKLAppE5qKe06s=
-github.com/uncharted-distil/distil-compute v0.0.0-20201207172858-168f2db32895/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
+github.com/uncharted-distil/distil-compute v0.0.0-20201209182648-9f88fc2cfd85 h1:DwkgfImMBQxER8PfeCXrtrWtnZz8I19e3sYjUmlxbio=
+github.com/uncharted-distil/distil-compute v0.0.0-20201209182648-9f88fc2cfd85/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/public/store/model/index.ts
+++ b/public/store/model/index.ts
@@ -22,7 +22,7 @@ export interface ModelState {
 export interface VariableDetail {
   name: string;
   rank: number;
-  type: string;
+  varType: string;
 }
 
 export const state: ModelState = {


### PR DESCRIPTION
Fixes #2103 

Added immutable and clone properties to dataset metadata and immutable to variable metadata. These are not used anywhere but do get returned to the client along with the rest of the metadata.

Removed some code that was no longer used in the persisting of datasets. The exported model variable type field was renamed to varType to make it more obvious that it is a separate field in the ES mapping.