### PR TITLE
Geobounds filtering

### DIFF
--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -220,7 +220,7 @@ func (s *SolutionRequest) Listen(listener SolutionStatusListener) error {
 	return <-s.finished
 }
 
-// Inovkes the context cancel function calls associated with this request.  This stops any
+// Cancel inovkes the context cancel function calls associated with this request.  This stops any
 // further messaging between the ta3 and ta2 for each solution.
 func (s *SolutionRequest) Cancel() {
 	// Cancel all further work for each solution

--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -80,14 +80,14 @@ type Point struct {
 }
 
 // ToString writes out the bounding box to a string.
-func (b *BoundingBox) ToString() string {
+func (b *BoundingBox) String() string {
 	coords := []string{
 		b.pointToString(b.LowerLeft, ","),
 		b.pointToString(b.UpperLeft, ","),
 		b.pointToString(b.UpperRight, ","),
 		b.pointToString(b.LowerRight, ","),
 	}
-	return fmt.Sprintf("{%s}", strings.Join(coords, ","))
+	return strings.Join(coords, ",")
 }
 
 // ToGeometryString writes out the bounding box to a geometry string (POSTGIS).
@@ -217,7 +217,7 @@ func (s *Satellite) CreateDataset(rootDataPath string, datasetName string, confi
 					d3mIDs[groupID] = d3mID
 				}
 
-				csvData = append(csvData, []string{fmt.Sprintf("%d", d3mID), path.Base(targetImageFilename), groupID, band, timestamp, coordinates.ToString(), label, coordinates.ToGeometryString()})
+				csvData = append(csvData, []string{fmt.Sprintf("%d", d3mID), path.Base(targetImageFilename), groupID, band, timestamp, coordinates.String(), label, coordinates.ToGeometryString()})
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20201209182648-9f88fc2cfd85
+	github.com/uncharted-distil/distil-compute v0.0.0-20201214164141-79413a6af4be
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20201209182648-9f88fc2cfd85 h1:DwkgfImMBQxER8PfeCXrtrWtnZz8I19e3sYjUmlxbio=
-github.com/uncharted-distil/distil-compute v0.0.0-20201209182648-9f88fc2cfd85/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
+github.com/uncharted-distil/distil-compute v0.0.0-20201214164141-79413a6af4be h1:9O9McoNHmBBlUw3cQgqymydx7LuPo6wm0IN7xy4BQ2I=
+github.com/uncharted-distil/distil-compute v0.0.0-20201214164141-79413a6af4be/go.mod h1:OfWuAtvhrzhBkin63I//WmZ0VS4BFgtdaXmKp6Sbweg=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=


### PR DESCRIPTION
Fixes #2051 (requires uncharted-distil/distil-compute#164 and uncharted-distil/distil-primitives#228).  Geo-coordinates were being wrapped in `{` and `}` when written out by the satellite data import process.  The D3M spec requires a comma separated list of values only.

