### PR TITLE
#2075 lex bar utils

### DIFF
--- a/public/components/facets/FacetDateTime.vue
+++ b/public/components/facets/FacetDateTime.vue
@@ -57,7 +57,7 @@ import {
   facetTypeChangeState,
 } from "../../util/facets";
 import { DATETIME_FILTER } from "../../util/filters";
-import { DATETIME_UNIX_ADJUSTMENT } from "../../util/types";
+import { numToDate, dateToNum } from "../../util/types";
 import _ from "lodash";
 import moment from "moment";
 
@@ -172,12 +172,8 @@ export default Vue.extend({
   },
 
   methods: {
-    numToDate(key: any): string {
-      return moment.unix(_.toNumber(key)).utc().format("YYYY/MM/DD");
-    },
-    dateToNum(dateStr: string): number {
-      return Date.parse(dateStr) / DATETIME_UNIX_ADJUSTMENT;
-    },
+    numToDate,
+    dateToNum,
     getHighlightValue(highlight: Highlight): any {
       if (highlight && highlight.value) {
         return highlight.value;

--- a/public/components/layout/SearchBar.vue
+++ b/public/components/layout/SearchBar.vue
@@ -11,8 +11,9 @@ import _ from "lodash";
 import { h } from "preact";
 import { Lex } from "@uncharted.software/lex";
 import { Variable } from "../../store/dataset/index";
-import "../../../node_modules/@uncharted.software/lex/dist/lex.css";
 import { variablesToLexLanguage } from "../../util/lex";
+import "../../../node_modules/@uncharted.software/lex/dist/lex.css";
+import "../../../node_modules/flatpickr/dist/flatpickr.min.css";
 
 /** SearchBar component to display LexBar utility
  *

--- a/public/components/layout/SearchBar.vue
+++ b/public/components/layout/SearchBar.vue
@@ -9,17 +9,10 @@
 import Vue from "vue";
 import _ from "lodash";
 import { h } from "preact";
-import {
-  LabelState,
-  Lex,
-  NumericEntryState,
-  TextEntryState,
-  TransitionFactory,
-  ValueState,
-  ValueStateValue,
-} from "@uncharted.software/lex";
+import { Lex } from "@uncharted.software/lex";
 import { Variable } from "../../store/dataset/index";
 import "../../../node_modules/@uncharted.software/lex/dist/lex.css";
+import { variablesToLexLanguage } from "../../util/lex";
 
 /** SearchBar component to display LexBar utility
  *
@@ -40,29 +33,8 @@ export default Vue.extend({
   },
 
   computed: {
-    language(): any {
-      return Lex.from("field", ValueState, {
-        name: "Choose a variable to filter",
-        icon: '<i class="fa fa-filter" />',
-        suggestions: this.suggestions,
-      }).branch(
-        Lex.from(LabelState, {
-          label: "From",
-          ...TransitionFactory.valueMetaCompare({ type: "numeric" }),
-        })
-          .to("lower bound", NumericEntryState, { name: "Enter lower bound" })
-          .to(LabelState, { label: "To" })
-          .to("upper bound", NumericEntryState, { name: "Enter upper bound" })
-      );
-    },
-
-    suggestions(): ValueStateValue[] {
-      if (_.isEmpty(this.variables)) return;
-      return this.variables.map((variable) => {
-        const name = _.capitalize(variable.colDisplayName);
-        const options = { type: "numeric" }; // variable.colType
-        return new ValueStateValue(name, options);
-      });
+    language(): Lex {
+      return variablesToLexLanguage(this.variables);
     },
   },
 

--- a/public/components/layout/SearchBar.vue
+++ b/public/components/layout/SearchBar.vue
@@ -11,9 +11,10 @@ import _ from "lodash";
 import { h } from "preact";
 import { Lex } from "@uncharted.software/lex";
 import { Variable } from "../../store/dataset/index";
-import { variablesToLexLanguage } from "../../util/lex";
+import { variablesToLexLanguage, filterParamsToLexQuery } from "../../util/lex";
 import "../../../node_modules/@uncharted.software/lex/dist/lex.css";
 import "../../../node_modules/flatpickr/dist/flatpickr.min.css";
+import { FilterParams } from "../../util/filters";
 
 /** SearchBar component to display LexBar utility
  *
@@ -64,8 +65,7 @@ export default Vue.extend({
       this.lex.on("query changed", (
         ...args /* [newModel, oldModel, newUnboxedModel, oldUnboxedModel, nextTokenStarted] */
       ) => {
-        const filters = []; // TODO - lexModelToFilters(args[0]);
-        this.$emit("lex-filter", filters);
+        this.$emit("lex-query", args);
       });
 
       // Render our search bar into our desired element
@@ -75,7 +75,7 @@ export default Vue.extend({
 
     setQuery(): void {
       if (!this.lex) return;
-      const lexQuery = []; // TODO - filtersToLexQuery(this.filters);
+      const lexQuery = filterParamsToLexQuery(this.filters, this.variables);
       this.lex.setQuery(lexQuery, false);
     },
   },

--- a/public/util/filters.ts
+++ b/public/util/filters.ts
@@ -270,7 +270,11 @@ export function removeFiltersByName(router: VueRouter, key: string) {
   decoded = decoded.filter((filter) => {
     return filter.key !== key;
   });
-  const encoded = encodeFilters(decoded);
+  deepUpdateFiltersInRoute(router, decoded);
+}
+
+export function deepUpdateFiltersInRoute(router: VueRouter, filters: Filter[]) {
+  const encoded = encodeFilters(filters);
   const entry = overlayRouteEntry(routeGetters.getRoute(store), {
     filters: encoded,
   });

--- a/public/util/lex.ts
+++ b/public/util/lex.ts
@@ -1,0 +1,53 @@
+import { Variable } from "../store/dataset";
+import { isNumericType, isTextType, TEXT_TYPE, NUMERIC_TYPE } from "./types";
+import {
+  LabelState,
+  Lex,
+  NumericEntryState,
+  TextEntryState,
+  TransitionFactory,
+  ValueState,
+  ValueStateValue,
+} from "@uncharted.software/lex";
+
+export function variablesToLexLanguage(variables: Variable[]): Lex {
+  const suggestions = variablesToLexSuggestions(variables);
+  return Lex.from("field", ValueState, {
+    name: "Choose a variable to filter",
+    icon: '<i class="fa fa-filter" />',
+    suggestions: suggestions,
+  }).branch(
+    Lex.from("value", TextEntryState, {
+      // User option meta compare to limit this branch to string fields
+      ...TransitionFactory.valueMetaCompare({ type: TEXT_TYPE }),
+    }),
+    Lex.from(LabelState, {
+      label: "From",
+      ...TransitionFactory.valueMetaCompare({ type: NUMERIC_TYPE }),
+    })
+      .to("lower bound", NumericEntryState, { name: "Enter lower bound" })
+      .to(LabelState, { label: "To" })
+      .to("upper bound", NumericEntryState, { name: "Enter upper bound" })
+  );
+}
+
+function variablesToLexSuggestions(variables: Variable[]): ValueStateValue[] {
+  if (!variables) return;
+  return variables.map((variable) => {
+    const name = variable.colDisplayName;
+    const options = {
+      type: colTypeToOptionType(variable.colType.toLowerCase()),
+    };
+    return new ValueStateValue(name, options);
+  });
+}
+
+function colTypeToOptionType(colType: string): string {
+  if (isNumericType(colType)) {
+    return NUMERIC_TYPE;
+  } else if (isTextType(colType)) {
+    return TEXT_TYPE;
+  } else {
+    return TEXT_TYPE;
+  }
+}

--- a/public/util/lex.ts
+++ b/public/util/lex.ts
@@ -2,10 +2,19 @@ import { Variable } from "../store/dataset";
 import {
   isNumericType,
   isTextType,
-  TEXT_TYPE,
-  NUMERIC_TYPE,
+  dateToNum,
   DATE_TIME_LOWER_TYPE,
+  CATEGORICAL_TYPE,
 } from "./types";
+import {
+  decodeFilters,
+  Filter,
+  INCLUDE_FILTER,
+  CATEGORICAL_FILTER,
+  DATETIME_FILTER,
+  NUMERICAL_FILTER,
+  TEXT_FILTER,
+} from "./filters";
 import {
   LabelState,
   Lex,
@@ -25,32 +34,105 @@ export function variablesToLexLanguage(variables: Variable[]): Lex {
     suggestions: suggestions,
   }).branch(
     Lex.from("value", TextEntryState, {
-      // User option meta compare to limit this branch to string fields
-      ...TransitionFactory.valueMetaCompare({ type: TEXT_TYPE }),
+      ...TransitionFactory.valueMetaCompare({ type: TEXT_FILTER }),
+    }),
+    Lex.from("value", TextEntryState, {
+      ...TransitionFactory.valueMetaCompare({ type: CATEGORICAL_FILTER }),
     }),
     Lex.from(LabelState, {
       label: "From",
-      ...TransitionFactory.valueMetaCompare({ type: NUMERIC_TYPE }),
+      ...TransitionFactory.valueMetaCompare({ type: NUMERICAL_FILTER }),
     })
-      .to("lower bound", NumericEntryState, { name: "Enter lower bound" })
+      .to("min", NumericEntryState, { name: "Enter lower bound" })
       .to(LabelState, { label: "To" })
-      .to("upper bound", NumericEntryState, { name: "Enter upper bound" }),
+      .to("max", NumericEntryState, { name: "Enter upper bound" }),
     Lex.from(LabelState, {
       label: "From",
-      ...TransitionFactory.valueMetaCompare({ type: DATE_TIME_LOWER_TYPE }),
+      ...TransitionFactory.valueMetaCompare({ type: DATETIME_FILTER }),
     })
-      .to("Start Date", DateTimeEntryState, {
+      .to("min", DateTimeEntryState, {
         enableTime: true,
         enableCalendar: true,
         timezone: "Greenwich",
       })
       .to(LabelState, { label: "To" })
-      .to("End Date", DateTimeEntryState, {
+      .to("max", DateTimeEntryState, {
         enableTime: true,
         enableCalendar: true,
         timezone: "Greenwich",
       })
   );
+}
+
+export function filterParamsToLexQuery(
+  filter: string,
+  allVariables: Variable[]
+) {
+  const filters = decodeFilters(filter);
+  const variableDict = allVariables.reduce((a, v) => {
+    a[v.colName] = v;
+    return a;
+  }, {});
+  const filterVariables = filters.map((f) => {
+    return variableDict[f.key];
+  });
+  const suggestions = variablesToLexSuggestions(filterVariables);
+
+  const lexQuery = filters.map((f, i) => {
+    if (isNumericType(f.type)) {
+      return {
+        field: suggestions[i],
+        min: new ValueStateValue(f.min),
+        max: new ValueStateValue(f.max),
+      };
+    } else if (f.type === DATETIME_FILTER) {
+      return {
+        field: suggestions[i],
+        min: new Date(f.min * 1000),
+        max: new Date(f.max * 1000),
+      };
+    } else {
+      return {
+        field: suggestions[i],
+        value: new ValueStateValue(f.categories[0]),
+      };
+    }
+  });
+  return lexQuery;
+}
+
+export function lexQueryToFilters(
+  lexQuery: any[][],
+  allVariables: Variable[]
+): Filter[] {
+  const variableDict = allVariables.reduce((a, v) => {
+    a[v.colName] = v;
+    return a;
+  }, {});
+
+  const filters = lexQuery[0].map((lq) => {
+    const key = lq.field.key;
+    const type = lq.field.meta.type;
+    const filter: Filter = {
+      mode: INCLUDE_FILTER,
+      displayName: key,
+      type,
+      key,
+    };
+
+    if (isNumericType(type)) {
+      filter.min = parseFloat(lq.min.key);
+      filter.max = parseFloat(lq.max.key);
+    } else if (type === DATETIME_FILTER) {
+      filter.min = dateToNum(lq.min);
+      filter.max = dateToNum(lq.max);
+    } else {
+      filter.categories = [lq.value.key];
+    }
+
+    return filter;
+  });
+  return filters;
 }
 
 function variablesToLexSuggestions(variables: Variable[]): ValueStateValue[] {
@@ -66,12 +148,14 @@ function variablesToLexSuggestions(variables: Variable[]): ValueStateValue[] {
 
 function colTypeToOptionType(colType: string): string {
   if (isNumericType(colType)) {
-    return NUMERIC_TYPE;
-  } else if (isTextType(colType)) {
-    return TEXT_TYPE;
+    return NUMERICAL_FILTER;
   } else if (colType.toLowerCase() === DATE_TIME_LOWER_TYPE) {
-    return DATE_TIME_LOWER_TYPE;
+    return DATETIME_FILTER;
+  } else if (colType === CATEGORICAL_TYPE) {
+    return CATEGORICAL_FILTER;
+  } else if (isTextType(colType)) {
+    return TEXT_FILTER;
   } else {
-    return TEXT_TYPE;
+    return TEXT_FILTER;
   }
 }

--- a/public/util/lex.ts
+++ b/public/util/lex.ts
@@ -1,10 +1,17 @@
 import { Variable } from "../store/dataset";
-import { isNumericType, isTextType, TEXT_TYPE, NUMERIC_TYPE } from "./types";
+import {
+  isNumericType,
+  isTextType,
+  TEXT_TYPE,
+  NUMERIC_TYPE,
+  DATE_TIME_LOWER_TYPE,
+} from "./types";
 import {
   LabelState,
   Lex,
   NumericEntryState,
   TextEntryState,
+  DateTimeEntryState,
   TransitionFactory,
   ValueState,
   ValueStateValue,
@@ -27,7 +34,22 @@ export function variablesToLexLanguage(variables: Variable[]): Lex {
     })
       .to("lower bound", NumericEntryState, { name: "Enter lower bound" })
       .to(LabelState, { label: "To" })
-      .to("upper bound", NumericEntryState, { name: "Enter upper bound" })
+      .to("upper bound", NumericEntryState, { name: "Enter upper bound" }),
+    Lex.from(LabelState, {
+      label: "From",
+      ...TransitionFactory.valueMetaCompare({ type: DATE_TIME_LOWER_TYPE }),
+    })
+      .to("Start Date", DateTimeEntryState, {
+        enableTime: true,
+        enableCalendar: true,
+        timezone: "Greenwich",
+      })
+      .to(LabelState, { label: "To" })
+      .to("End Date", DateTimeEntryState, {
+        enableTime: true,
+        enableCalendar: true,
+        timezone: "Greenwich",
+      })
   );
 }
 
@@ -47,6 +69,8 @@ function colTypeToOptionType(colType: string): string {
     return NUMERIC_TYPE;
   } else if (isTextType(colType)) {
     return TEXT_TYPE;
+  } else if (colType.toLowerCase() === DATE_TIME_LOWER_TYPE) {
+    return DATE_TIME_LOWER_TYPE;
   } else {
     return TEXT_TYPE;
   }

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import moment from "moment";
 import { D3M_INDEX_FIELD } from "../store/dataset/index";
 import { getters as datasetGetters } from "../store/dataset/module";
 import store from "../store/store";
@@ -51,8 +52,8 @@ export const TIMESERIES_TYPE = "timeseries";
 export const UNKNOWN_TYPE = "unknown";
 export const GEOCOORDINATE_TYPE = "geocoordinate";
 export const GEOBOUNDS_TYPE = "geobounds";
+export const NUMERIC_TYPE = "numerical";
 export const LABELING_TYPE = "labeling"; // strictly used for labeling view
-export const NUMERIC_TYPE = "numerical"; // strictly used for lex bar languages
 
 // Group types per meta-types to categorize them on the Data Explorer view.
 export const META_TYPES = {
@@ -123,6 +124,7 @@ const FLOATING_POINT_TYPES = [
   LATITUDE_TYPE,
   LONGITUDE_TYPE,
   GEOBOUNDS_TYPE,
+  NUMERIC_TYPE,
 ];
 
 const LIST_TYPES = [REAL_LIST_TYPE, REAL_VECTOR_TYPE, GEOBOUNDS_TYPE];
@@ -454,4 +456,12 @@ export function getTypeFromLabel(label: string) {
   }
   console.warn(`No type exists for label \`${label}\``);
   return label;
+}
+
+export function numToDate(key: any): string {
+  return moment.unix(_.toNumber(key)).utc().format("YYYY/MM/DD");
+}
+
+export function dateToNum(dateStr: string): number {
+  return Date.parse(dateStr) / DATETIME_UNIX_ADJUSTMENT;
 }

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -52,6 +52,7 @@ export const UNKNOWN_TYPE = "unknown";
 export const GEOCOORDINATE_TYPE = "geocoordinate";
 export const GEOBOUNDS_TYPE = "geobounds";
 export const LABELING_TYPE = "labeling"; // strictly used for labeling view
+export const NUMERIC_TYPE = "numerical"; // strictly used for lex bar languages
 
 // Group types per meta-types to categorize them on the Data Explorer view.
 export const META_TYPES = {

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -19,7 +19,12 @@
 
     <main class="content">
       <search-input class="mb-3" />
-      <search-bar class="mb-3" :variables="selectedVariables" />
+      <search-bar
+        class="mb-3"
+        :variables="selectedVariables"
+        :filters="filters"
+        @lex-query="updateFilterFromLexQuery"
+      />
 
       <!-- Tabs to switch views -->
       <b-tabs pills v-model="activeView" class="mb-3">
@@ -88,6 +93,8 @@ import { getters as routeGetters } from "../store/route/module";
 import { actions as viewActions } from "../store/view/module";
 
 // Util
+import { deepUpdateFiltersInRoute } from "../util/filters";
+import { lexQueryToFilters } from "../util/lex";
 import { overlayRouteEntry } from "../util/routes";
 import { getNumIncludedRows } from "../util/row";
 import { spinnerHTML } from "../util/spinner";
@@ -314,6 +321,11 @@ export default Vue.extend({
 
   methods: {
     capitalize,
+
+    updateFilterFromLexQuery(lexQuery) {
+      const updatedFilter = lexQueryToFilters(lexQuery, this.variables);
+      deepUpdateFiltersInRoute(this.$router, updatedFilter);
+    },
 
     /* When the user request to fetch a different size of data. */
     onDataSizeSubmit(dataSize: number) {

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -21,7 +21,7 @@
       <search-input class="mb-3" />
       <search-bar
         class="mb-3"
-        :variables="selectedVariables"
+        :variables="variables"
         :filters="filters"
         @lex-query="updateFilterFromLexQuery"
       />


### PR DESCRIPTION
- added lex.ts with variables to lex language, lex query to filters and filters to lex query utility functions
- factored lex bar language stuff from the searchBar wrapper component for the lex bar to lex.ts so that searchBar wrapper can focus more on display concerns, added needed style imports for date filters, wired up to actually populate filters in the lex bar.
- added bulk filter update to filter.ts utility as lex queries (unlike filter badges) provide use the entire current filter, so it are easier to just fully replace than update per variable. 
- added an event fired function to the data explorer that binds to lex-query event, passes the query to the utility translator, then updates the filter in the route with the new bulk filter utility. 
- factored out dateToNum and numToDate utilities from facetDateTime view to types.ts for reuse as utility functions in 