### PR TITLE
Added Band and GeoCoordinates to Image Drilldown

### DIFF
--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -47,7 +47,6 @@ export default Vue.extend({
   },
 
   props: {
-    dataFields: Object as () => Dictionary<TableColumn>,
     includedActive: Boolean as () => boolean,
     item: Object as () => TableRow,
     shortenLabels: {
@@ -62,9 +61,7 @@ export default Vue.extend({
 
   computed: {
     fields(): Dictionary<TableColumn> {
-      return this.dataFields
-        ? this.dataFields
-        : this.includedActive
+      return this.includedActive
         ? datasetGetters.getIncludedTableDataFields(this.$store)
         : datasetGetters.getExcludedTableDataFields(this.$store);
     },

--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -137,7 +137,7 @@ export default Vue.extend({
 
     // Creates a dictionary of label lengths keyed by a label's first character.  This supports
     // the generation of a minimum ambiguous label by starting letter.  For the set [Airport, Agriculture, Forest],
-    // we will end up with [A=4, F=1], which at runtime will generate display lables of [Ai, Ag, F].  This is a computed
+    // we will end up with [A=4, F=1], which at runtime will generate display labels of [Ai, Ag, F].  This is a computed
     // property so it should only end up being updated when the underlying data changes.
     labelLengths(): Dictionary<number> {
       let summary: VariableSummary = null;
@@ -150,13 +150,13 @@ export default Vue.extend({
           this.targetField
         ][minKey];
       }
-      const bucketNames = summary.baseline.buckets.map((b) => b.key);
+      const bucketNames = summary?.baseline?.buckets.map((b) => b.key);
       // If this isn't categorical, don't generate the table.
       if (!bucketNames) {
         return {};
       }
 
-      // initailize label lengths with zeroes
+      // initialize label lengths with zeroes
       const imageLabelLengths: Dictionary<number> = {};
       bucketNames.forEach((b) => (imageLabelLengths[b[0]] = 0));
 

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -2,8 +2,8 @@
   <div class="mosaic-container">
     <div class="image-mosaic">
       <template v-for="imageField in imageFields">
-        <template v-for="item in paginatedItems">
-          <div class="image-tile">
+        <template v-for="(item, idx) in paginatedItems">
+          <div class="image-tile" :key="idx">
             <template v-for="(fieldInfo, fieldKey) in fields">
               <image-preview
                 v-if="fieldKey === imageField.key"
@@ -17,7 +17,7 @@
                 :key="fieldKey"
                 uniqueTrail="mosaic"
                 :debounce="true"
-              ></image-preview>
+              />
             </template>
             <image-label
               class="image-label"
@@ -40,7 +40,7 @@
       v-model="currentPage"
       :per-page="perPage"
       :total-rows="itemCount"
-    ></b-pagination>
+    />
   </div>
 </template>
 

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -28,9 +28,12 @@
         <i class="fa fa-search-plus zoom-icon" @click.stop="showZoomedImage" />
       </template>
     </div>
+
     <image-drilldown
-      :imageUrl="imageUrl"
-      :title="imageUrl"
+      :url="imageUrl"
+      :type="type"
+      :info="imageDrilldown"
+      :item="row"
       :visible="!!zoomImage"
       @hide="hideZoomImage"
     />
@@ -38,10 +41,9 @@
 </template>
 
 <script lang="ts">
-import $ from "jquery";
 import _ from "lodash";
 import Vue from "vue";
-import ImageDrilldown from "./ImageDrilldown.vue";
+import ImageDrilldown, { DrillDownInfo } from "./ImageDrilldown.vue";
 import {
   getters as datasetGetters,
   actions as datasetActions,
@@ -153,17 +155,17 @@ export default Vue.extend({
 
   data() {
     return {
-      zoomImage: false,
+      debouncedRequestImage: null,
       entry: null,
-      zoomedWidth: 400,
-      zoomedHeight: 400,
-      isVisible: false,
+      getImage: null,
       hasRendered: false,
       hasRequested: false,
-      stopSpinner: false,
-      debouncedRequestImage: null,
-      getImage: null,
       imageAttentionHasRendered: false,
+      isVisible: false,
+      stopSpinner: false,
+      zoomedHeight: 400,
+      zoomImage: false,
+      zoomedWidth: 400,
     };
   },
 
@@ -171,9 +173,18 @@ export default Vue.extend({
     colorScale(): ColorScaleNames {
       return routeGetters.getColorScale(this.$store);
     },
+
     imageId(): string {
       return this.imageUrl?.split(/_B[0-9][0-9a-zA-Z][.]/)[0];
     },
+
+    imageDrilldown(): DrillDownInfo {
+      return {
+        band: this.band,
+        title: this.imageUrl,
+      };
+    },
+
     files(): Dictionary<any> {
       return datasetGetters.getFiles(this.$store);
     },
@@ -233,9 +244,11 @@ export default Vue.extend({
       }
       return false;
     },
+
     band(): string {
       return routeGetters.getBandCombinationId(this.$store);
     },
+
     hasImageAttention(): boolean {
       return routeGetters.getImageAttention(this.$store);
     },

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -55,18 +55,14 @@ import {
   D3M_INDEX_FIELD,
   TableRow,
   RowSelection,
-  BandID,
-  BandCombination,
-  TaskTypes,
 } from "../store/dataset/index";
 import { isRowSelected } from "../util/row";
 import { Dictionary } from "../util/dict";
 import { MULTIBAND_IMAGE_TYPE, IMAGE_TYPE } from "../util/types";
-import { createRouteEntry } from "../util/routes";
 import { ColorScaleNames } from "../util/data";
 
 export default Vue.extend({
-  name: "image-preview",
+  name: "ImagePreview",
 
   components: {
     ImageDrilldown,

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="results-data-slot">
-    <p class="results-data-slot-summary" v-if="hasResults">
+    <p v-if="hasResults" class="results-data-slot-summary">
       Displaying
       <data-size
-        :currentSize="numItems"
+        :current-size="numItems"
         :total="numRows"
         @submit="onDataSizeSubmit"
       />
@@ -15,8 +15,8 @@
     </p>
 
     <div class="results-data-slot-container" :class="{ pending: !hasData }">
-      <div class="results-data-no-results" v-if="isPending || hasNoResults">
-        <div v-if="isPending" v-html="spinnerHTML"></div>
+      <div v-if="isPending || hasNoResults" class="results-data-no-results">
+        <div v-if="isPending" v-html="spinnerHTML" />
         <p v-if="hasNoResults">No results available</p>
       </div>
 
@@ -77,7 +77,7 @@ const TIMESERIES_VIEW = "timeseries";
  * @param {Boolean} excluded - display only excluded results
  */
 export default Vue.extend({
-  name: "results-data-slot",
+  name: "ResultsDataSlot",
 
   components: {
     DataSize,
@@ -123,11 +123,13 @@ export default Vue.extend({
     solutionId(): string {
       return this.solution?.solutionId;
     },
+
     confidenceSummaries(): VariableSummary {
       return resultsGetters.getConfidenceSummaries(this.$store).filter((cf) => {
         return cf.solutionId === this.solutionId;
       })[0];
     },
+
     solutionHasErrored(): boolean {
       return this.solution
         ? this.solution.progress === SolutionStatus.SOLUTION_ERRORED

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -11,10 +11,10 @@
       :sort-compare="sortFunction"
       :per-page="perPage"
       :total-rows="itemCount"
-      @row-clicked="onRowClick"
-      @sort-changed="onSortChanged"
       sticky-header="100%"
       class="distil-table mb-1"
+      @row-clicked="onRowClick"
+      @sort-changed="onSortChanged"
     >
       <template
         v-for="computedField in computedFields"
@@ -29,9 +29,9 @@
       </template>
 
       <template v-slot:[headSlot(predictedCol)]="data">
-        <span
-          >{{ data.label }}<sup>{{ solutionIndex }}</sup></span
-        >
+        <span>
+          {{ data.label }}<sup>{{ solutionIndex }}</sup>
+        </span>
       </template>
 
       <template
@@ -39,13 +39,13 @@
         v-slot:[cellSlot(imageField.key)]="data"
       >
         <image-preview
-          :row="data.item"
           :key="imageField.key"
+          :row="data.item"
           :type="imageField.type"
           :image-url="data.item[imageField.key].value"
           :debounce="true"
-          :uniqueTrail="uniqueTrail"
-        ></image-preview>
+          :unique-trail="uniqueTrail"
+        />
       </template>
 
       <template
@@ -61,7 +61,7 @@
           :timeseries-id="data.item[timeseriesGrouping.idCol].value"
           :solution-id="solutionId"
           :include-forecast="isTargetTimeseries"
-          :uniqueTrail="uniqueTrail"
+          :unique-trail="uniqueTrail"
         />
       </template>
 
@@ -78,19 +78,19 @@
         <!-- residual error -->
         <div>
           <div
-            class="error-bar-container"
             v-if="isTargetNumerical"
+            class="error-bar-container"
             :title="data.value.value"
           >
             <div
               class="error-bar"
-              v-bind:style="{
+              :style="{
                 'background-color': errorBarColor(data.value.value),
                 width: errorBarWidth(data.value.value),
                 left: errorBarLeft(data.value.value),
               }"
-            ></div>
-            <div class="error-bar-center"></div>
+            />
+            <div class="error-bar-center" />
           </div>
 
           <!-- correctness error -->
@@ -120,15 +120,15 @@
     </b-table>
     <b-pagination
       v-if="items && items.length > perPage"
+      v-model="currentPage"
       align="center"
       first-number
       last-number
       size="sm"
-      v-model="currentPage"
       :per-page="perPage"
       :total-rows="itemCount"
       @change="onPagination"
-    ></b-pagination>
+    />
   </div>
 </template>
 
@@ -181,13 +181,20 @@ import {
 import { getSolutionIndex } from "../util/solutions";
 
 export default Vue.extend({
-  name: "results-data-table",
+  name: "ResultsDataTable",
 
   components: {
     ImagePreview,
     SparklinePreview,
     IconBase,
     IconFork,
+  },
+
+  filters: {
+    /* Display number with only two decimal. */
+    cleanNumber(value) {
+      return _.isNumber(value) ? value.toFixed(2) : "—";
+    },
   },
 
   data() {
@@ -204,13 +211,6 @@ export default Vue.extend({
     dataItems: Array as () => any[],
     dataFields: Object as () => Dictionary<TableColumn>,
     instanceName: String as () => string,
-  },
-
-  filters: {
-    /* Display number with only two decimal. */
-    cleanNumber(value) {
-      return _.isNumber(value) ? value.toFixed(2) : "—";
-    },
   },
 
   computed: {
@@ -512,6 +512,7 @@ export default Vue.extend({
       });
     },
   },
+
   watch: {
     highlight() {
       this.initialized = false;

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -1,23 +1,25 @@
 <template>
   <div class="select-data-slot">
     <view-type-toggle
-      has-tabs
       v-model="viewTypeModel"
+      has-tabs
       :variables="variables"
       :available-variables="trainingVariables"
     >
       <b-nav-item
         class="font-weight-bold"
-        @click="setIncludedActive"
         :active="includedActive"
-        >Samples to Model From</b-nav-item
+        @click="setIncludedActive"
       >
+        Samples to Model From
+      </b-nav-item>
       <b-nav-item
         class="font-weight-bold mr-auto"
-        @click="setExcludedActive"
         :active="!includedActive"
-        >Excluded Samples</b-nav-item
+        @click="setExcludedActive"
       >
+        Excluded Samples
+      </b-nav-item>
     </view-type-toggle>
 
     <div class="fake-search-input">
@@ -32,7 +34,7 @@
     <div class="table-title-container">
       <p class="selection-data-slot-summary">
         <data-size
-          :currentSize="numItems"
+          :current-size="numItems"
           :total="numRows"
           @submit="onDataSizeSubmit"
         />
@@ -45,8 +47,8 @@
 
       <layer-selection v-if="isMultiBandImage" class="layer-select-dropdown" />
       <b-button
-        class="select-data-action-exclude"
         v-if="includedActive"
+        class="select-data-action-exclude"
         variant="outline-secondary"
         :disabled="isExcludeDisabled"
         @click="onExcludeClick"
@@ -57,7 +59,7 @@
             'exclude-highlight': isFilteringHighlights,
             'exclude-selection': isFilteringSelection,
           }"
-        ></i>
+        />
         Exclude
       </b-button>
       <b-button
@@ -69,14 +71,14 @@
         <i
           class="fa fa-plus-circle pr-1"
           :class="{ 'include-selection': isFilteringSelection }"
-        ></i>
+        />
         Reinclude
       </b-button>
     </div>
 
     <div class="select-data-container" :class="{ pending: !hasData }">
-      <div class="select-data-no-results" v-if="!hasData">
-        <div v-html="spinnerHTML"></div>
+      <div v-if="!hasData" class="select-data-no-results">
+        <div v-html="spinnerHTML" />
       </div>
       <component
         :is="viewComponent"
@@ -106,7 +108,6 @@ import {
 } from "../store/dataset/module";
 import {
   TableRow,
-  D3M_INDEX_FIELD,
   Variable,
   Highlight,
   RowSelection,
@@ -114,17 +115,13 @@ import {
 import { getters as routeGetters } from "../store/route/module";
 import {
   Filter,
-  FilterParams,
   addFilterToRoute,
   EXCLUDE_FILTER,
   INCLUDE_FILTER,
 } from "../util/filters";
 import { clearHighlight, createFilterFromHighlight } from "../util/highlights";
 import {
-  addRowSelection,
-  removeRowSelection,
   clearRowSelection,
-  isRowSelected,
   getNumIncludedRows,
   getNumExcludedRows,
   createFilterFromRowSelection,
@@ -140,7 +137,7 @@ const TABLE_VIEW = "table";
 const TIMESERIES_VIEW = "timeseries";
 
 export default Vue.extend({
-  name: "select-data-slot",
+  name: "SelectDataSlot",
 
   components: {
     DataSize,
@@ -239,7 +236,7 @@ export default Vue.extend({
     },
 
     /* Check if the Active Filter is from an available feature. */
-    isActiveFilterFromAnAvailableFeature(): Boolean {
+    isActiveFilterFromAnAvailableFeature(): boolean {
       if (!this.activeFilter) {
         return false;
       }
@@ -253,7 +250,7 @@ export default Vue.extend({
     },
 
     /* Disable the Exclude filter button. */
-    isExcludeDisabled(): Boolean {
+    isExcludeDisabled(): boolean {
       return (
         (!this.isFilteringHighlights && !this.isFilteringSelection) ||
         this.isActiveFilterFromAnAvailableFeature
@@ -291,12 +288,13 @@ export default Vue.extend({
     },
 
     /* Select which component to display the data. */
-    viewComponent() {
+    viewComponent(): string {
       if (this.viewTypeModel === GEO_VIEW) return "SelectGeoPlot";
       if (this.viewTypeModel === GRAPH_VIEW) return "SelectGraphView";
       if (this.viewTypeModel === IMAGE_VIEW) return "ImageMosaic";
-      if (this.viewTypeModel === TABLE_VIEW) return "SelectDataTable";
       if (this.viewTypeModel === TIMESERIES_VIEW) return "SelectTimeseriesView";
+      // Default is TABLE_VIEW
+      return "SelectDataTable";
     },
   },
 

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -26,13 +26,14 @@
       </template>
 
       <template
-        v-for="imageField in imageFields"
+        v-for="(imageField, idx) in imageFields"
         v-slot:[cellSlot(imageField.key)]="data"
       >
-        <div class="position-relative">
+        <div class="position-relative" :key="idx">
           <image-preview
             :key="imageField.key"
             :type="imageField.type"
+            :row="data.item"
             :image-url="data.item[imageField.key].value"
             :debounce="true"
             :uniqueTrail="uniqueTrail"

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -9,9 +9,9 @@
       :fields="tableFields"
       :per-page="perPage"
       :total-rows="itemCount"
-      @row-clicked="onRowClick"
       sticky-header="100%"
       class="distil-table mb-1"
+      @row-clicked="onRowClick"
     >
       <template
         v-for="computedField in computedFields"
@@ -29,21 +29,20 @@
         v-for="(imageField, idx) in imageFields"
         v-slot:[cellSlot(imageField.key)]="data"
       >
-        <div class="position-relative" :key="idx">
+        <div :key="idx" class="position-relative">
           <image-preview
             :key="imageField.key"
             :type="imageField.type"
             :row="data.item"
             :image-url="data.item[imageField.key].value"
             :debounce="true"
-            :uniqueTrail="uniqueTrail"
+            :unique-trail="uniqueTrail"
           />
           <image-label
             class="image-label"
-            :dataFields="fields"
-            includedActive
-            shortenLabels
-            alignHorizontal
+            included-active
+            shorten-labels
+            align-horizontal
             :item="data.item"
           />
         </div>
@@ -53,7 +52,7 @@
         v-for="timeseriesGrouping in timeseriesGroupings"
         v-slot:[cellSlot(timeseriesGrouping.idCol)]="data"
       >
-        <div class="container" :key="data.item[timeseriesGrouping.idCol].value">
+        <div :key="data.item[timeseriesGrouping.idCol].value" class="container">
           <div class="row">
             <sparkline-preview
               :truth-dataset="dataset"
@@ -61,7 +60,7 @@
               :y-col="timeseriesGrouping.yCol"
               :timeseries-col="timeseriesGrouping.idCol"
               :timeseries-id="data.item[timeseriesGrouping.idCol].value"
-              :uniqueTrail="uniqueTrail"
+              :unique-trail="uniqueTrail"
             />
           </div>
         </div>
@@ -85,11 +84,11 @@
     </b-table>
     <b-pagination
       v-if="items && items.length > perPage"
+      v-model="currentPage"
       align="center"
       first-number
       last-number
       size="sm"
-      v-model="currentPage"
       :per-page="perPage"
       :total-rows="itemCount"
       @input="onPagination"
@@ -142,7 +141,7 @@ import { Feature, Activity, SubActivity } from "../util/userEvents";
 import ImageLabel from "./ImageLabel.vue";
 
 export default Vue.extend({
-  name: "selected-data-table",
+  name: "SelectedDataTable",
 
   components: {
     ImagePreview,
@@ -150,6 +149,13 @@ export default Vue.extend({
     IconBase,
     IconFork,
     ImageLabel,
+  },
+
+  filters: {
+    /* Display number with only two decimal. */
+    cleanNumber(value) {
+      return _.isNumber(value) ? value.toFixed(2) : "—";
+    },
   },
 
   props: {
@@ -165,12 +171,6 @@ export default Vue.extend({
       uniqueTrail: "selected-table",
       initialized: false,
     };
-  },
-  filters: {
-    /* Display number with only two decimal. */
-    cleanNumber(value) {
-      return _.isNumber(value) ? value.toFixed(2) : "—";
-    },
   },
 
   computed: {
@@ -280,6 +280,33 @@ export default Vue.extend({
     },
   },
 
+  watch: {
+    includedActive() {
+      if (this.items.length) {
+        this.fetchTimeSeries();
+      }
+    },
+    filters() {
+      // new data will be coming through pipeline
+      this.initialized = false;
+    },
+    items(cur, prev) {
+      // checks to see if items exist and if the timeseries has been queried for the new data
+      if (!this.initialized && this.items.length) {
+        this.fetchTimeSeries();
+        this.initialized = true;
+      }
+      if (prev?.length !== this.items.length) {
+        this.fetchTimeSeries();
+      }
+      // if the itemCount changes such that it's less than page
+      // we were on, reset to page 1.
+      if (this.itemCount < this.perPage * this.currentPage) {
+        this.currentPage = 1;
+      }
+    },
+  },
+
   methods: {
     fetchTimeSeries() {
       if (!this.isTimeseries) {
@@ -356,32 +383,6 @@ export default Vue.extend({
         Status: number;
       }[];
       return listData.map((l) => l.Float);
-    },
-  },
-  watch: {
-    includedActive() {
-      if (this.items.length) {
-        this.fetchTimeSeries();
-      }
-    },
-    filters() {
-      // new data will be coming through pipeline
-      this.initialized = false;
-    },
-    items(cur, prev) {
-      // checks to see if items exist and if the timeseries has been queried for the new data
-      if (!this.initialized && this.items.length) {
-        this.fetchTimeSeries();
-        this.initialized = true;
-      }
-      if (prev?.length !== this.items.length) {
-        this.fetchTimeSeries();
-      }
-      // if the itemCount changes such that it's less than page
-      // we were on, reset to page 1.
-      if (this.itemCount < this.perPage * this.currentPage) {
-        this.currentPage = 1;
-      }
     },
   },
 });

--- a/public/components/facets/FacetImage.vue
+++ b/public/components/facets/FacetImage.vue
@@ -17,8 +17,7 @@
         :dataset="summary.dataset"
         :field="summary.key"
         :expandCollapse="expandCollapse"
-      >
-      </type-change-menu>
+      />
     </div>
     <facet-template target="facet-terms-value" class="facet-content-container">
       <div slot="header" class="facet-image-preview-display">${metadata}</div>
@@ -55,8 +54,8 @@ import Vue from "vue";
 import "@uncharted.software/facets-core";
 import { FacetTermsData } from "@uncharted.software/facets-core/dist/types/facet-terms/FacetTerms";
 
-import TypeChangeMenu from "../TypeChangeMenu";
-import ImagePreview from "../ImagePreview";
+import TypeChangeMenu from "../TypeChangeMenu.vue";
+import ImagePreview from "../ImagePreview.vue";
 import { Highlight, RowSelection, VariableSummary } from "../../store/dataset";
 import {
   getCategoricalChunkSize,

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -210,6 +210,7 @@ export interface TableRow {
   _key: number;
   _rowVariant: string;
   _cellVariants: Dictionary<string>;
+  coordinates: any;
   d3mIndex?: number;
   isExcluded?: boolean;
 }

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -1066,9 +1066,9 @@ export function getImageFields(
     };
   }).filter((field) => field.type === IMAGE_TYPE);
 
-  // find remote senings image fields
+  // find remote sensing image fields
   const fieldKeys = _.map(fields, (_, key) => key);
-  const MultiBandImageFields = datasetGetters
+  const multiBandImageFields = datasetGetters
     .getVariables(store)
     .filter(
       (v) =>
@@ -1080,7 +1080,7 @@ export function getImageFields(
     .map((v) => ({ key: v.grouping.idCol, type: v.colType }));
 
   // the two are probably mutually exclusive, but it doesn't hurt anything to allow for both
-  return imageFields.concat(MultiBandImageFields);
+  return imageFields.concat(multiBandImageFields);
 }
 
 export function getListFields(


### PR DESCRIPTION
Extra cleanup and reorganization of code.

In the _SelectDataSlot_:
<img width="828" alt="Screen Shot 2020-12-16 at 18 13 33" src="https://user-images.githubusercontent.com/636801/102417807-77283700-3fca-11eb-97c5-0d35e6212989.png">

In the _FacetImage_:
<img width="829" alt="Screen Shot 2020-12-16 at 18 13 11" src="https://user-images.githubusercontent.com/636801/102417851-91621500-3fca-11eb-8e76-f9384c63abce.png">


fix #1668