### PR TITLE
Demo fixes

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -205,7 +205,7 @@ func (s *Storage) buildIncludeFilter(dataset string, wheres []string, params []i
 			indices = append(indices, fmt.Sprintf("$%d", offset+i))
 			params = append(params, d3mIndex)
 		}
-		where := fmt.Sprintf("\"%s\" IN (%s)", model.D3MIndexFieldName, strings.Join(indices, ", "))
+		where := fmt.Sprintf("%s IN (%s)", name, strings.Join(indices, ", "))
 		wheres = append(wheres, where)
 	case model.TextFilter:
 		// text
@@ -332,7 +332,7 @@ func (s *Storage) buildExcludeFilter(dataset string, wheres []string, params []i
 			indices = append(indices, fmt.Sprintf("$%d", offset+i))
 			params = append(params, d3mIndex)
 		}
-		where := fmt.Sprintf("\"%s\" NOT IN (%s)", model.D3MIndexFieldName, strings.Join(indices, ", "))
+		where := fmt.Sprintf("%s NOT IN (%s)", name, strings.Join(indices, ", "))
 		wheres = append(wheres, where)
 	case model.TextFilter:
 		// text

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -82,8 +82,11 @@ const (
 	// NDWI identifies a band mapping that displays Normalized Difference Water Index mapped using an RGB ramp.
 	NDWI = "ndwi"
 
-	// NDMI idenfifies a band mapping that display Normalized Difference Moisture Index mapped using an RGB ramp.
+	// NDMI identifies a band mapping that displays Normalized Difference Moisture Index mapped using an RGB ramp.
 	NDMI = "ndmi"
+
+	// NSMI identifies a band mapping that display Normalized Soil Moisture Index mapped using an RGB ramp.
+	NSMI = "nsmi"
 )
 
 // BandCombinationID uniquely identifies a band combination
@@ -149,6 +152,7 @@ func init() {
 		NDVI:                   {NDVI, "Normalized Difference Vegetation Index", []string{"b08", "b04"}, RedYellowGreenRamp, ClampedNormalizingTransform},
 		NDMI:                   {NDMI, "Normalized Difference Moisture Index ", []string{"b08", "b11"}, BlueYellowBrownRamp, NormalizingTransform},
 		NDWI:                   {NDWI, "Normalized Difference Water Index", []string{"b03", "b08"}, BlueYellowBrownRamp, NormalizingTransform},
+		NSMI:                   {NSMI, "Normalized Soil Moisture Index", []string{"b11", "b12"}, BlueYellowBrownRamp, NormalizingTransform},
 	}
 }
 


### PR DESCRIPTION
1. uses key in row filter to disambiguate column name during result fetch - was failing when a row-based filter was included
1. adds normalized soil moisture index as a new measure
