### PR TITLE
Predictions cleanup initial

### DIFF
--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -437,6 +437,21 @@ func handlePredict(conn *Connection, client *compute.Client, metadataCtor apiMod
 	}
 	predictParams.DatasetConstructor = ds
 
+	// import the dataset
+	datasetName, datasetPath, err := task.ImportPredictionDataset(predictParams)
+	if err != nil {
+		handleErr(conn, msg, err)
+		return
+	}
+	predictParams.Dataset = datasetName
+
+	// ingest the dataset
+	err = task.IngestPredictionDataset(datasetPath, predictParams)
+	if err != nil {
+		handleErr(conn, msg, err)
+		return
+	}
+
 	// run predictions - synchronous call for now
 	result, err := task.Predict(predictParams)
 	if err != nil {

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -424,10 +424,9 @@ func handlePredict(conn *Connection, client *compute.Client, metadataCtor apiMod
 		DataStorage:      dataStorage,
 		SolutionStorage:  solutionStorage,
 		ModelStorage:     modelStorage,
-		DatasetIngested:  false,
-		DatasetImported:  false,
 		Config:           &config,
 		IngestConfig:     ingestConfig,
+		SourceDatasetID:  meta.ID,
 	}
 
 	ds, err := createPredictionDataset(requestTask, request, predictParams)
@@ -444,9 +443,10 @@ func handlePredict(conn *Connection, client *compute.Client, metadataCtor apiMod
 		return
 	}
 	predictParams.Dataset = datasetName
+	predictParams.SchemaPath = datasetPath
 
 	// ingest the dataset
-	err = task.IngestPredictionDataset(datasetPath, predictParams)
+	err = task.IngestPredictionDataset(predictParams)
 	if err != nil {
 		handleErr(conn, msg, err)
 		return

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -453,7 +453,14 @@ func handlePredict(conn *Connection, client *compute.Client, metadataCtor apiMod
 	}
 
 	// run predictions - synchronous call for now
-	result, err := task.Predict(predictParams)
+	resultID, err := task.Predict(predictParams)
+	if err != nil {
+		handleErr(conn, msg, err)
+		return
+	}
+
+	// read the results from the database
+	result, err := solutionStorage.FetchPredictionResultByProduceRequestID(resultID)
 	if err != nil {
 		handleErr(conn, msg, err)
 		return


### PR DESCRIPTION
A reorganization of the prediction code that splits off the prediction dataset import, ingest and the prediction itself. The code is now a bit easier to follow since it is broken up, and should make it possible to fairly easily get predictions for previously ingested datasets or on data written to disk somewhere.