### PR TITLE
Image attention drill down

### DIFF
--- a/main.go
+++ b/main.go
@@ -260,7 +260,7 @@ func main() {
 	registerRoute(mux, "/distil/export-results/:produce-request-id", routes.ExportResultHandler(pgSolutionStorageCtor, pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/distil/model-metrics/:task", routes.ModelMetricsHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/ws", ws.SolutionHandler(solutionClient, esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor, esExportedModelStorageCtor))
-	registerRoute(mux, "/distil/image-attention/:dataset/:resultId/:index", routes.ImageAttentionHandler(pgSolutionStorageCtor, esMetadataStorageCtor))
+	registerRoute(mux, "/distil/image-attention/:dataset/:result-id/:index/:opacity/:color-scale", routes.ImageAttentionHandler(pgSolutionStorageCtor, esMetadataStorageCtor))
 
 	// POST
 	registerRoutePost(mux, "/distil/grouping/:dataset", routes.GroupingHandler(pgDataStorageCtor, esMetadataStorageCtor))

--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -283,17 +283,17 @@ export default Vue.extend({
         return;
       }
       const elem = this.$refs.imageAttentionElem as any;
+      const container = this.$refs.imageContainer as any;
       if (elem) {
         this.clearImage(elem);
         const image = this.imageAttention.cloneNode() as HTMLImageElement;
-
-        const ratio = Math.min(
-          IMAGE_MAX_SIZE / Math.max(this.image.height, this.image.width),
-          IMAGE_MAX_ZOOM
-        );
+        const width = container.querySelector("#injected-image" + image.id)
+          ?.width;
+        const height = container.querySelector("#injected-image" + image.id)
+          ?.height;
         // Update the image to be bigger, but not bigger than the modal box.
-        image.height = this.image.height * ratio;
-        image.width = this.image.width * ratio;
+        image.height = height;
+        image.width = width;
         elem.appendChild(image);
       }
     },

--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -36,7 +36,7 @@
         <li v-if="bandName"><label>Band:</label> {{ bandName }}</li>
         <li v-if="latLongValue"><label>Lat/Long:</label> {{ latLongValue }}</li>
         <li v-if="isResultScreen" class="d-flex justify-content-between">
-          <label> Enable image explanation: </label>
+          <label> {{ toggleStateString }} image explanation: </label>
           <div>
             <input
               class="form-check-input"
@@ -171,6 +171,9 @@ export default Vue.extend({
           this.solutionId + this.items[this.carouselPosition]?.d3mIndex
         ] ?? null
       );
+    },
+    toggleStateString(): string {
+      return this.isFilteredToggled ? "Disable" : "Enable";
     },
     isResultScreen(): boolean {
       return routeGetters.getRouteSolutionId(this.$store) != null;

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -33,7 +33,7 @@
       :url="imageUrl"
       :type="type"
       :info="imageDrilldown"
-      :item="row"
+      :items="[row]"
       :visible="!!zoomImage"
       @hide="hideZoomImage"
       :imageUrls="overlappedUrls"
@@ -289,10 +289,6 @@ export default Vue.extend({
       }
       if (this.hasImageAttention && this.imageAttentionIsLoaded) {
         this.injectFilter();
-      }
-      if (!this.hasImageAttention && this.imageAttentionHasRendered) {
-        this.clearImage(this.$refs.imageAttentionElem as any);
-        this.imageAttentionHasRendered = false;
       }
       if (!this.hasImageAttention && this.imageAttentionHasRendered) {
         this.clearImage(this.$refs.imageAttentionElem as any);

--- a/public/components/SettingsModal.vue
+++ b/public/components/SettingsModal.vue
@@ -263,9 +263,10 @@ export default Vue.extend({
         modelQuality: this.speedQuality,
         metrics: this.selectedMetric,
         trainTestSplit: this.trainingRatio,
-        timestampSplit: this.hasTimeRange
-          ? this.timestampSplitValue.getTime() / 1000
-          : null,
+        timestampSplit:
+          this.hasTimeRange && this.shouldSplitByTime
+            ? this.timestampSplitValue.getTime() / 1000
+            : null,
       });
       this.$router.push(entry).catch((err) => console.warn(err));
     },


### PR DESCRIPTION
closes #2112 

- Added filter support for drill down
- Added toggle for filter on drill down support (only on result screen)
- Fixed all the errors from from image drill down
- Supports displaying multiple filters (for the carousel feature)
- Fixed route param issues
- Fixed bug with timesplit always applying
![Peek 2021-01-05 14-16](https://user-images.githubusercontent.com/25306965/103689009-b5c56780-4f60-11eb-8236-0a1a9407984e.gif)
