### PR TITLE
Added deletion, immutability and clone support for datasets

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -101,6 +101,8 @@ type DataStorage interface {
 
 	// CloneDataset creates a copy of an existing dataset
 	CloneDataset(dataset string, storageName string, datasetNew string, storageNameNew string) error
+	// DeleteDataset drops all tables associated to storageName
+	DeleteDataset(storageName string) error
 }
 
 // SolutionStorageCtor represents a client constructor to instantiate a

--- a/api/model/storage/datamart/nyu.go
+++ b/api/model/storage/datamart/nyu.go
@@ -244,7 +244,7 @@ func materializeNYUDataset(datamart *Storage, id string, uri string) (string, er
 	}
 
 	// copy the formatted output to the datamart output path (delete existing copy)
-	err = util.RemoveContents(extractedArchivePath)
+	err = util.RemoveContents(extractedArchivePath, false)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to delete raw datamart dataset")
 	}

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -48,8 +48,12 @@ func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew
 	// update the id to match the new info
 	ds.ID = datasetNew
 	ds.StorageName = storageNameNew
+	ds.Name = datasetNew
 	ds.Folder = folderNew
 	ds.Source = metadata.Augmented
+	// cloned datasets CAN be altered
+	ds.Immutable = false
+	ds.Clone = true
 
 	return s.UpdateDataset(ds)
 }
@@ -158,7 +162,7 @@ func (s *Storage) IngestDataset(datasetSource metadata.DatasetSource, meta *mode
 
 // DeleteDataset deletes a dataset from ES.
 func (s *Storage) DeleteDataset(dataset string) error {
-	_, err := s.client.Delete().Index(s.datasetIndex).Id(dataset).Do(context.Background())
+	_, err := s.client.Delete().Index(s.datasetIndex).Id(dataset).Refresh("true").Do(context.Background())
 
 	return err
 }

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -84,7 +84,51 @@ func (s *Storage) CloneDataset(dataset string, storageName string, datasetNew st
 
 	return nil
 }
-
+// DeleteDataset drops all tables associated to the dataset
+func (s *Storage) DeleteDataset(storageName string) error {
+	// drop view
+	err := s.dropView(storageName)
+	if err != nil {
+		return err
+	}
+	// drop base table
+	err = s.dropTable(getBaseTableName(storageName))
+	if err != nil {
+		return err
+	}
+	// drop variable table
+	err = s.dropTable(getVariableTableName(storageName))
+	if err != nil {
+		return err
+	}
+	// drop result table
+	err = s.dropTable(s.getResultTable(storageName))
+	if err != nil {
+		return err
+	}
+	// drop explanation table
+	err = s.dropTable(s.getSolutionFeatureWeightTable(storageName))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (s *Storage) dropView(view string) error{
+	sql := fmt.Sprintf("DROP VIEW IF EXISTS %s", view)
+	_, err := s.client.Exec(sql)
+	if err != nil {
+		return errors.Wrapf(err, "unable to drop table")
+	}
+	return nil
+}
+func (s *Storage) dropTable(table string) error{
+	sql := fmt.Sprintf("DROP TABLE IF EXISTS %s", table)
+	_, err := s.client.Exec(sql)
+	if err != nil {
+		return errors.Wrapf(err, "unable to drop table")
+	}
+	return nil
+}
 func (s *Storage) cloneTable(existingTable string, newTable string, copyData bool) error {
 	sql := fmt.Sprintf("CREATE TABLE %s AS TABLE %s", newTable, existingTable)
 	if !copyData {

--- a/api/routes/clone.go
+++ b/api/routes/clone.go
@@ -54,7 +54,10 @@ func CloningHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCt
 			handleError(w, err)
 			return
 		}
-
+		if ds.Clone {
+			handleError(w, errors.New("Cannot make a clone of a clone"))
+			return
+		}
 		datasetClone, err := task.GetUniqueOutputFolder(fmt.Sprintf("%s_clone", dataset), env.GetAugmentedPath())
 		if err != nil {
 			handleError(w, err)

--- a/api/routes/delete_dataset.go
+++ b/api/routes/delete_dataset.go
@@ -1,0 +1,66 @@
+
+package routes
+
+import (
+	"github.com/uncharted-distil/distil/api/util"
+	"net/http"
+
+	"goji.io/v3/pat"
+	"github.com/pkg/errors"
+	"github.com/uncharted-distil/distil/api/env"
+	api "github.com/uncharted-distil/distil/api/model"
+)
+// DeletingDatasetHandler attempts to delete mutable datasets
+func DeletingDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCtor) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// get params
+		dataset := pat.Param(r, "dataset")
+		// get meta and data storage
+		metaStorage, err := metaCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		dataStorage, err := dataCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		ds, err := metaStorage.FetchDataset(dataset, true, true, false)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		folder := env.ResolvePath(ds.Source, ds.Folder)
+		// verify dataset is a clone	
+		if ds.Immutable {
+			handleError(w, errors.New("cannot delete Immutable dataset"))
+			return
+		}
+		// delete db tables
+		err = dataStorage.DeleteDataset(ds.StorageName)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		// delete meta
+		err = metaStorage.DeleteDataset(dataset)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		// delete files
+		err = util.RemoveContents(folder, true)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		// send json
+		err = handleJSON(w, map[string]interface{}{"success": true})
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal clustering result into JSON"))
+			return
+		}
+	}
+}

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -313,7 +313,8 @@ func Ingest(originalSchemaFile string, schemaFile string, data api.DataStorage, 
 	if err != nil {
 		return "", err
 	}
-
+	// original datasets should NOT be changed
+	meta.Immutable = true
 	if !config.IngestOverwrite {
 		// get the unique name, and if it is different then write out the updated metadata
 		uniqueName, err := getUniqueDatasetName(meta, storage)
@@ -428,7 +429,7 @@ func IngestMetadata(originalSchemaFile string, schemaFile string, data api.DataS
 			}
 		}
 	}
-
+	meta.Immutable = true
 	// Ingest the dataset info into the metadata storage
 	err = storage.IngestDataset(source, meta)
 	if err != nil {

--- a/api/util/file.go
+++ b/api/util/file.go
@@ -185,8 +185,8 @@ func CopyFile(sourceFile string, destinationFile string) error {
 	return nil
 }
 
-// RemoveContents removes the files and directories from the supplied parent.
-func RemoveContents(dir string) error {
+// RemoveContents removes the files and directories from the supplied parent. includeParent will remove the parent directory as well if true
+func RemoveContents(dir string, includeParent bool) error {
 	d, err := os.Open(dir)
 	if err != nil {
 		return err
@@ -198,6 +198,12 @@ func RemoveContents(dir string) error {
 	}
 	for _, name := range names {
 		err = os.RemoveAll(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+	}
+	if includeParent {
+		err = os.RemoveAll(dir)
 		if err != nil {
 			return err
 		}

--- a/api/util/file.go
+++ b/api/util/file.go
@@ -192,18 +192,19 @@ func RemoveContents(dir string, includeParent bool) error {
 		return err
 	}
 	defer d.Close()
+	if includeParent {
+		err = os.RemoveAll(dir)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
 	names, err := d.Readdirnames(-1)
 	if err != nil {
 		return err
 	}
 	for _, name := range names {
 		err = os.RemoveAll(filepath.Join(dir, name))
-		if err != nil {
-			return err
-		}
-	}
-	if includeParent {
-		err = os.RemoveAll(dir)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -292,7 +292,7 @@ func main() {
 	registerRoutePost(mux, "/distil/timeseries-forecast/:truthDataset/:forecastDataset/:timeseriesColName/:xColName/:yColName/:timeseriesURI/:result-uuid", routes.TimeseriesForecastHandler(esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor, config.TrainTestSplitTimeSeries))
 	registerRoutePost(mux, "/distil/event", routes.UserEventHandler(discoveryLogger))
 	registerRoutePost(mux, "/distil/save/:solution-id/:fitted", routes.SaveHandler(esExportedModelStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor))
-
+	registerRoutePost(mux, "/distil/delete-dataset/:dataset", routes.DeletingDatasetHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	// static
 	registerRoute(mux, "/distil/image/:dataset/:file", routes.ImageHandler(esMetadataStorageCtor, &config))
 	registerRoute(mux, "/distil/graphs/:dataset/:file", routes.GraphsHandler(config.D3MInputDir))

--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -10,7 +10,7 @@
       @click.stop="setActiveDataset()"
     >
       <a class="nav-link">
-        <i class="fa fa-table" /> <b>Dateset Name:</b>
+        <i class="fa fa-table" /> <b>Dataset Name:</b>
         {{ dataset.name }}
       </a>
       <a class="nav-link">
@@ -19,6 +19,15 @@
       </a>
       <a class="nav-link"><b>Rows:</b> {{ dataset.numRows }}</a>
       <a class="nav-link"><b>Size:</b> {{ formatBytes(dataset.numBytes) }}</a>
+      <b-button
+        v-if="!dataset.immutable"
+        class="delete-button"
+        data-toggle="tooltip"
+        title="Delete dataset"
+        @click.stop="onDeleteClicked(dataset)"
+      >
+        <i class="fa fa-times text-danger" aria-hidden="true" />
+      </b-button>
       <a v-if="isImportReady">
         <b-button
           class="dataset-preview-button"
@@ -175,6 +184,9 @@ export default Vue.extend({
   },
 
   methods: {
+    onDeleteClicked(dataset: Dataset) {
+      this.$emit("dataset-delete", dataset);
+    },
     formatBytes(n: number): string {
       return formatBytes(n);
     },
@@ -260,7 +272,10 @@ export default Vue.extend({
 .highlight {
   background-color: #87cefa;
 }
-
+.delete-button {
+  background-color: transparent;
+  border: none;
+}
 .dataset-header {
   display: flex;
   padding: 4px 8px;

--- a/public/components/DeletionModal.vue
+++ b/public/components/DeletionModal.vue
@@ -1,0 +1,33 @@
+<template>
+  <b-modal :id="modalId" @ok="okHandler">
+    <template #modal-title> Deleting {{ target }}</template>
+    This action can NOT be undone. Do you want to delete {{ target }}?
+  </b-modal>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+export default Vue.extend({
+  name: "deletion-modal",
+  props: {
+    target: { type: String as () => string, default: "" },
+  },
+  data() {
+    return { modalId: "deletion-modal" };
+  },
+  watch: {
+    target() {
+      if (!this.target.length) {
+        return;
+      }
+      // show deletion prompt if target changed
+      this.$bvModal.show(this.modalId);
+    },
+  },
+  methods: {
+    okHandler() {
+      this.$emit("ok");
+    },
+  },
+});
+</script>

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -94,7 +94,24 @@ export const actions = {
       mutations.setDatasets(context, []);
     }
   },
-
+  async deleteDataset(
+    context: DatasetContext,
+    payload: { dataset: string; terms: string }
+  ): Promise<void> {
+    if (!payload.dataset) {
+      return;
+    }
+    try {
+      // delete dataset
+      const response = await axios.post(
+        `/distil/delete-dataset/${payload.dataset}`
+      );
+      // update current list of datasets
+      await actions.searchDatasets(context, payload.terms);
+    } catch (err) {
+      console.error(err);
+    }
+  },
   // fetches all variables for a single dataset.
   async fetchVariables(
     context: DatasetContext,

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -105,6 +105,8 @@ export interface Dataset {
   source: string;
   joinSuggestion?: JoinSuggestion[];
   joinScore?: number;
+  storageName?: string;
+  clone?: boolean;
   type: string;
 }
 

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -99,6 +99,7 @@ export const getters = {
 export const actions = {
   // dataset
   fetchDataset: dispatch(moduleActions.fetchDataset),
+  deleteDataset: dispatch(moduleActions.deleteDataset),
   searchDatasets: dispatch(moduleActions.searchDatasets),
   geocodeVariable: dispatch(moduleActions.geocodeVariable),
   importDataset: dispatch(moduleActions.importDataset),

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -220,9 +220,8 @@ export default Vue.extend({
       return routeGetters.getDecodedTrainingVariableNames(this.$store);
     },
     isClone(): boolean {
-      return this.variables.some((v) => {
-        return v.colName === LOW_SHOT_LABEL_COLUMN_NAME;
-      });
+      const datasets = datasetGetters.getDatasets(this.$store);
+      return datasets.find((d) => d.id === this.dataset).clone;
     },
   },
   watch: {

--- a/public/views/Search.vue
+++ b/public/views/Search.vue
@@ -121,6 +121,7 @@
               v-if="result.type === 'dataset'"
               :key="result.dataset.id"
               :dataset="result.dataset"
+              @dataset-delete="onDeletionClicked"
               allow-join
               allow-import
             />
@@ -131,6 +132,10 @@
             />
           </template>
         </div>
+        <deletion-modal
+          :target="deletionTarget"
+          @ok="onDatasetDeletionConfirmed"
+        />
       </div>
     </section>
 
@@ -144,6 +149,7 @@ import _ from "lodash";
 import Vue from "vue";
 import AddDataset from "../components/AddDataset.vue";
 import DatasetPreview from "../components/DatasetPreview.vue";
+import DeletionModal from "../components/DeletionModal.vue";
 import ImportStatus from "../components/ImportStatus.vue";
 import ModelPreview from "../components/ModelPreview.vue";
 import SearchBar from "../components/SearchBar.vue";
@@ -168,6 +174,7 @@ export default Vue.extend({
     ImportStatus,
     ModelPreview,
     SearchBar,
+    DeletionModal,
   },
 
   data() {
@@ -186,6 +193,8 @@ export default Vue.extend({
         dataset: "",
         location: "",
       },
+      deletionTarget: "",
+      deletionInfo: null,
     };
   },
 
@@ -321,7 +330,17 @@ export default Vue.extend({
         this.isPending = false;
       });
     },
-
+    onDeletionClicked(dataset: Dataset) {
+      this.deletionTarget = dataset.name;
+      this.deletionInfo = dataset;
+    },
+    onDatasetDeletionConfirmed() {
+      const terms = routeGetters.getRouteTerms(this.$store);
+      datasetActions.deleteDataset(this.$store, {
+        dataset: this.deletionInfo.id,
+        terms: terms,
+      });
+    },
     onUploadStart(uploadData) {
       this.uploadData = uploadData;
       this.uploadStatus = "started";


### PR DESCRIPTION
closes #2146 
![Peek 2021-01-06 14-11](https://user-images.githubusercontent.com/25306965/103810678-a78f4e00-5029-11eb-8832-21026f98b6e5.gif)


- Added deletion support for cloned datasets
- Integrated the use of the Immutable tag for datasets
- Integrated the use of Clone tag for datasets
- Added new dataset-deletion route
- Added functions for dropping tables and views
- Changed deletion in ES to sync behaviour
- Two step deletion user interface
- Data that is ingested is Immutable and therefore cannot be deleted or altered
- Cloned datasets are mutable