### PR TITLE
support added for multiple selections for image query

### DIFF
--- a/public/components/DrillDown.vue
+++ b/public/components/DrillDown.vue
@@ -27,7 +27,7 @@
                 :height="imageHeight"
                 :type="imageType"
                 :gray="renderTiles[i][j].selected.gray"
-                :on-click="onImageClick"
+                @click="onImageClick"
                 :overlappedUrls="
                   renderTiles[i][j].overlapped.map((o) => o.imageUrl)
                 "

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -15,15 +15,15 @@
       <template v-else-if="!stopSpinner">
         <div
           ref="imageElem"
-          class="image-elem"
-          :class="{ clickable: hasClick }"
-          @click.stop="handleClick"
+          class="image-elem clickable"
+          @click.stop.exact="handleClick"
+          @click.shift.exact.stop="handleShiftClick"
         />
         <div
           ref="imageAttentionElem"
-          class="filter-elem"
-          :class="{ clickable: hasClick }"
-          @click.stop="handleClick"
+          class="filter-elem clickable"
+          @click.stop.exact="handleClick"
+          @click.shift.exact.stop="handleShiftClick"
         />
         <i class="fa fa-search-plus zoom-icon" @click.stop="showZoomedImage" />
       </template>
@@ -93,7 +93,6 @@ export default Vue.extend({
       default: false,
       type: Boolean as () => boolean,
     },
-    onClick: Function,
     gray: { type: Number, default: 0 }, // support for graying images.
     debounce: { type: Boolean as () => boolean, default: false },
     debounceWaitTime: { type: Number as () => number, default: 500 },
@@ -236,9 +235,6 @@ export default Vue.extend({
       }
       return routeGetters.getRouteDataset(this.$store);
     },
-    hasClick(): boolean {
-      return !!this.onClick;
-    },
     rowSelection(): RowSelection {
       return routeGetters.getDecodedRowSelection(this.$store);
     },
@@ -262,6 +258,9 @@ export default Vue.extend({
   },
 
   methods: {
+    handleShiftClick() {
+      this.$emit("shift-click", this.row);
+    },
     async visibilityChanged(isVisible: boolean) {
       this.isVisible = isVisible;
       if (this.isVisible && !this.hasRequested) {
@@ -296,13 +295,11 @@ export default Vue.extend({
       }
     },
     handleClick() {
-      if (this.onClick) {
-        this.onClick({
-          row: this.row,
-          imageUrl: this.imageUrl,
-          image: this.image,
-        });
-      }
+      this.$emit("click", {
+        row: this.row,
+        imageUrl: this.imageUrl,
+        image: this.image,
+      });
     },
 
     showZoomedImage() {

--- a/public/components/OverlapSelection.vue
+++ b/public/components/OverlapSelection.vue
@@ -27,7 +27,7 @@
               :height="imageHeight"
               :type="imageType"
               :gray="items[i].gray"
-              :onClick="onClick"
+              @click="onClick"
             />
           </div>
           <label v-if="hasTimeStamp">{{ items[i].item.timestamp.value }}</label>

--- a/public/components/labelingComponents/LabelHeaderButtons.vue
+++ b/public/components/labelingComponents/LabelHeaderButtons.vue
@@ -1,14 +1,27 @@
 <template>
   <div class="pt-2">
-    <b-button @click="onButtonClick(positive)">
+    <b-button title="Select all items on page" @click="onSelectAll"
+      >Select All</b-button
+    >
+    <b-button
+      title="Annotate selected items to positive"
+      @click="onButtonClick(positive)"
+    >
       <i class="fa fa-check text-success" aria-hidden="true"></i>
       Positive
     </b-button>
-    <b-button @click="onButtonClick(negative)">
+    <b-button
+      title="Annotate selected items to negative"
+      @click="onButtonClick(negative)"
+    >
       <i class="fa fa-times red" aria-hidden="true"></i>
       Negative</b-button
     >
-    <b-button @click="onButtonClick(unlabeled)">Unlabeled</b-button>
+    <b-button
+      title="Annotate select items to negative"
+      @click="onButtonClick(unlabeled)"
+      >Unlabeled</b-button
+    >
     <layer-selection v-if="isRemoteSensing" />
   </div>
 </template>
@@ -37,6 +50,9 @@ export default Vue.extend({
   methods: {
     onButtonClick(event: string) {
       this.$emit("button-event", event);
+    },
+    onSelectAll() {
+      this.$emit("select-all");
     },
     isRemoteSensing(): boolean {
       return routeGetters.isMultiBandImage(this.$store);

--- a/public/components/labelingComponents/LabelingDataSlot.vue
+++ b/public/components/labelingComponents/LabelingDataSlot.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="h-75">
     <div class="d-flex justify-content-around m-1">
-      <label-header-buttons @button-event="onAnnotationClicked" />
+      <label-header-buttons
+        @button-event="onAnnotationClicked"
+        @select-all="onSelectAll"
+      />
       <view-type-toggle
         v-model="viewTypeModel"
         :variables="variables"
@@ -11,6 +14,7 @@
     <div class="label-data-container">
       <component
         :is="viewComponent"
+        ref="dataView"
         :data-fields="dataFields"
         :data-items="dataItems"
         :instance-name="instanceName"
@@ -50,7 +54,9 @@ import LabelHeaderButtons from "./LabelHeaderButtons.vue";
 const GEO_VIEW = "geo";
 const IMAGE_VIEW = "image";
 const TABLE_VIEW = "table";
-
+interface DataView {
+  selectAll: () => void;
+}
 export default Vue.extend({
   name: "labeling-data-slot",
   components: {
@@ -131,6 +137,10 @@ export default Vue.extend({
         return;
       }
       this.$emit(this.eventLabel, label);
+    },
+    onSelectAll() {
+      const dataView = (this.$refs.dataView as unknown) as DataView;
+      dataView.selectAll();
     },
   },
 });

--- a/public/util/row.ts
+++ b/public/util/row.ts
@@ -171,7 +171,38 @@ export function getSelectedRows(): Row[] {
   });
   return rows;
 }
-
+// bulkRowSelectionUpdate takes an array of d3mIndices to update (this will remove and add depending on if the d3mIndex already exists within the selection)
+export function bulkRowSelectionUpdate(
+  router: VueRouter,
+  context: string,
+  selection: RowSelection,
+  d3mIndices: number[]
+) {
+  if (!selection || selection.context !== context) {
+    selection = {
+      context: context,
+      d3mIndices: [],
+    };
+  }
+  const rowSelectionMap = new Map(
+    selection.d3mIndices.map((i) => {
+      return [i, i];
+    })
+  );
+  d3mIndices.forEach((item) => {
+    if (rowSelectionMap.has(item)) {
+      rowSelectionMap.delete(item);
+      return;
+    }
+    rowSelectionMap.set(item, item);
+  });
+  selection.d3mIndices = Array.from(rowSelectionMap.keys());
+  const entry = overlayRouteEntry(routeGetters.getRoute(store), {
+    row: encodeRowSelection(selection),
+  });
+  router.push(entry).catch((err) => console.warn(err));
+  dataActions.updateRowSelectionData(store);
+}
 export function addRowSelection(
   router: VueRouter,
   context: string,


### PR DESCRIPTION
![Peek 2021-01-07 13-09](https://user-images.githubusercontent.com/25306965/103928332-ab82a500-50e9-11eb-9b01-2e26b9c6ce55.gif)

closes #2156 

- Added support for shift click selection for image mosaic and tabular view (only for the image query view, it can be added to other views if needed)
- Added select all button which selects all the items on the current page for image mosaic and tabular view