### PR TITLE
Commercial Dataset Support

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -374,7 +374,7 @@ func CreateBatches(schemaFile string, maxBatchSize int) ([]string, error) {
 	for _, v := range meta.GetMainDataResource().Variables {
 		if v.DistilRole == model.VarDistilRoleGrouping {
 			groupColIndex = v.Index
-		} else if v.StorageName == model.D3MIndexFieldName && groupColIndex == -1 {
+		} else if v.Key == model.D3MIndexFieldName && groupColIndex == -1 {
 			groupColIndex = v.Index
 		}
 	}

--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -232,7 +232,7 @@ func (s *SolutionRequest) explainSolutionOutput(outputURI string, solutionID str
 	// map column name to get the feature index
 	varsMapped := make(map[string]*model.Variable)
 	for _, v := range variables {
-		varsMapped[v.StorageName] = v
+		varsMapped[v.Key] = v
 	}
 
 	output := make([]*api.SolutionWeight, 0)

--- a/api/compute/problem_persist.go
+++ b/api/compute/problem_persist.go
@@ -119,7 +119,7 @@ func DefaultTaskType(targetType string, problemType string) []string {
 // problem format.
 func CreateProblemSchema(datasetDir string, dataset string, targetVar *model.Variable, filters *api.FilterParams) (*ProblemPersist, string, error) {
 	// parse the dataset and its filter state and generate a hashcode from both
-	hash, err := getFilteredDatasetHash(dataset, targetVar.StorageName, filters, true)
+	hash, err := getFilteredDatasetHash(dataset, targetVar.Key, filters, true)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "unable to build dataset filter hash")
 	}

--- a/api/dataset/table.go
+++ b/api/dataset/table.go
@@ -19,6 +19,8 @@ import (
 	"bytes"
 	"encoding/csv"
 	"path"
+	"strings"
+	"unicode"
 
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/model"
@@ -42,6 +44,14 @@ func NewTableDataset(dataset string, rawData []byte, flagD3MIndex bool) (*Table,
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read csv data")
 	}
+
+	// remove invisible characters from the header
+	for i, c := range csvData[0] {
+		csvData[0][i] = strings.TrimFunc(c, func(r rune) bool {
+			return !unicode.IsGraphic(r)
+		})
+	}
+
 	return &Table{
 		Dataset:   dataset,
 		CSVData:   csvData,

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -147,7 +147,7 @@ func FetchDataset(dataset string, includeIndex bool, includeMeta bool, filterPar
 // GetD3MIndexVariable returns the D3M index variable.
 func (d *Dataset) GetD3MIndexVariable() *model.Variable {
 	for _, v := range d.Variables {
-		if v.StorageName == model.D3MIndexName {
+		if v.Key == model.D3MIndexName {
 			return v
 		}
 	}
@@ -198,7 +198,7 @@ func UpdateExtremas(dataset string, varName string, storageMeta MetadataStorage,
 	// find the variable
 	var v *model.Variable
 	for _, variable := range d.Variables {
-		if variable.StorageName == varName {
+		if variable.Key == varName {
 			v = variable
 			break
 		}

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -197,7 +197,7 @@ func GetFilterVariables(filterVariables []string, variables []*model.Variable) [
 
 	variableLookup := make(map[string]*model.Variable)
 	for _, v := range variables {
-		variableLookup[v.StorageName] = v
+		variableLookup[v.Key] = v
 	}
 
 	filtered := make([]*model.Variable, 0)

--- a/api/model/grouped_variables.go
+++ b/api/model/grouped_variables.go
@@ -27,7 +27,7 @@ func FetchSummaryVariables(dataset string, metaStore MetadataStorage) ([]*model.
 	// loop through the var list and drop any that should be hidden
 	visibleVars := []*model.Variable{}
 	for _, variable := range variables {
-		if !isHidden(variable.StorageName, hidden) {
+		if !isHidden(variable.Key, hidden) {
 			visibleVars = append(visibleVars, variable)
 		}
 	}
@@ -82,7 +82,7 @@ func ExpandFilterParams(dataset string, filterParams *FilterParams, includeHidde
 	// create variable lookup
 	varMap := make(map[string]*model.Variable)
 	for _, variable := range variables {
-		varMap[variable.StorageName] = variable
+		varMap[variable.Key] = variable
 	}
 
 	updatedFilterParams.Variables = []string{}
@@ -124,13 +124,13 @@ func ExpandFilterParams(dataset string, filterParams *FilterParams, includeHidde
 				}
 			} else if model.IsImage(variable.Type) {
 				// add the variable, and if it exists the cluster{
-				updatedFilterParams.AddVariable(variable.StorageName)
-				clusterField := fmt.Sprintf("_cluster_%s", variable.StorageName)
+				updatedFilterParams.AddVariable(variable.Key)
+				clusterField := fmt.Sprintf("_cluster_%s", variable.Key)
 				if varMap[clusterField] != nil {
-					updatedFilterParams.AddVariable(varMap[clusterField].StorageName)
+					updatedFilterParams.AddVariable(varMap[clusterField].Key)
 				}
 			} else {
-				updatedFilterParams.AddVariable(variable.StorageName)
+				updatedFilterParams.AddVariable(variable.Key)
 			}
 		}
 	}
@@ -170,7 +170,7 @@ func GetClusterColFromGrouping(group model.BaseGrouping) (string, bool) {
 // UpdateFilterKey updates the supplied filter key to point to a group-specific column, rather than relying on the group variable
 // name.
 func UpdateFilterKey(metaStore MetadataStorage, dataset string, dataMode DataMode, filter *model.Filter, variable *model.Variable) {
-	if variable.StorageName == filter.Key && variable.IsGrouping() {
+	if variable.Key == filter.Key && variable.IsGrouping() {
 		clusterCol, ok := GetClusterColFromGrouping(variable.Grouping)
 		if ok && dataMode == ClusterDataMode && HasClusterData(dataset, clusterCol, metaStore) {
 			filter.Key = clusterCol

--- a/api/model/storage/datamart/isi.go
+++ b/api/model/storage/datamart/isi.go
@@ -171,7 +171,7 @@ func parseISISearchResult(responseRaw []byte, baseDataset *api.Dataset) ([]*api.
 		// for now, assume that a var has a selector with at least 2 elements.
 		for _, c := range res.Summary.Columns {
 			vars = append(vars, &model.Variable{
-				StorageName: c,
+				Key:         c,
 				DisplayName: c,
 			})
 		}

--- a/api/model/storage/datamart/nyu.go
+++ b/api/model/storage/datamart/nyu.go
@@ -180,7 +180,7 @@ func parseNYUSearchResult(responseRaw []byte, baseDataset *api.Dataset) ([]*api.
 		vars := make([]*model.Variable, 0)
 		for _, c := range res.Metadata.Columns {
 			vars = append(vars, &model.Variable{
-				StorageName:  c.Name,
+				Key:          c.Name,
 				DisplayName:  c.Name,
 				OriginalType: mapNYUDataTypesToDistil(c.StructuralType),
 			})

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -376,7 +376,7 @@ func (s *Storage) updateVariables(dataset string, variables []*model.Variable) e
 	for _, v := range variables {
 		serialized = append(serialized, map[string]interface{}{
 			model.VarNameField:             v.HeaderName,
-			model.VarStorageNameField:      v.StorageName,
+			model.VarKeyField:              v.Key,
 			model.VarIndexField:            v.Index,
 			model.VarRoleField:             v.Role,
 			model.VarSelectedRoleField:     v.SelectedRole,
@@ -422,7 +422,7 @@ func (s *Storage) SetDataType(dataset string, varName string, varType string) er
 
 	// Update only the variable we care about
 	for _, v := range vars {
-		if v.StorageName == varName {
+		if v.Key == varName {
 			v.Type = varType
 		}
 	}
@@ -431,7 +431,7 @@ func (s *Storage) SetDataType(dataset string, varName string, varType string) er
 }
 
 // SetExtrema updates the min & max values of a field in ES.
-func (s *Storage) SetExtrema(dataset string, varName string, extrema *api.Extrema) error {
+func (s *Storage) SetExtrema(dataset string, key string, extrema *api.Extrema) error {
 	// Fetch all existing variables
 	vars, err := s.FetchVariables(dataset, true, true, false)
 	if err != nil {
@@ -440,7 +440,7 @@ func (s *Storage) SetExtrema(dataset string, varName string, extrema *api.Extrem
 
 	// Update only the variable we care about
 	for _, v := range vars {
-		if v.StorageName == varName {
+		if v.Key == key {
 			v.Min = extrema.Min
 			v.Max = extrema.Max
 		}
@@ -449,20 +449,20 @@ func (s *Storage) SetExtrema(dataset string, varName string, extrema *api.Extrem
 	return s.updateVariables(dataset, vars)
 }
 
-// AddVariable adds a new variable to the dataset.  If the varDisplayName is left blank it will be set to the varName value.
-func (s *Storage) AddVariable(dataset string, varName string, varDisplayName string, varType string, varRole string) error {
+// AddVariable adds a new variable to the dataset.  If the varDisplayName is left blank it will be set to the key value.
+func (s *Storage) AddVariable(dataset string, key string, varDisplayName string, varType string, varRole string) error {
 
 	if varDisplayName == "" {
-		varDisplayName = varName
+		varDisplayName = key
 	}
 
 	// new variable definition
 	variable := &model.Variable{
-		StorageName:      varName,
-		HeaderName:       varName,
+		Key:              key,
+		HeaderName:       key,
 		Type:             varType,
 		OriginalType:     varType,
-		OriginalVariable: varName,
+		OriginalVariable: key,
 		DisplayName:      varDisplayName,
 		DistilRole:       varRole,
 		Deleted:          false,
@@ -479,7 +479,7 @@ func (s *Storage) AddVariable(dataset string, varName string, varDisplayName str
 	// check if var already exists
 	found := false
 	for index, v := range vars {
-		if v.StorageName == varName {
+		if v.Key == key {
 			// check if it has been deleted
 			if !v.Deleted {
 				return errors.Errorf("variable already exists under this key")
@@ -502,7 +502,7 @@ func (s *Storage) AddVariable(dataset string, varName string, varDisplayName str
 }
 
 // DeleteVariable flags a variable as deleted.
-func (s *Storage) DeleteVariable(dataset string, varName string) error {
+func (s *Storage) DeleteVariable(dataset string, key string) error {
 	// query for existing variables
 	vars, err := s.FetchVariables(dataset, true, true, true)
 	if err != nil {
@@ -511,7 +511,7 @@ func (s *Storage) DeleteVariable(dataset string, varName string) error {
 
 	// soft delete the variable
 	for _, v := range vars {
-		if v.StorageName == varName {
+		if v.Key == key {
 			v.Deleted = true
 		}
 	}

--- a/api/model/storage/file/dataset.go
+++ b/api/model/storage/file/dataset.go
@@ -180,7 +180,7 @@ func datasetMatches(meta *model.Metadata, terms []string) bool {
 
 	for _, dr := range meta.DataResources {
 		for _, f := range dr.Variables {
-			if matches(f.StorageName, terms) {
+			if matches(f.Key, terms) {
 				return true
 			}
 		}

--- a/api/model/storage/postgres/bounds.go
+++ b/api/model/storage/postgres/bounds.go
@@ -309,7 +309,7 @@ func (f *BoundsField) fetchHistogramByResult(resultURI string, filterParams *api
 	query := fmt.Sprintf(`
 		SELECT b.xbuckets, b.xcoord, b.ybuckets, b.ycoord, COUNT(%s)
 		FROM %s AS data inner join %s AS b ON ST_WITHIN(data."%s", b.coordinates)
-		INNER JOIN %s result ON data."%s" = result.index
+		INNER JOIN %s result ON cast(data."%s" as double precision) = result.index
 		WHERE result.result_id = $%d %s
 		GROUP BY b.xbuckets, b.xcoord, b.ybuckets, b.ycoord
 		ORDER BY b.xbuckets, b.ybuckets;`, f.Count, queryTableName, tmpTableName, f.PolygonCol,

--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -59,7 +59,7 @@ func (s *Storage) FetchConfidenceSummary(dataset string, storageName string, res
 
 		explainedSummaries[explainName] = &api.VariableSummary{
 			Label:    variable.DisplayName,
-			Key:      variable.StorageName,
+			Key:      variable.Key,
 			Type:     model.NumericalType,
 			VarType:  variable.Type,
 			Baseline: baseline,

--- a/api/model/storage/postgres/correctness.go
+++ b/api/model/storage/postgres/correctness.go
@@ -54,7 +54,7 @@ func (s *Storage) FetchCorrectnessSummary(dataset string, storageName string, re
 
 	return &api.VariableSummary{
 		Label:    variable.DisplayName,
-		Key:      variable.StorageName,
+		Key:      variable.Key,
 		Type:     model.CategoricalType,
 		VarType:  variable.Type,
 		Baseline: baseline,
@@ -124,7 +124,7 @@ func (s *Storage) getCountCol(dataset string, mode api.SummaryMode) (string, err
 
 func (s *Storage) parseHistogram(rows pgx.Rows, variable *model.Variable) (*api.Histogram, error) {
 
-	termsAggName := api.TermsAggPrefix + variable.StorageName
+	termsAggName := api.TermsAggPrefix + variable.Key
 
 	// extract the counts
 	countMap := map[string]map[string]int64{}

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -225,9 +225,9 @@ func (s *Storage) getExistingFields(dataset string, storageName string) (map[str
 	// make sure they exist in the underlying database already
 	fields := make(map[string]*model.Variable)
 	for _, v := range vars {
-		exists, _ := s.DoesVariableExist(dataset, storageName, v.StorageName)
+		exists, _ := s.DoesVariableExist(dataset, storageName, v.Key)
 		if exists {
-			fields[v.StorageName] = v
+			fields[v.Key] = v
 		}
 	}
 
@@ -241,8 +241,8 @@ func (s *Storage) createView(storageName string, fields map[string]*model.Variab
 	// Build the select statement of the query.
 	fieldList := make([]string, 0)
 	for _, v := range fields {
-		fieldList = append(fieldList, s.getViewField(postgres.ValueForFieldType(v.Type, v.StorageName),
-			v.StorageName, postgres.MapD3MTypeToPostgresType(v.Type), postgres.DefaultPostgresValueFromD3MType(v.Type)))
+		fieldList = append(fieldList, s.getViewField(postgres.ValueForFieldType(v.Type, v.Key),
+			v.Key, postgres.MapD3MTypeToPostgresType(v.Type), postgres.DefaultPostgresValueFromD3MType(v.Type)))
 	}
 	sql = fmt.Sprintf(sql, storageName, strings.Join(fieldList, ","), storageName)
 
@@ -318,7 +318,7 @@ func (s *Storage) FetchDataset(dataset string, storageName string, invert bool, 
 	}
 	varNames := []string{}
 	for _, v := range filteredVars {
-		varNames = append(varNames, fmt.Sprintf("COALESCE(\"%s\", '') AS \"%s\"", v.StorageName, v.StorageName))
+		varNames = append(varNames, fmt.Sprintf("COALESCE(\"%s\", '') AS \"%s\"", v.Key, v.Key))
 	}
 	wheres := []string{}
 	paramsFilter := make([]interface{}, 0)
@@ -399,7 +399,7 @@ func (s *Storage) createViewFromMetadataFields(storageName string, fields map[st
 	// map the types to db types.
 	for field, v := range fields {
 		dbFields[field] = &model.Variable{
-			StorageName:      v.StorageName,
+			Key:              v.Key,
 			OriginalVariable: v.OriginalVariable,
 			Type:             v.Type,
 		}
@@ -414,7 +414,7 @@ func (s *Storage) createViewFromMetadataFields(storageName string, fields map[st
 }
 
 // AddVariable adds a new variable to the dataset.
-func (s *Storage) AddVariable(dataset string, storageName string, varName string, varType string, defaultVal string) error {
+func (s *Storage) AddVariable(dataset string, storageName string, key string, varType string, defaultVal string) error {
 	// check to make sure the column doesnt exist already
 	dbFields, err := s.getDatabaseFields(fmt.Sprintf("%s_base", storageName))
 	if err != nil {
@@ -423,7 +423,7 @@ func (s *Storage) AddVariable(dataset string, storageName string, varName string
 
 	found := false
 	for _, v := range dbFields {
-		if v == varName {
+		if v == key {
 			found = true
 			break
 		}
@@ -435,14 +435,14 @@ func (s *Storage) AddVariable(dataset string, storageName string, varName string
 			defaultClause = fmt.Sprintf(" Default '%s'", defaultVal)
 		}
 		// add the empty column to the base table and the explain table
-		sql := fmt.Sprintf("ALTER TABLE %s_base ADD COLUMN \"%s\" TEXT%s;", storageName, varName, defaultClause)
+		sql := fmt.Sprintf("ALTER TABLE %s_base ADD COLUMN \"%s\" TEXT%s;", storageName, key, defaultClause)
 
 		_, err = s.client.Exec(sql)
 		if err != nil {
 			return errors.Wrap(err, "unable to add new column to database table")
 		}
 
-		sql = fmt.Sprintf("ALTER TABLE %s_explain ADD COLUMN \"%s\" DOUBLE PRECISION;", storageName, varName)
+		sql = fmt.Sprintf("ALTER TABLE %s_explain ADD COLUMN \"%s\" DOUBLE PRECISION;", storageName, key)
 		_, err = s.client.Exec(sql)
 		if err != nil {
 			return errors.Wrap(err, "unable to add new column to database explain table")
@@ -456,9 +456,9 @@ func (s *Storage) AddVariable(dataset string, storageName string, varName string
 	}
 
 	// need to add the field to the view
-	fields[varName] = &model.Variable{
-		StorageName:      varName,
-		OriginalVariable: varName,
+	fields[key] = &model.Variable{
+		Key:              key,
+		OriginalVariable: key,
 		Type:             varType,
 	}
 

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -84,6 +84,7 @@ func (s *Storage) CloneDataset(dataset string, storageName string, datasetNew st
 
 	return nil
 }
+
 // DeleteDataset drops all tables associated to the dataset
 func (s *Storage) DeleteDataset(storageName string) error {
 	// drop view
@@ -113,7 +114,7 @@ func (s *Storage) DeleteDataset(storageName string) error {
 	}
 	return nil
 }
-func (s *Storage) dropView(view string) error{
+func (s *Storage) dropView(view string) error {
 	sql := fmt.Sprintf("DROP VIEW IF EXISTS %s", view)
 	_, err := s.client.Exec(sql)
 	if err != nil {
@@ -121,7 +122,7 @@ func (s *Storage) dropView(view string) error{
 	}
 	return nil
 }
-func (s *Storage) dropTable(table string) error{
+func (s *Storage) dropTable(table string) error {
 	sql := fmt.Sprintf("DROP TABLE IF EXISTS %s", table)
 	_, err := s.client.Exec(sql)
 	if err != nil {

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -417,8 +417,8 @@ func (f *DateTimeField) FetchPredictedSummaryData(resultURI string, datasetResul
 
 func (f *DateTimeField) fetchPredictedSummaryData(resultURI string, datasetResult string, filterParams *api.FilterParams, extrema *api.Extrema, numBuckets int) (*api.Histogram, error) {
 	resultVariable := &model.Variable{
-		StorageName: "value",
-		Type:        model.StringType,
+		Key:  "value",
+		Type: model.StringType,
 	}
 
 	// need the extrema to calculate the histogram interval
@@ -467,11 +467,11 @@ func (f *DateTimeField) fetchPredictedSummaryData(resultURI string, datasetResul
 
 func (f *DateTimeField) getResultMinMaxAggsQuery(resultVariable *model.Variable) string {
 	// get min / max agg names
-	minAggName := api.MinAggPrefix + resultVariable.StorageName
-	maxAggName := api.MaxAggPrefix + resultVariable.StorageName
+	minAggName := api.MinAggPrefix + resultVariable.Key
+	maxAggName := api.MaxAggPrefix + resultVariable.Key
 
 	// Only numeric types should occur.
-	fieldTyped := fmt.Sprintf("cast(\"%s\" as double precision)", resultVariable.StorageName)
+	fieldTyped := fmt.Sprintf("cast(\"%s\" as double precision)", resultVariable.Key)
 
 	// create aggregations
 	queryPart := fmt.Sprintf("MIN(%s) AS \"%s\", MAX(%s) AS \"%s\"", fieldTyped, minAggName, fieldTyped, maxAggName)
@@ -484,7 +484,7 @@ func (f *DateTimeField) getResultHistogramAggQuery(extrema *api.Extrema, resultV
 	interval := extrema.GetBucketInterval(numBuckets)
 
 	// Only numeric types should occur.
-	fieldTyped := fmt.Sprintf("cast(\"%s\" as double precision)", resultVariable.StorageName)
+	fieldTyped := fmt.Sprintf("cast(\"%s\" as double precision)", resultVariable.Key)
 
 	// get histogram agg name & query string.
 	histogramAggName := fmt.Sprintf("\"%s%s\"", api.HistogramAggPrefix, extrema.Key)

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -45,7 +45,7 @@ func SetRandomSeed(seed float64) {
 
 func getVariableByKey(key string, variables []*model.Variable) *model.Variable {
 	for _, variable := range variables {
-		if variable.StorageName == key {
+		if variable.Key == key {
 			return variable
 		}
 	}
@@ -231,7 +231,7 @@ func (s *Storage) getBivariateFilterKeys(dataset string, key string, alias strin
 
 	if model.IsGeoBounds(g.Type) {
 		// only checking top left for now
-		name := s.formatFilterKey(alias, g.StorageName)
+		name := s.formatFilterKey(alias, g.Key)
 		fields[0] = fmt.Sprintf("%s[1]", name)
 		fields[1] = fmt.Sprintf("%s[2]", name)
 		return fields, nil
@@ -389,8 +389,8 @@ func (s *Storage) buildSelectStatement(variables []*model.Variable, filterVariab
 	indexIncluded := false
 	for _, variable := range api.GetFilterVariables(filterVariables, variables) {
 		// derived metadata variables (ex: postgis geometry) should use the original variables
-		varName := variable.StorageName
-		if variable.DistilRole == model.VarDistilRoleMetadata && variable.OriginalVariable != variable.StorageName {
+		varName := variable.Key
+		if variable.DistilRole == model.VarDistilRoleMetadata && variable.OriginalVariable != variable.Key {
 			varName = variable.OriginalVariable
 		}
 
@@ -414,17 +414,17 @@ func (s *Storage) buildFilteredQueryField(variables []*model.Variable, filterVar
 	for _, variable := range api.GetFilterVariables(filterVariables, variables) {
 
 		if variable.DistilRole == model.VarDistilRoleGrouping {
-			distincts = append(distincts, fmt.Sprintf("DISTINCT ON (\"%s\")", variable.StorageName))
+			distincts = append(distincts, fmt.Sprintf("DISTINCT ON (\"%s\")", variable.Key))
 		}
 
 		// derived metadata variables (ex: postgis geometry) should use the original variables
-		varName := variable.StorageName
-		if variable.DistilRole == model.VarDistilRoleMetadata && variable.OriginalVariable != variable.StorageName {
-			varName = variable.OriginalVariable
+		varKey := variable.Key
+		if variable.DistilRole == model.VarDistilRoleMetadata && variable.OriginalVariable != variable.Key {
+			varKey = variable.OriginalVariable
 		}
 
-		fields = append(fields, fmt.Sprintf("\"%s\"", varName))
-		if varName == model.D3MIndexFieldName {
+		fields = append(fields, fmt.Sprintf("\"%s\"", varKey))
+		if varKey == model.D3MIndexFieldName {
 			indexIncluded = true
 		}
 
@@ -442,13 +442,13 @@ func (s *Storage) buildFilteredResultQueryField(variables []*model.Variable, tar
 	fields := make([]string, 0)
 	for _, variable := range api.GetFilterVariables(filterVariables, variables) {
 
-		if strings.Compare(targetVariable.StorageName, variable.StorageName) != 0 {
+		if strings.Compare(targetVariable.Key, variable.Key) != 0 {
 
 			if variable.DistilRole == model.VarDistilRoleGrouping {
-				distincts = append(distincts, fmt.Sprintf("DISTINCT ON (\"%s\")", variable.StorageName))
+				distincts = append(distincts, fmt.Sprintf("DISTINCT ON (\"%s\")", variable.Key))
 			}
 
-			fields = append(fields, fmt.Sprintf("\"%s\"", variable.StorageName))
+			fields = append(fields, fmt.Sprintf("\"%s\"", variable.Key))
 		}
 	}
 	fields = append(fields, fmt.Sprintf("\"%s\"", model.D3MIndexFieldName))
@@ -499,7 +499,7 @@ func (s *Storage) buildErrorResultWhere(wheres []string, params []interface{}, r
 		return nil, nil, err
 	}
 
-	typedError := getErrorTyped("", targetVariable.StorageName)
+	typedError := getErrorTyped("", targetVariable.Key)
 
 	where := fmt.Sprintf("(%s >= $%d AND %s <= $%d)", typedError, len(params)+1, typedError, len(params)+2)
 	params = append(params, *residualFilter.Min)

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -456,8 +456,8 @@ func (f *NumericalField) FetchPredictedSummaryData(resultURI string, datasetResu
 
 func (f *NumericalField) fetchPredictedSummaryData(resultURI string, datasetResult string, filterParams *api.FilterParams, extrema *api.Extrema, numBuckets int) (*api.Histogram, error) {
 	resultVariable := &model.Variable{
-		StorageName: "value",
-		Type:        model.StringType,
+		Key:  "value",
+		Type: model.StringType,
 	}
 
 	// need the extrema to calculate the histogram interval
@@ -483,7 +483,7 @@ func (f *NumericalField) fetchPredictedSummaryData(resultURI string, datasetResu
 
 	wheres = append(wheres, fmt.Sprintf("result.result_id = $%d AND result.target = $%d ", len(params)+1, len(params)+2))
 	params = append(params, resultURI, f.Key)
-	wheres = append(wheres, fmt.Sprintf("%s != ''", resultVariable.StorageName))
+	wheres = append(wheres, fmt.Sprintf("%s != ''", resultVariable.Key))
 
 	// Create the complete query string.
 	query := fmt.Sprintf(`
@@ -507,11 +507,11 @@ func (f *NumericalField) fetchPredictedSummaryData(resultURI string, datasetResu
 
 func (f *NumericalField) getResultMinMaxAggsQuery(resultVariable *model.Variable) string {
 	// get min / max agg names
-	minAggName := api.MinAggPrefix + resultVariable.StorageName
-	maxAggName := api.MaxAggPrefix + resultVariable.StorageName
+	minAggName := api.MinAggPrefix + resultVariable.Key
+	maxAggName := api.MaxAggPrefix + resultVariable.Key
 
 	// Only numeric types should occur.
-	fieldTyped := fmt.Sprintf("CAST(CASE WHEN \"%s\" = '' THEN 'NaN' ELSE \"%s\" END as double precision)", resultVariable.StorageName, resultVariable.StorageName)
+	fieldTyped := fmt.Sprintf("CAST(CASE WHEN \"%s\" = '' THEN 'NaN' ELSE \"%s\" END as double precision)", resultVariable.Key, resultVariable.Key)
 
 	// create aggregations
 	queryPart := fmt.Sprintf("MIN(%s) AS \"%s\", MAX(%s) AS \"%s\"", fieldTyped, minAggName, fieldTyped, maxAggName)
@@ -525,7 +525,7 @@ func (f *NumericalField) getResultHistogramAggQuery(extrema *api.Extrema, result
 	interval := extrema.GetBucketInterval(numBuckets)
 
 	// Only numeric types should occur.
-	fieldTyped := fmt.Sprintf("CAST(CASE WHEN \"%s\" = '' THEN 'NaN' ELSE \"%s\" END as double precision)", resultVariable.StorageName, resultVariable.StorageName)
+	fieldTyped := fmt.Sprintf("CAST(CASE WHEN \"%s\" = '' THEN 'NaN' ELSE \"%s\" END as double precision)", resultVariable.Key, resultVariable.Key)
 
 	// get histogram agg name & query string.
 	histogramAggName := fmt.Sprintf("\"%s%s\"", api.HistogramAggPrefix, extrema.Key)
@@ -550,7 +550,7 @@ func (f *NumericalField) fetchResultsExtrema(resultURI string, dataset string, r
 	aggQuery := f.getResultMinMaxAggsQuery(resultVariable)
 
 	// create a query that does min and max aggregations for each variable
-	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE result_id = $1 AND target = $2 AND %s != '';", aggQuery, dataset, resultVariable.StorageName)
+	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE result_id = $1 AND target = $2 AND %s != '';", aggQuery, dataset, resultVariable.Key)
 
 	// execute the postgres query
 	res, err := f.Storage.client.Query(queryString, resultURI, f.Key)

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -108,7 +108,7 @@ func (s *Storage) PersistSolutionFeatureWeight(dataset string, storageName strin
 	fields := []string{"result_id"}
 	for _, dbField := range fieldsDatabase {
 		for i := 0; i < len(fieldsWeight); i++ {
-			if fieldsMetadataMap[dbField] != nil && fieldsMetadataMap[dbField].StorageName == fieldsWeight[i] {
+			if fieldsMetadataMap[dbField] != nil && fieldsMetadataMap[dbField].Key == fieldsWeight[i] {
 				// before we append the field, the length will give us the index for the field we will append
 				fieldsMap[i] = len(fields)
 				fields = append(fields, dbField)
@@ -272,7 +272,7 @@ func (s *Storage) PersistResult(dataset string, storageName string, resultURI st
 	}
 
 	// Translate from display name to storage name.
-	targetDisplayName, err := s.getDisplayName(dataset, targetVariable.StorageName)
+	targetDisplayName, err := s.getDisplayName(dataset, targetVariable.Key)
 	if err != nil {
 		return errors.Wrap(err, "unable to map target name")
 	}
@@ -319,7 +319,7 @@ func (s *Storage) PersistResult(dataset string, storageName string, resultURI st
 		}
 		indicesParsed[parsedVal] = true
 
-		dataForInsert := []interface{}{resultURI, parsedVal, targetVariable.StorageName, records[i][targetIndex]}
+		dataForInsert := []interface{}{resultURI, parsedVal, targetVariable.Key, records[i][targetIndex]}
 		explainValues, err := s.parseExplainValues(records[i], confidenceIndex, rankIndex)
 		if err != nil {
 			return err
@@ -405,7 +405,7 @@ func (s *Storage) parseFilteredResults(variables []*model.Variable, rows pgx.Row
 						explainCol = i
 						continue
 					} else {
-						if key == target.StorageName {
+						if key == target.Key {
 							typ = target.Type
 						} else {
 							v := getVariableByKey(key, variables)
@@ -490,7 +490,7 @@ func addIncludeCorrectnessFilterToWhere(wheres []string, params []interface{}, c
 	} else if strings.EqualFold(correctnessFilter.Categories[0], IncorrectCategory) {
 		op = "!="
 	}
-	where = fmt.Sprintf("predicted.value %s data.\"%s\"", op, target.StorageName)
+	where = fmt.Sprintf("predicted.value %s data.\"%s\"", op, target.Key)
 	wheres = append(wheres, where)
 	return wheres, params, nil
 }
@@ -507,7 +507,7 @@ func addExcludeCorrectnessFilterToWhere(wheres []string, params []interface{}, c
 	} else if strings.EqualFold(correctnessFilter.Categories[0], IncorrectCategory) {
 		op = "="
 	}
-	where = fmt.Sprintf("predicted.value %s data.\"%s\"", op, target.StorageName)
+	where = fmt.Sprintf("predicted.value %s data.\"%s\"", op, target.Key)
 	wheres = append(wheres, where)
 	return wheres, params, nil
 }
@@ -795,7 +795,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 		errorCol := api.GetErrorKey(id)
 		errorExpr := ""
 		if model.IsNumerical(variable.Type) && !predictionResultMode {
-			errorExpr = fmt.Sprintf("%s as \"%s\",", getErrorTyped(dataTableAlias, variable.StorageName), errorCol)
+			errorExpr = fmt.Sprintf("%s as \"%s\",", getErrorTyped(dataTableAlias, variable.Key), errorCol)
 		}
 
 		targetColumnQuery := ""
@@ -872,7 +872,7 @@ func (s *Storage) getAverageWeights(dataset string, storageName string, storageN
 	variablesSQL := []string{}
 	for _, v := range variables {
 		if model.IsTA2Field(v.DistilRole, v.SelectedRole) {
-			variablesSQL = append(variablesSQL, fmt.Sprintf("AVG(weights.\"%s\") as \"%s\"", v.StorageName, v.StorageName))
+			variablesSQL = append(variablesSQL, fmt.Sprintf("AVG(weights.\"%s\") as \"%s\"", v.Key, v.Key))
 		}
 	}
 
@@ -906,11 +906,11 @@ func (s *Storage) FetchResultsExtremaByURI(dataset string, storageName string, r
 		return nil, err
 	}
 	resultVariable := &model.Variable{
-		StorageName: "value",
-		Type:        model.StringType,
+		Key:  "value",
+		Type: model.StringType,
 	}
 
-	field := NewNumericalField(s, dataset, storageName, targetVariable.StorageName, targetVariable.DisplayName, targetVariable.Type, "")
+	field := NewNumericalField(s, dataset, storageName, targetVariable.Key, targetVariable.DisplayName, targetVariable.Type, "")
 	return field.fetchResultsExtrema(resultURI, storageNameResult, resultVariable)
 }
 
@@ -937,13 +937,13 @@ func (s *Storage) FetchPredictedSummary(dataset string, storageName string, resu
 	// use the variable type to guide the summary creation
 	var field Field
 	if model.IsNumerical(variable.Type) {
-		field = NewNumericalField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type, countCol)
+		field = NewNumericalField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type, countCol)
 	} else if model.IsCategorical(variable.Type) {
-		field = NewCategoricalField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type, countCol)
+		field = NewCategoricalField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type, countCol)
 	} else if model.IsVector(variable.Type) {
-		field = NewVectorField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type)
+		field = NewVectorField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type)
 	} else {
-		return nil, errors.Errorf("variable %s of type %s does not support summary", variable.StorageName, variable.Type)
+		return nil, errors.Errorf("variable %s of type %s does not support summary", variable.Key, variable.Type)
 	}
 
 	summary, err := field.FetchPredictedSummaryData(resultURI, storageNameResult, filterParams, extrema, mode)
@@ -980,7 +980,7 @@ func (s *Storage) getIsWeighted(resultURI string, weightTableName string) (bool,
 	return bool(values[0].(bool)), nil
 }
 
-func (s *Storage) getDisplayName(dataset string, columnName string) (string, error) {
+func (s *Storage) getDisplayName(dataset string, key string) (string, error) {
 	displayName := ""
 	variables, err := s.metadata.FetchVariables(dataset, false, false, false)
 	if err != nil {
@@ -988,7 +988,7 @@ func (s *Storage) getDisplayName(dataset string, columnName string) (string, err
 	}
 
 	for _, v := range variables {
-		if v.StorageName == columnName {
+		if v.Key == key {
 			displayName = v.DisplayName
 		}
 	}
@@ -999,7 +999,7 @@ func (s *Storage) getDisplayName(dataset string, columnName string) (string, err
 func mapFields(fields []*model.Variable) map[string]*model.Variable {
 	mapped := make(map[string]*model.Variable)
 	for _, f := range fields {
-		mapped[f.StorageName] = f
+		mapped[f.Key] = f
 	}
 
 	return mapped
@@ -1009,7 +1009,7 @@ func isTimeSeriesValue(variables []*model.Variable, targetVariable *model.Variab
 	for _, v := range variables {
 		if v.IsGrouping() && model.IsTimeSeries(v.Grouping.GetType()) {
 			tsg := v.Grouping.(*model.TimeseriesGrouping)
-			if tsg.YCol == targetVariable.StorageName {
+			if tsg.YCol == targetVariable.Key {
 				return true
 			}
 		}

--- a/api/model/storage/postgres/storage.go
+++ b/api/model/storage/postgres/storage.go
@@ -127,9 +127,9 @@ func (s *Storage) isColumnType(tableName string, variable *model.Variable, colTy
 		return false
 	}
 	// generate view query
-	viewQuery := fmt.Sprintf("CREATE TEMPORARY VIEW temp_view_%[1]s AS SELECT \"%[1]s\"::%[3]s FROM %[2]s", variable.StorageName, tableName, colType)
+	viewQuery := fmt.Sprintf("CREATE TEMPORARY VIEW temp_view_%[1]s AS SELECT \"%[1]s\"::%[3]s FROM %[2]s", variable.Key, tableName, colType)
 	// test query
-	testQuery := fmt.Sprintf("SELECT COUNT(\"%[1]s\") FROM temp_view_%[1]s", variable.StorageName)
+	testQuery := fmt.Sprintf("SELECT COUNT(\"%[1]s\") FROM temp_view_%[1]s", variable.Key)
 
 	// create transaction
 	tx, err := s.client.Begin()

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -50,7 +50,7 @@ func (s *Storage) parseExtrema(row pgx.Rows, variable *model.Variable) (*api.Ext
 	}
 	// assign attributes
 	return &api.Extrema{
-		Key:  variable.StorageName,
+		Key:  variable.Key,
 		Type: variable.Type,
 		Min:  *minValue,
 		Max:  *maxValue,
@@ -77,7 +77,7 @@ func (s *Storage) parseDateExtrema(row pgx.Rows, variable *model.Variable) (*api
 	}
 	// assign attributes
 	return &api.Extrema{
-		Key:  variable.StorageName,
+		Key:  variable.Key,
 		Type: variable.Type,
 		Min:  float64(*minValue),
 		Max:  float64(*maxValue),
@@ -103,12 +103,12 @@ func (s *Storage) getMinMaxAggsQuery(variableName string, variableType string) s
 // FetchExtrema return extrema of a variable in a result set.
 func (s *Storage) FetchExtrema(storageName string, variable *model.Variable) (*api.Extrema, error) {
 	// add min / max aggregation
-	aggQuery := s.getMinMaxAggsQuery(variable.StorageName, variable.Type)
+	aggQuery := s.getMinMaxAggsQuery(variable.Key, variable.Type)
 
 	// numerical columns need to filter NaN out
 	filter := ""
 	if model.IsNumerical(variable.Type) {
-		filter = fmt.Sprintf("WHERE \"%s\" != 'NaN'", variable.StorageName)
+		filter = fmt.Sprintf("WHERE \"%s\" != 'NaN'", variable.Key)
 	}
 
 	// create a query that does min and max aggregations for each variable
@@ -132,17 +132,17 @@ func (s *Storage) FetchExtrema(storageName string, variable *model.Variable) (*a
 }
 
 func (s *Storage) fetchExtremaByURI(storageName string, resultURI string, variable *model.Variable) (*api.Extrema, error) {
-	varName := variable.StorageName
+	varKey := variable.Key
 	if variable.IsGrouping() && model.IsTimeSeries(variable.Grouping.GetType()) {
 		tsg := variable.Grouping.(*model.TimeseriesGrouping)
-		varName = tsg.YCol
+		varKey = tsg.YCol
 	} else if variable.IsGrouping() && model.IsGeoCoordinate(variable.Grouping.GetType()) {
 		gcg := variable.Grouping.(*model.GeoCoordinateGrouping)
-		varName = gcg.YCol
+		varKey = gcg.YCol
 	}
 
 	// add min / max aggregation
-	aggQuery := s.getMinMaxAggsQuery(varName, variable.Type)
+	aggQuery := s.getMinMaxAggsQuery(varKey, variable.Type)
 
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s data INNER JOIN %s result ON data.\"%s\" = result.index WHERE result.result_id = $1;",
@@ -196,17 +196,17 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 				return nil, errors.Wrap(err, "failed to fetch variable description for summary")
 			}
 
-			field = NewTimeSeriesField(s, dataset, storageName, tsg.ClusterCol, variable.StorageName, variable.DisplayName, variable.Type,
-				variable.Grouping.GetIDCol(), timeColVar.StorageName, timeColVar.Type, valueColVar.StorageName, valueColVar.Type)
+			field = NewTimeSeriesField(s, dataset, storageName, tsg.ClusterCol, variable.Key, variable.DisplayName, variable.Type,
+				variable.Grouping.GetIDCol(), timeColVar.Key, timeColVar.Type, valueColVar.Key, valueColVar.Type)
 		} else if model.IsGeoCoordinate(variable.Grouping.GetType()) {
 			gcg := variable.Grouping.(*model.GeoCoordinateGrouping)
-			field = NewCoordinateField(variable.StorageName, s, dataset, storageName, gcg.XCol, gcg.YCol, variable.DisplayName, variable.Grouping.GetType(), "")
+			field = NewCoordinateField(variable.Key, s, dataset, storageName, gcg.XCol, gcg.YCol, variable.DisplayName, variable.Grouping.GetType(), "")
 		} else if model.IsMultiBandImage(variable.Grouping.GetType()) {
 			rsg := variable.Grouping.(*model.MultiBandImageGrouping)
-			field = NewMultiBandImageField(s, dataset, storageName, rsg.ClusterCol, variable.StorageName, variable.DisplayName, variable.Grouping.GetType(), rsg.IDCol, rsg.BandCol)
+			field = NewMultiBandImageField(s, dataset, storageName, rsg.ClusterCol, variable.Key, variable.DisplayName, variable.Grouping.GetType(), rsg.IDCol, rsg.BandCol)
 		} else if model.IsGeoBounds(variable.Type) {
 			gbg := variable.Grouping.(*model.GeoBoundsGrouping)
-			field = NewBoundsField(s, dataset, storageName, gbg.CoordinatesCol, gbg.PolygonCol, variable.StorageName, variable.DisplayName, variable.Grouping.GetType(), "")
+			field = NewBoundsField(s, dataset, storageName, gbg.CoordinatesCol, gbg.PolygonCol, variable.Key, variable.DisplayName, variable.Grouping.GetType(), "")
 		} else {
 			return nil, errors.Errorf("variable grouping `%s` of type `%s` does not support summary", variable.Grouping.GetIDCol(), variable.Grouping.GetType())
 		}
@@ -226,19 +226,19 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 		}
 
 		if model.IsNumerical(variable.Type) || model.IsTimestamp(variable.Type) {
-			field = NewNumericalField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type, countCol)
+			field = NewNumericalField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type, countCol)
 		} else if model.IsCategorical(variable.Type) {
-			field = NewCategoricalField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type, countCol)
+			field = NewCategoricalField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type, countCol)
 		} else if model.IsVector(variable.Type) || model.IsList(variable.Type) {
-			field = NewVectorField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type)
+			field = NewVectorField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type)
 		} else if model.IsText(variable.Type) {
-			field = NewTextField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type, countCol)
+			field = NewTextField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type, countCol)
 		} else if model.IsImage(variable.Type) {
-			field = NewImageField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type, countCol)
+			field = NewImageField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type, countCol)
 		} else if model.IsDateTime(variable.Type) {
-			field = NewDateTimeField(s, dataset, storageName, variable.StorageName, variable.DisplayName, variable.Type, countCol)
+			field = NewDateTimeField(s, dataset, storageName, variable.Key, variable.DisplayName, variable.Type, countCol)
 		} else {
-			return nil, errors.Errorf("variable `%s` of type `%s` does not support summary", variable.StorageName, variable.Type)
+			return nil, errors.Errorf("variable `%s` of type `%s` does not support summary", variable.Key, variable.Type)
 		}
 	}
 
@@ -276,14 +276,14 @@ func (s *Storage) FetchSummaryByResult(dataset string, storageName string, varNa
 // FetchCategoryCounts fetches the count of each label that occurs for the supplied categorical variable.
 func (s *Storage) FetchCategoryCounts(storageName string, variable *model.Variable) (map[string]int, error) {
 	if !model.IsCategorical(variable.Type) {
-		return nil, errors.Errorf("supplied variable %s is of type %s", variable.StorageName, variable.Type)
+		return nil, errors.Errorf("supplied variable %s is of type %s", variable.Key, variable.Type)
 	}
 
 	// Run a query to count the categories in the given row
-	query := fmt.Sprintf("SELECT \"%s\", COUNT(\"%s\") FROM %s GROUP BY \"%s\"", variable.StorageName, variable.StorageName, storageName, variable.StorageName)
+	query := fmt.Sprintf("SELECT \"%s\", COUNT(\"%s\") FROM %s GROUP BY \"%s\"", variable.Key, variable.Key, storageName, variable.Key)
 	rows, err := s.client.Query(query)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to count categories for %s", variable.StorageName)
+		return nil, errors.Wrapf(err, "failed to count categories for %s", variable.Key)
 	}
 
 	// Exract into a (category,count) map

--- a/api/postgres/dataset.go
+++ b/api/postgres/dataset.go
@@ -55,7 +55,7 @@ func NewDataset(id, name, description string, variables []*model.Variable, prima
 		ds.Variables = variables
 		fields := []string{}
 		for _, v := range ds.Variables {
-			fields = append(fields, v.StorageName)
+			fields = append(fields, v.Key)
 		}
 		ds.fieldSQL = fmt.Sprintf("\"%s\"", strings.Join(fields, "\",\""))
 	}
@@ -73,13 +73,13 @@ func (ds *Dataset) ResetBatch() {
 
 // HasVariable checks to see if a variable is already contained in the dataset.
 func (ds *Dataset) HasVariable(variable *model.Variable) bool {
-	return ds.variablesLookup[variable.StorageName]
+	return ds.variablesLookup[variable.Key]
 }
 
 // AddVariable adds a variable to the dataset.
 func (ds *Dataset) AddVariable(variable *model.Variable) {
 	ds.Variables = append(ds.Variables, variable)
-	ds.variablesLookup[variable.StorageName] = true
+	ds.variablesLookup[variable.Key] = true
 }
 
 // AddInsert adds an insert statement and parameters to the batch.
@@ -96,7 +96,7 @@ func (ds *Dataset) AddInsertFromSource(values []interface{}) {
 func (ds *Dataset) GetColumns() []string {
 	columns := make([]string, len(ds.Variables))
 	for i, v := range ds.Variables {
-		columns[i] = v.StorageName
+		columns[i] = v.Key
 	}
 
 	return columns
@@ -126,10 +126,10 @@ func (ds *Dataset) createTableSQL(tableName string, temp bool, typeAll bool, typ
 	fieldsSQL := []string{}
 	for _, v := range ds.Variables {
 		typ := "TEXT"
-		if typeAll || (typeMap != nil && typeMap[v.StorageName]) {
+		if typeAll || (typeMap != nil && typeMap[v.Key]) {
 			typ = MapD3MTypeToPostgresType(v.Type)
 		}
-		fieldsSQL = append(fieldsSQL, fmt.Sprintf("\"%s\" %s", v.StorageName, typ))
+		fieldsSQL = append(fieldsSQL, fmt.Sprintf("\"%s\" %s", v.Key, typ))
 	}
 
 	tempString := ""

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -220,7 +220,7 @@ func NewDatabase(config *Config, batch bool) (*Database, error) {
 	}
 
 	database.Tables[WordStemTableName] = NewDataset(WordStemTableName, WordStemTableName, "",
-		[]*model.Variable{{StorageName: "stem"}, {StorageName: "word"}}, "stem")
+		[]*model.Variable{{Key: "stem"}, {Key: "word"}}, "stem")
 	database.Tables[WordStemTableName].insertFunction = insertFromSourceUnique
 
 	return database, nil
@@ -371,10 +371,10 @@ func insertFromSourceGeometry(d *Database, tableName string, ds *Dataset) error 
 	fields := []string{}
 	for _, v := range ds.Variables {
 		typ := dataTypeText
-		if v.StorageName == model.D3MIndexFieldName || v.Type == model.GeoBoundsType {
+		if v.Key == model.D3MIndexFieldName || v.Type == model.GeoBoundsType {
 			typ = MapD3MTypeToPostgresType(v.Type)
 		}
-		fields = append(fields, fmt.Sprintf("\"%s\"::%s", v.StorageName, typ))
+		fields = append(fields, fmt.Sprintf("\"%s\"::%s", v.Key, typ))
 	}
 	fieldSQL := strings.Join(fields, ",")
 	updateSQL := fmt.Sprintf("INSERT INTO \"%s_base\" SELECT %s FROM \"%s\";", tableName, fieldSQL, tmpTableName)
@@ -457,7 +457,7 @@ func (d *Database) StoreMetadata(tableName string) error {
 	// Insert the variable metadata into the new table.
 	for _, v := range d.Tables[tableName].Variables {
 		insertStatement := fmt.Sprintf("INSERT INTO %s (name, role, type) VALUES ($1, $2, $3);", variableTableName)
-		values := []interface{}{v.StorageName, v.DistilRole, v.Type}
+		values := []interface{}{v.Key, v.DistilRole, v.Type}
 		_, err = d.Client.Exec(insertStatement, values...)
 		if err != nil {
 			return errors.Wrapf(err, "unable to store variable in postgres")
@@ -605,14 +605,14 @@ func (d *Database) InitializeTable(tableName string, ds *Dataset) error {
 	varsExplain := ""
 	for _, variable := range ds.Variables {
 		tableType := dataTypeText
-		viewVar := fmt.Sprintf("COALESCE(CAST(%s AS %s), %v) AS \"%s\"", ValueForFieldType(variable.Type, variable.StorageName),
-			MapD3MTypeToPostgresType(variable.Type), DefaultPostgresValueFromD3MType(variable.Type), variable.StorageName)
+		viewVar := fmt.Sprintf("COALESCE(CAST(%s AS %s), %v) AS \"%s\"", ValueForFieldType(variable.Type, variable.Key),
+			MapD3MTypeToPostgresType(variable.Type), DefaultPostgresValueFromD3MType(variable.Type), variable.Key)
 		if variable.Type == model.GeoBoundsType {
 			tableType = "geometry"
-			viewVar = fmt.Sprintf("\"%s\"", variable.StorageName)
+			viewVar = fmt.Sprintf("\"%s\"", variable.Key)
 		}
-		varsTable = fmt.Sprintf("%s\n\"%s\" %s,", varsTable, variable.StorageName, tableType)
-		varsExplain = fmt.Sprintf("%s\n\"%s\" DOUBLE PRECISION,", varsExplain, variable.StorageName)
+		varsTable = fmt.Sprintf("%s\n\"%s\" %s,", varsTable, variable.Key, tableType)
+		varsExplain = fmt.Sprintf("%s\n\"%s\" DOUBLE PRECISION,", varsExplain, variable.Key)
 		varsView = fmt.Sprintf("%s\n%s,", varsView, viewVar)
 	}
 	if len(varsTable) > 0 {

--- a/api/routes/delete_dataset.go
+++ b/api/routes/delete_dataset.go
@@ -1,15 +1,15 @@
-
 package routes
 
 import (
 	"github.com/uncharted-distil/distil/api/util"
 	"net/http"
 
-	"goji.io/v3/pat"
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
+	"goji.io/v3/pat"
 )
+
 // DeletingDatasetHandler attempts to delete mutable datasets
 func DeletingDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -33,7 +33,7 @@ func DeletingDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataS
 			return
 		}
 		folder := env.ResolvePath(ds.Source, ds.Folder)
-		// verify dataset is a clone	
+		// verify dataset is a clone
 		if ds.Immutable {
 			handleError(w, errors.New("cannot delete Immutable dataset"))
 			return

--- a/api/routes/geocoding.go
+++ b/api/routes/geocoding.go
@@ -41,7 +41,7 @@ func GeocodingHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 		// get dataset name
 		dataset := pat.Param(r, "dataset")
 		// get variable name
-		varName := pat.Param(r, "variable")
+		varKey := pat.Param(r, "variable")
 
 		// get storage clients
 		metaStorage, err := metaCtor()
@@ -62,8 +62,8 @@ func GeocodingHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 		}
 		storageName := ds.StorageName
 
-		latVarName := fmt.Sprintf("_lat_%s", varName)
-		lonVarName := fmt.Sprintf("_lon_%s", varName)
+		latVarName := fmt.Sprintf("_lat_%s", varKey)
+		lonVarName := fmt.Sprintf("_lon_%s", varKey)
 
 		// check if the lat and lon variables exist
 		latVarExist, err := metaStorage.DoesVariableExist(dataset, latVarName)
@@ -114,7 +114,7 @@ func GeocodingHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 		// get the variable to geocode
 		var variable *model.Variable
 		for _, v := range datasetMeta.Variables {
-			if v.StorageName == varName {
+			if v.Key == varKey {
 				variable = v
 			}
 		}

--- a/api/routes/join_suggestion.go
+++ b/api/routes/join_suggestion.go
@@ -133,7 +133,7 @@ func JoinSuggestionHandler(esCtor model.MetadataStorageCtor, metaCtors map[strin
 						var localColNameTokens []string
 						for _, token := range colNameTokens {
 							// displayName holds the column name of the original datamart dataset
-							localColNameTokens = append(localColNameTokens, getColNameByDisplayName(localDataset, token))
+							localColNameTokens = append(localColNameTokens, getColKeyByDisplayName(localDataset, token))
 						}
 						localColName := strings.Join(localColNameTokens, ", ")
 						suggestion.JoinColumns[j] = localColName
@@ -168,10 +168,10 @@ func JoinSuggestionHandler(esCtor model.MetadataStorageCtor, metaCtors map[strin
 	}
 }
 
-func getColNameByDisplayName(dataset model.Dataset, colDisplayName string) string {
+func getColKeyByDisplayName(dataset model.Dataset, colDisplayName string) string {
 	for _, variable := range dataset.Variables {
 		if variable.DisplayName == colDisplayName {
-			return variable.StorageName
+			return variable.Key
 		}
 	}
 	return compute.NormalizeVariableName(colDisplayName) // fallback

--- a/api/routes/solution_variable_rankings.go
+++ b/api/routes/solution_variable_rankings.go
@@ -81,11 +81,11 @@ func SolutionVariableRankingHandler(metaCtor api.MetadataStorageCtor, solutionCt
 
 		res := make(map[string]interface{})
 		for _, variable := range dataset.Variables {
-			rank, ok := rankings[variable.StorageName]
+			rank, ok := rankings[variable.Key]
 			if ok {
-				res[variable.StorageName] = rank
+				res[variable.Key] = rank
 			} else {
-				res[variable.StorageName] = nil
+				res[variable.Key] = nil
 			}
 		}
 

--- a/api/routes/variable_rankings.go
+++ b/api/routes/variable_rankings.go
@@ -64,11 +64,11 @@ func VariableRankingHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.S
 
 		res := make(map[string]interface{})
 		for _, variable := range d.Variables {
-			rank, ok := rankings[variable.StorageName]
+			rank, ok := rankings[variable.Key]
 			if ok {
-				res[variable.StorageName] = rank
+				res[variable.Key] = rank
 			} else {
-				res[variable.StorageName] = nil
+				res[variable.Key] = nil
 			}
 		}
 

--- a/api/routes/variables.go
+++ b/api/routes/variables.go
@@ -67,7 +67,7 @@ func VariablesHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 			if model.IsNumerical(v.Type) || model.IsDateTime(v.Type) {
 				extrema, err := data.FetchExtrema(storageName, v)
 				if err != nil {
-					log.Warnf("defaulting extrema values due to error fetching extrema for '%s': %+v", v.StorageName, err)
+					log.Warnf("defaulting extrema values due to error fetching extrema for '%s': %+v", v.Key, err)
 					extrema = getDefaultExtrema(v)
 				}
 				v.Min = extrema.Min

--- a/api/serialization/csv.go
+++ b/api/serialization/csv.go
@@ -213,7 +213,7 @@ func (d *CSV) writeVariable(variable *model.Variable, extended bool) interface{}
 		output[model.VarSelectedRoleField] = variable.SelectedRole
 		output[model.VarDistilRole] = variable.DistilRole
 		output[model.VarOriginalVariableField] = variable.OriginalVariable
-		output[model.VarStorageNameField] = variable.StorageName
+		output[model.VarKeyField] = variable.Key
 		output[model.VarDisplayVariableField] = variable.DisplayName
 		output[model.VarImportanceField] = variable.Importance
 		output[model.VarSuggestedTypesField] = variable.SuggestedTypes

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -338,7 +338,7 @@ func (d *Parquet) writeVariable(variable *model.Variable, extended bool) interfa
 		output[model.VarSelectedRoleField] = variable.SelectedRole
 		output[model.VarDistilRole] = variable.DistilRole
 		output[model.VarOriginalVariableField] = variable.OriginalVariable
-		output[model.VarStorageNameField] = variable.StorageName
+		output[model.VarKeyField] = variable.Key
 		output[model.VarDisplayVariableField] = variable.DisplayName
 		output[model.VarImportanceField] = variable.Importance
 		output[model.VarSuggestedTypesField] = variable.SuggestedTypes

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -110,14 +110,14 @@ func Cluster(dataset *api.Dataset, variable string, useKMeans bool) (bool, []*Cl
 	// needed for full set clustering
 	var clusteringVar *model.Variable
 	for _, v := range features {
-		if v.StorageName == variable {
+		if v.Key == variable {
 			clusteringVar = v
 		}
 	}
 
 	var step *description.FullySpecifiedPipeline
 	var err error
-	clusterGroup := getClusterGroup(clusteringVar.StorageName, features)
+	clusterGroup := getClusterGroup(clusteringVar.Key, features)
 	if model.IsImage(clusteringVar.Type) {
 		step, err = description.CreateImageClusteringPipeline("image_cluster", "basic image clustering", []*model.Variable{clusteringVar}, useKMeans)
 	} else if clusterGroup != nil && model.IsMultiBandImage(clusterGroup.GetType()) {
@@ -152,7 +152,7 @@ func Cluster(dataset *api.Dataset, variable string, useKMeans bool) (bool, []*Cl
 		// general clustering pipeline
 		selectedFeatures := make([]string, len(features))
 		for i, f := range features {
-			selectedFeatures[i] = f.StorageName
+			selectedFeatures[i] = f.Key
 		}
 		datasetDescription := &description.UserDatasetDescription{
 			AllFeatures:      features,

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -147,7 +147,7 @@ func UpdateExtremas(dataset string, metaStorage api.MetadataStorage, dataStorage
 	}
 
 	for _, v := range d.Variables {
-		err = api.UpdateExtremas(dataset, v.StorageName, metaStorage, dataStorage)
+		err = api.UpdateExtremas(dataset, v.Key, metaStorage, dataStorage)
 		if err != nil {
 			return err
 		}

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -116,7 +116,7 @@ func checkD3MIndexExists(meta *model.Metadata) bool {
 	// check all variables for a d3m index
 	for _, dr := range meta.DataResources {
 		for _, v := range dr.Variables {
-			if v.StorageName == model.D3MIndexFieldName {
+			if v.Key == model.D3MIndexFieldName {
 				return true
 			}
 		}

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -175,7 +175,7 @@ func GeocodeForward(datasetInputDir string, dataset string, variable *model.Vari
 
 		geocodedData[i] = &GeocodedPoint{
 			D3MIndex:    d3mIndex,
-			SourceField: variable.StorageName,
+			SourceField: variable.Key,
 			Latitude:    lat,
 			Longitude:   lon,
 		}

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -631,7 +631,7 @@ func matchDataset(storage api.MetadataStorage, meta *model.Metadata) (string, er
 		}
 		variables := make([]string, 0)
 		for _, v := range dataset.Variables {
-			variables = append(variables, v.StorageName)
+			variables = append(variables, v.Key)
 		}
 		if metadata.DatasetMatches(meta, variables) {
 			return dataset.Name, nil
@@ -677,13 +677,13 @@ func getUniqueDatasetName(meta *model.Metadata, storage api.MetadataStorage) (st
 
 func createIndices(pg *postgres.Database, datasetID string, fields []string, meta *model.Metadata, config *IngestTaskConfig) error {
 	// build variable lookup
-	mappedVariables := mapVariables(meta.GetMainDataResource().Variables, func(variable *model.Variable) string { return variable.StorageName })
+	mappedVariables := mapVariables(meta.GetMainDataResource().Variables, func(variable *model.Variable) string { return variable.Key })
 
 	// create indices for flagged fields
 	for _, fieldName := range fields {
 		field := mappedVariables[fieldName]
-		log.Infof("creating index on %s", field.StorageName)
-		err := pg.CreateIndex(fmt.Sprintf("%s%s", meta.StorageName, baseTableSuffix), field.StorageName, field.Type)
+		log.Infof("creating index on %s", field.Key)
+		err := pg.CreateIndex(fmt.Sprintf("%s%s", meta.StorageName, baseTableSuffix), field.Key, field.Type)
 		if err != nil {
 			return err
 		}

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -117,11 +117,11 @@ func createVarMap(vars []*model.Variable, useDisplayName bool, keepOnlyDataVars 
 		if !model.IsTA2Field(v.DistilRole, v.SelectedRole) && keepOnlyDataVars {
 			continue
 		}
-		name := v.StorageName
+		key := v.Key
 		if useDisplayName {
-			name = v.DisplayName
+			key = v.DisplayName
 		}
-		varsMap[name] = v
+		varsMap[key] = v
 	}
 	return varsMap
 }
@@ -144,7 +144,7 @@ func createMergedVariables(varNames []string, leftVarsMap map[string]*model.Vari
 				if v.OriginalType != "" {
 					v.Type = v.OriginalType
 				}
-				v.StorageName = v.DisplayName
+				v.Key = v.DisplayName
 				v.OriginalVariable = v.DisplayName
 				v.HeaderName = v.DisplayName
 			}
@@ -227,7 +227,7 @@ func createFilteredData(csvFile string, variables []*model.Variable, lineCount i
 	for _, variable := range variables {
 		data.Columns = append(data.Columns, &apiModel.Column{
 			Label: variable.DisplayName,
-			Key:   variable.StorageName,
+			Key:   variable.Key,
 			Type:  variable.Type,
 		})
 	}

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -38,19 +38,19 @@ func TestJoin(t *testing.T) {
 
 	varsLeft := []*model.Variable{
 		{
-			StorageName: "d3mIndex",
+			Key:         "d3mIndex",
 			DisplayName: "D3M Index",
 			Type:        model.IntegerType,
 			DistilRole:  "data",
 		},
 		{
-			StorageName: "alpha",
+			Key:         "alpha",
 			DisplayName: "Alpha",
 			Type:        model.RealType,
 			DistilRole:  "data",
 		},
 		{
-			StorageName: "bravo",
+			Key:         "bravo",
 			DisplayName: "Bravo",
 			Type:        model.IntegerType,
 			DistilRole:  "data",
@@ -59,20 +59,20 @@ func TestJoin(t *testing.T) {
 
 	varsRight := []*model.Variable{
 		{
-			StorageName: "d3mIndex",
+			Key:         "d3mIndex",
 			DisplayName: "D3M Index",
 			Type:        model.IntegerType,
 			DistilRole:  "data",
 		},
 		{
-			StorageName:  "charlie",
+			Key:          "charlie",
 			DisplayName:  "Charlie",
 			Type:         model.CountryType,
 			OriginalType: model.CategoricalFilter,
 			DistilRole:   "data",
 		},
 		{
-			StorageName: "delta",
+			Key:         "delta",
 			DisplayName: "Delta",
 			Type:        model.IntegerType,
 			DistilRole:  "data",

--- a/api/task/pipelines.go
+++ b/api/task/pipelines.go
@@ -123,10 +123,10 @@ func getClusterVariables(meta *model.Metadata, prefix string) ([]*FeatureRequest
 			// check if needs to be featurized
 			if res.ResType == "timeseries" {
 				// create the new resource to hold the featured output
-				indexName := fmt.Sprintf("%s%s", prefix, v.StorageName)
+				indexName := fmt.Sprintf("%s%s", prefix, v.Key)
 
 				// add the feature variable
-				v := model.NewVariable(len(mainDR.Variables), indexName, "group", v.StorageName, v.StorageName, model.CategoricalType,
+				v := model.NewVariable(len(mainDR.Variables), indexName, "group", v.Key, v.Key, model.CategoricalType,
 					model.CategoricalType, "", []string{"attribute"}, model.VarDistilRoleMetadata, nil, mainDR.Variables, false)
 
 				// create the required pipeline
@@ -161,7 +161,7 @@ func getClusterVariables(meta *model.Metadata, prefix string) ([]*FeatureRequest
 func getD3MIndexField(dr *model.DataResource) int {
 	d3mIndexField := -1
 	for _, v := range dr.Variables {
-		if v.StorageName == model.D3MIndexName {
+		if v.Key == model.D3MIndexName {
 			d3mIndexField = v.Index
 		}
 	}
@@ -196,10 +196,10 @@ func getTimeValueCols(dr *model.DataResource) (*timeValueCols, bool) {
 		for _, v := range dr.Variables {
 			for _, r := range v.Role {
 				if r == "timeIndicator" && timeCol == "" {
-					timeCol = v.StorageName
+					timeCol = v.Key
 				}
 				if r == "attribute" && valueCol == "" {
-					valueCol = v.StorageName
+					valueCol = v.Key
 				}
 			}
 		}

--- a/api/task/solution.go
+++ b/api/task/solution.go
@@ -63,7 +63,7 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 	types := make(map[string]string)
 
 	for _, vt := range dataset.Variables {
-		types[vt.StorageName] = vt.Type
+		types[vt.Key] = vt.Type
 	}
 
 	vars := make([]string, len(request.Features)-1)

--- a/api/task/target_rank.go
+++ b/api/task/target_rank.go
@@ -46,7 +46,7 @@ func TargetRank(dataset string, target string, features []*model.Variable, sourc
 	filteredFeatures := []*model.Variable{}
 	var targetFeature *model.Variable
 	for _, feature := range features {
-		if feature.StorageName == target {
+		if feature.Key == target {
 			targetFeature = feature
 		}
 		if !exclusions[feature.Type] {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210106191844-5e1736fd12f8
+	github.com/uncharted-distil/distil-compute v0.0.0-20210111160856-cc29a278809a
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.5.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210111160856-cc29a278809a
+	github.com/uncharted-distil/distil-compute v0.0.0-20210112144800-363c209ecaa9
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9
 	github.com/vova616/xxhash v0.0.0-20130313230233-f0a9a8b74d48

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20210111160856-cc29a278809a h1:9IvpdrL/586K/+H+23F/lXqwPdRo0J0oPhfS3UTonFc=
-github.com/uncharted-distil/distil-compute v0.0.0-20210111160856-cc29a278809a/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210112144800-363c209ecaa9 h1:1im00kygueNNq1v3eoOT7pDoKc7R+bdAlqqgAW4lcts=
+github.com/uncharted-distil/distil-compute v0.0.0-20210112144800-363c209ecaa9/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/uncharted-distil/distil-compute v0.0.0-20210106191844-5e1736fd12f8 h1:AdPd174tmdm/1lpeMs47VYf42p1YRfWcl/4bgWsJJAw=
-github.com/uncharted-distil/distil-compute v0.0.0-20210106191844-5e1736fd12f8/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210111160856-cc29a278809a h1:9IvpdrL/586K/+H+23F/lXqwPdRo0J0oPhfS3UTonFc=
+github.com/uncharted-distil/distil-compute v0.0.0-20210111160856-cc29a278809a/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a/go.mod h1:L8AZAnu0MT3E5I3WPNTo5BZaT5b3q21TrX1U9R9+/9E=
 github.com/unchartedsoftware/plog v0.0.0-20170413154239-34d2bbd3c0a9 h1:P1B7OAnmyIdSN9UGhDvIU3s8K3/2rQcvntYV5WPi+qY=

--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -130,7 +130,7 @@ export default Vue.extend({
 
     html(): (group: Group) => HTMLElement {
       return (group: Group) => {
-        const variable = group.storageName;
+        const variable = group.key;
         const trainingElem = document.createElement("button");
         trainingElem.className += "btn btn-sm btn-outline-secondary mb-2";
         trainingElem.textContent = "Add";
@@ -148,7 +148,7 @@ export default Vue.extend({
             feature: Feature.ADD_FEATURE,
             activity: Activity.DATA_PREPARATION,
             subActivity: SubActivity.DATA_TRANSFORMATION,
-            details: { feature: group.storageName },
+            details: { feature: group.key },
           });
 
           const dataset = routeGetters.getRouteDataset(this.$store);
@@ -157,7 +157,7 @@ export default Vue.extend({
           // get an updated view of the training data list
           const training = routeGetters
             .getDecodedTrainingVariableNames(this.$store)
-            .concat([group.storageName]);
+            .concat([group.key]);
 
           // update task based on the current training data
           const taskResponse = await datasetActions.fetchTask(this.$store, {
@@ -176,7 +176,7 @@ export default Vue.extend({
             // Fetch the information of the timeseries grouping
             const currentGrouping = datasetGetters
               .getGroupings(this.$store)
-              .find((v) => v.storageName === targetName)?.grouping;
+              .find((v) => v.key === targetName)?.grouping;
 
             // Simply duplicate its grouping information and add the new variable
             const grouping = JSON.parse(JSON.stringify(currentGrouping));
@@ -213,7 +213,7 @@ export default Vue.extend({
       );
 
       this.availableVariables.forEach((variable) => {
-        training.push(variable.storageName);
+        training.push(variable.key);
       });
 
       const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {

--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -130,7 +130,7 @@ export default Vue.extend({
 
     html(): (group: Group) => HTMLElement {
       return (group: Group) => {
-        const variable = group.colName;
+        const variable = group.storageName;
         const trainingElem = document.createElement("button");
         trainingElem.className += "btn btn-sm btn-outline-secondary mb-2";
         trainingElem.textContent = "Add";
@@ -148,7 +148,7 @@ export default Vue.extend({
             feature: Feature.ADD_FEATURE,
             activity: Activity.DATA_PREPARATION,
             subActivity: SubActivity.DATA_TRANSFORMATION,
-            details: { feature: group.colName },
+            details: { feature: group.storageName },
           });
 
           const dataset = routeGetters.getRouteDataset(this.$store);
@@ -157,7 +157,7 @@ export default Vue.extend({
           // get an updated view of the training data list
           const training = routeGetters
             .getDecodedTrainingVariableNames(this.$store)
-            .concat([group.colName]);
+            .concat([group.storageName]);
 
           // update task based on the current training data
           const taskResponse = await datasetActions.fetchTask(this.$store, {
@@ -176,7 +176,7 @@ export default Vue.extend({
             // Fetch the information of the timeseries grouping
             const currentGrouping = datasetGetters
               .getGroupings(this.$store)
-              .find((v) => v.colName === targetName)?.grouping;
+              .find((v) => v.storageName === targetName)?.grouping;
 
             // Simply duplicate its grouping information and add the new variable
             const grouping = JSON.parse(JSON.stringify(currentGrouping));
@@ -213,7 +213,7 @@ export default Vue.extend({
       );
 
       this.availableVariables.forEach((variable) => {
-        training.push(variable.colName);
+        training.push(variable.storageName);
       });
 
       const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -105,7 +105,7 @@ export default Vue.extend({
     },
     targetVariable(): Variable {
       return _.find(this.variables, (v) => {
-        return _.toLower(v.colName) === _.toLower(this.target);
+        return _.toLower(v.storageName) === _.toLower(this.target);
       });
     },
     dateTimeExtrema(): { min: number; max: number } {

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -105,7 +105,7 @@ export default Vue.extend({
     },
     targetVariable(): Variable {
       return _.find(this.variables, (v) => {
-        return _.toLower(v.storageName) === _.toLower(this.target);
+        return _.toLower(v.key) === _.toLower(this.target);
       });
     },
     dateTimeExtrema(): { min: number; max: number } {

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -319,7 +319,7 @@ export default Vue.extend({
         .filter((v) => v.datasetName === this.dataset);
       return variables
         .map((variable) => ({
-          variable: variable.storageName,
+          variable: variable.key,
           order: _.isNumber(variable.ranking)
             ? variable.ranking
             : variable.importance,
@@ -387,14 +387,14 @@ export default Vue.extend({
         } else if (match.colType === REAL_VECTOR_TYPE) {
           fields.push({
             type: SINGLE_FIELD,
-            field: match.storageName,
+            field: match.key,
           });
         } else {
           if (match.colType === LONGITUDE_TYPE) {
-            lng = match.storageName;
+            lng = match.key;
           }
           if (match.colType === LATITUDE_TYPE) {
-            lat = match.storageName;
+            lat = match.key;
           }
         }
 

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -319,7 +319,7 @@ export default Vue.extend({
         .filter((v) => v.datasetName === this.dataset);
       return variables
         .map((variable) => ({
-          variable: variable.colName,
+          variable: variable.storageName,
           order: _.isNumber(variable.ranking)
             ? variable.ranking
             : variable.importance,
@@ -387,14 +387,14 @@ export default Vue.extend({
         } else if (match.colType === REAL_VECTOR_TYPE) {
           fields.push({
             type: SINGLE_FIELD,
-            field: match.colName,
+            field: match.storageName,
           });
         } else {
           if (match.colType === LONGITUDE_TYPE) {
-            lng = match.colName;
+            lng = match.storageName;
           }
           if (match.colType === LATITUDE_TYPE) {
-            lat = match.colName;
+            lat = match.storageName;
           }
         }
 

--- a/public/components/JoinDataTable.vue
+++ b/public/components/JoinDataTable.vue
@@ -65,12 +65,12 @@ import {
 
 function findSuggestionIndex(
   columnSuggestions: string[],
-  colName: string
+  storageName: string
 ): number {
   return columnSuggestions.findIndex((col) => {
     // col can be something like "lat+lng" for multi column suggestions
-    const colNames = col.split("+");
-    return Boolean(colNames.find((c) => c === colName));
+    const storageNames = col.split("+");
+    return Boolean(storageNames.find((c) => c === storageName));
   });
 }
 

--- a/public/components/JoinDataTable.vue
+++ b/public/components/JoinDataTable.vue
@@ -63,14 +63,11 @@ import {
   getImageFields,
 } from "../util/data";
 
-function findSuggestionIndex(
-  columnSuggestions: string[],
-  storageName: string
-): number {
+function findSuggestionIndex(columnSuggestions: string[], key: string): number {
   return columnSuggestions.findIndex((col) => {
     // col can be something like "lat+lng" for multi column suggestions
-    const storageNames = col.split("+");
-    return Boolean(storageNames.find((c) => c === storageName));
+    const keys = col.split("+");
+    return Boolean(keys.find((c) => c === key));
   });
 }
 

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -118,7 +118,7 @@ export default Vue.extend({
     targetType(): string {
       const targetName = this.target;
       const variables = this.variables;
-      return variables.find((v) => v.colName === targetName)?.colType;
+      return variables.find((v) => v.storageName === targetName)?.colType;
     },
 
     variables(): Variable[] {

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -118,7 +118,7 @@ export default Vue.extend({
     targetType(): string {
       const targetName = this.target;
       const variables = this.variables;
-      return variables.find((v) => v.storageName === targetName)?.colType;
+      return variables.find((v) => v.key === targetName)?.colType;
     },
 
     variables(): Variable[] {

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -242,9 +242,7 @@ export default Vue.extend({
       }
 
       const activeFilterName = this.activeFilter.key;
-      const availableVariablesNames = this.availableVariables.map(
-        (v) => v.storageName
-      );
+      const availableVariablesNames = this.availableVariables.map((v) => v.key);
 
       return availableVariablesNames.includes(activeFilterName);
     },

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -243,7 +243,7 @@ export default Vue.extend({
 
       const activeFilterName = this.activeFilter.key;
       const availableVariablesNames = this.availableVariables.map(
-        (v) => v.colName
+        (v) => v.storageName
       );
 
       return availableVariablesNames.includes(activeFilterName);

--- a/public/components/SparklineTimeseriesView.vue
+++ b/public/components/SparklineTimeseriesView.vue
@@ -167,9 +167,7 @@ export default Vue.extend({
 
     isDateScale(): boolean {
       const grouping = this.timeseriesGrouping;
-      const timeVar = this.variables.find(
-        (v) => v.storageName === grouping.xCol
-      );
+      const timeVar = this.variables.find((v) => v.key === grouping.xCol);
       return timeVar && isTimeType(timeVar.colType);
     },
 

--- a/public/components/SparklineTimeseriesView.vue
+++ b/public/components/SparklineTimeseriesView.vue
@@ -167,7 +167,9 @@ export default Vue.extend({
 
     isDateScale(): boolean {
       const grouping = this.timeseriesGrouping;
-      const timeVar = this.variables.find((v) => v.colName === grouping.xCol);
+      const timeVar = this.variables.find(
+        (v) => v.storageName === grouping.xCol
+      );
       return timeVar && isTimeType(timeVar.colType);
     },
 

--- a/public/components/StatusPanel.vue
+++ b/public/components/StatusPanel.vue
@@ -260,7 +260,7 @@ export default Vue.extend({
         .getGroupings(this.$store)
         .filter((v) => isClusterType(v.colType))
         .forEach((v) => {
-          varModesMap.set(v.storageName, SummaryMode.Cluster);
+          varModesMap.set(v.key, SummaryMode.Cluster);
         });
 
       // find any image variables using this cluster data and update their mode
@@ -268,7 +268,7 @@ export default Vue.extend({
         .getVariables(this.$store)
         .filter((v) => v.colType === IMAGE_TYPE)
         .forEach((v) => {
-          varModesMap.set(v.storageName, SummaryMode.Cluster);
+          varModesMap.set(v.key, SummaryMode.Cluster);
         });
 
       // serialize the modes map into a string and add to the route

--- a/public/components/StatusPanel.vue
+++ b/public/components/StatusPanel.vue
@@ -260,7 +260,7 @@ export default Vue.extend({
         .getGroupings(this.$store)
         .filter((v) => isClusterType(v.colType))
         .forEach((v) => {
-          varModesMap.set(v.colName, SummaryMode.Cluster);
+          varModesMap.set(v.storageName, SummaryMode.Cluster);
         });
 
       // find any image variables using this cluster data and update their mode
@@ -268,7 +268,7 @@ export default Vue.extend({
         .getVariables(this.$store)
         .filter((v) => v.colType === IMAGE_TYPE)
         .forEach((v) => {
-          varModesMap.set(v.colName, SummaryMode.Cluster);
+          varModesMap.set(v.storageName, SummaryMode.Cluster);
         });
 
       // serialize the modes map into a string and add to the route

--- a/public/components/TimeseriesAnalysisModal.vue
+++ b/public/components/TimeseriesAnalysisModal.vue
@@ -62,7 +62,7 @@ export default Vue.extend({
       const suggestions = this.variables
         .filter((v) => isTimeType(v.colType))
         .map((v) => {
-          return { value: v.storageName, text: v.colDisplayName };
+          return { value: v.key, text: v.colDisplayName };
         });
 
       if (suggestions.length === 1) {

--- a/public/components/TimeseriesAnalysisModal.vue
+++ b/public/components/TimeseriesAnalysisModal.vue
@@ -62,7 +62,7 @@ export default Vue.extend({
       const suggestions = this.variables
         .filter((v) => isTimeType(v.colType))
         .map((v) => {
-          return { value: v.colName, text: v.colDisplayName };
+          return { value: v.storageName, text: v.colDisplayName };
         });
 
       if (suggestions.length === 1) {

--- a/public/components/TrainingVariables.vue
+++ b/public/components/TrainingVariables.vue
@@ -125,7 +125,7 @@ export default Vue.extend({
 
       // Filter them out of the available training variables.
       const trainingVariables = Array.from(this.trainingVariables).filter(
-        (variable) => !timeseriesGrouping.includes(variable.storageName)
+        (variable) => !timeseriesGrouping.includes(variable.key)
       );
 
       // The variables can be removed.
@@ -150,7 +150,7 @@ export default Vue.extend({
       return (group: Group) => {
         // get the target variable information
         const targetVar = this.variables.find((v) => {
-          return v.storageName === this.target;
+          return v.key === this.target;
         });
 
         // the target variable contains grouping information (Timeseries/Geocoordinate)
@@ -162,9 +162,7 @@ export default Vue.extend({
           if (seriesIds.length > 0) {
             // Make sure to show the button for all of them.
             if (seriesIds.length !== 1) {
-              hideRemoveButton = !seriesIds.some(
-                (v) => v === group.storageName
-              );
+              hideRemoveButton = !seriesIds.some((v) => v === group.key);
             }
             // unless there is only one series ID, then we hide the remove button.
             else {
@@ -197,7 +195,7 @@ export default Vue.extend({
             feature: Feature.REMOVE_FEATURE,
             activity: Activity.DATA_PREPARATION,
             subActivity: SubActivity.DATA_TRANSFORMATION,
-            details: { feature: group.storageName },
+            details: { feature: group.key },
           });
 
           const dataset = routeGetters.getRouteDataset(this.$store);
@@ -207,7 +205,7 @@ export default Vue.extend({
           const training = routeGetters.getDecodedTrainingVariableNames(
             this.$store
           );
-          training.splice(training.indexOf(group.storageName), 1);
+          training.splice(training.indexOf(group.key), 1);
 
           // update task based on the current training data
           const taskResponse = await datasetActions.fetchTask(this.$store, {
@@ -226,12 +224,12 @@ export default Vue.extend({
             // Fetch the information of the timeseries grouping
             const currentGrouping = datasetGetters
               .getGroupings(this.$store)
-              .find((v) => v.storageName === targetName)?.grouping;
+              .find((v) => v.key === targetName)?.grouping;
 
             // Simply duplicate its grouping information and remove the series ID
             const grouping = JSON.parse(JSON.stringify(currentGrouping));
             grouping.subIds = grouping.subIds.filter(
-              (subId) => subId !== group.storageName
+              (subId) => subId !== group.key
             );
             grouping.idCol = getComposedVariableKey(grouping.subIds);
 
@@ -243,7 +241,7 @@ export default Vue.extend({
           }
 
           this.$router.push(entry).catch((err) => console.warn(err));
-          removeFiltersByName(this.$router, group.storageName);
+          removeFiltersByName(this.$router, group.key);
         });
 
         return removeBtn;

--- a/public/components/TrainingVariables.vue
+++ b/public/components/TrainingVariables.vue
@@ -125,7 +125,7 @@ export default Vue.extend({
 
       // Filter them out of the available training variables.
       const trainingVariables = Array.from(this.trainingVariables).filter(
-        (variable) => !timeseriesGrouping.includes(variable.colName)
+        (variable) => !timeseriesGrouping.includes(variable.storageName)
       );
 
       // The variables can be removed.
@@ -150,7 +150,7 @@ export default Vue.extend({
       return (group: Group) => {
         // get the target variable information
         const targetVar = this.variables.find((v) => {
-          return v.colName === this.target;
+          return v.storageName === this.target;
         });
 
         // the target variable contains grouping information (Timeseries/Geocoordinate)
@@ -162,7 +162,9 @@ export default Vue.extend({
           if (seriesIds.length > 0) {
             // Make sure to show the button for all of them.
             if (seriesIds.length !== 1) {
-              hideRemoveButton = !seriesIds.some((v) => v === group.colName);
+              hideRemoveButton = !seriesIds.some(
+                (v) => v === group.storageName
+              );
             }
             // unless there is only one series ID, then we hide the remove button.
             else {
@@ -195,7 +197,7 @@ export default Vue.extend({
             feature: Feature.REMOVE_FEATURE,
             activity: Activity.DATA_PREPARATION,
             subActivity: SubActivity.DATA_TRANSFORMATION,
-            details: { feature: group.colName },
+            details: { feature: group.storageName },
           });
 
           const dataset = routeGetters.getRouteDataset(this.$store);
@@ -205,7 +207,7 @@ export default Vue.extend({
           const training = routeGetters.getDecodedTrainingVariableNames(
             this.$store
           );
-          training.splice(training.indexOf(group.colName), 1);
+          training.splice(training.indexOf(group.storageName), 1);
 
           // update task based on the current training data
           const taskResponse = await datasetActions.fetchTask(this.$store, {
@@ -224,12 +226,12 @@ export default Vue.extend({
             // Fetch the information of the timeseries grouping
             const currentGrouping = datasetGetters
               .getGroupings(this.$store)
-              .find((v) => v.colName === targetName)?.grouping;
+              .find((v) => v.storageName === targetName)?.grouping;
 
             // Simply duplicate its grouping information and remove the series ID
             const grouping = JSON.parse(JSON.stringify(currentGrouping));
             grouping.subIds = grouping.subIds.filter(
-              (subId) => subId !== group.colName
+              (subId) => subId !== group.storageName
             );
             grouping.idCol = getComposedVariableKey(grouping.subIds);
 
@@ -241,7 +243,7 @@ export default Vue.extend({
           }
 
           this.$router.push(entry).catch((err) => console.warn(err));
-          removeFiltersByName(this.$router, group.colName);
+          removeFiltersByName(this.$router, group.storageName);
         });
 
         return removeBtn;

--- a/public/components/TrainingVariables.vue
+++ b/public/components/TrainingVariables.vue
@@ -169,7 +169,7 @@ export default Vue.extend({
               hideRemoveButton = true;
             }
           } else {
-            hideRemoveButton = targetVar.grouping.idCol === group.key;
+            hideRemoveButton = targetVar.grouping.idCol === group.groupKey;
           }
 
           // Hide the remove button

--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -138,7 +138,7 @@ export default Vue.extend({
           return;
         }
         return (
-          v.colName.toLowerCase() === this.field.toLowerCase() &&
+          v.storageName.toLowerCase() === this.field.toLowerCase() &&
           v.datasetName === this.dataset
         );
       });
@@ -198,7 +198,7 @@ export default Vue.extend({
       );
     },
     isComputedFeature(): boolean {
-      return this.variable && hasComputedVarPrefix(this.variable.colName);
+      return this.variable && hasComputedVarPrefix(this.variable.storageName);
     },
     hasSchemaType(): boolean {
       return !!this.schemaType;
@@ -284,7 +284,7 @@ export default Vue.extend({
       } else {
         datasetActions.removeGrouping(this.$store, {
           dataset: this.dataset,
-          variable: this.variable.colName,
+          variable: this.variable.storageName,
         });
       }
     },
@@ -342,7 +342,7 @@ export default Vue.extend({
               dataset: dataset,
               field: field
             });
-          } else if (type === "image") { 
+          } else if (type === "image") {
           */
           if (type === "image") {
             return datasetActions.fetchClusters(this.$store, {

--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -138,7 +138,7 @@ export default Vue.extend({
           return;
         }
         return (
-          v.storageName.toLowerCase() === this.field.toLowerCase() &&
+          v.key.toLowerCase() === this.field.toLowerCase() &&
           v.datasetName === this.dataset
         );
       });
@@ -198,7 +198,7 @@ export default Vue.extend({
       );
     },
     isComputedFeature(): boolean {
-      return this.variable && hasComputedVarPrefix(this.variable.storageName);
+      return this.variable && hasComputedVarPrefix(this.variable.key);
     },
     hasSchemaType(): boolean {
       return !!this.schemaType;
@@ -284,7 +284,7 @@ export default Vue.extend({
       } else {
         datasetActions.removeGrouping(this.$store, {
           dataset: this.dataset,
-          variable: this.variable.storageName,
+          variable: this.variable.key,
         });
       }
     },

--- a/public/components/facets/FacetCategorical.vue
+++ b/public/components/facets/FacetCategorical.vue
@@ -220,8 +220,10 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, colName: string): boolean {
-      return this.isHighlightedInstance(highlight) && highlight.key === colName;
+    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
+      return (
+        this.isHighlightedInstance(highlight) && highlight.key === storageName
+      );
     },
     updateSelection(event) {
       if (!this.enableHighlighting) return;
@@ -263,7 +265,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              colName: this.summary.key,
+              storageName: this.summary.key,
               type: "categorical",
             })
           : this.html;

--- a/public/components/facets/FacetCategorical.vue
+++ b/public/components/facets/FacetCategorical.vue
@@ -220,10 +220,8 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
-      return (
-        this.isHighlightedInstance(highlight) && highlight.key === storageName
-      );
+    isHighlightedGroup(highlight: Highlight, key: string): boolean {
+      return this.isHighlightedInstance(highlight) && highlight.key === key;
     },
     updateSelection(event) {
       if (!this.enableHighlighting) return;
@@ -265,7 +263,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              storageName: this.summary.key,
+              key: this.summary.key,
               type: "categorical",
             })
           : this.html;

--- a/public/components/facets/FacetDateTime.vue
+++ b/public/components/facets/FacetDateTime.vue
@@ -183,8 +183,10 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, colName: string): boolean {
-      return this.isHighlightedInstance(highlight) && highlight.key === colName;
+    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
+      return (
+        this.isHighlightedInstance(highlight) && highlight.key === storageName
+      );
     },
     getRange(facet): { from: number; to: number; type: string } {
       if (!facet.selection) {
@@ -241,7 +243,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              colName: this.summary.key,
+              storageName: this.summary.key,
             })
           : this.html;
       }

--- a/public/components/facets/FacetDateTime.vue
+++ b/public/components/facets/FacetDateTime.vue
@@ -183,10 +183,8 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
-      return (
-        this.isHighlightedInstance(highlight) && highlight.key === storageName
-      );
+    isHighlightedGroup(highlight: Highlight, key: string): boolean {
+      return this.isHighlightedInstance(highlight) && highlight.key === key;
     },
     getRange(facet): { from: number; to: number; type: string } {
       if (!facet.selection) {
@@ -243,7 +241,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              storageName: this.summary.key,
+              key: this.summary.key,
             })
           : this.html;
       }

--- a/public/components/facets/FacetImage.vue
+++ b/public/components/facets/FacetImage.vue
@@ -249,8 +249,10 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, colName: string): boolean {
-      return this.isHighlightedInstance(highlight) && highlight.key === colName;
+    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
+      return (
+        this.isHighlightedInstance(highlight) && highlight.key === storageName
+      );
     },
     updateSelection(event) {
       if (!this.enableHighlighting) return;
@@ -292,7 +294,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              colName: this.summary.key,
+              storageName: this.summary.key,
             })
           : this.html;
       }

--- a/public/components/facets/FacetImage.vue
+++ b/public/components/facets/FacetImage.vue
@@ -249,10 +249,8 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
-      return (
-        this.isHighlightedInstance(highlight) && highlight.key === storageName
-      );
+    isHighlightedGroup(highlight: Highlight, key: string): boolean {
+      return this.isHighlightedInstance(highlight) && highlight.key === key;
     },
     updateSelection(event) {
       if (!this.enableHighlighting) return;
@@ -294,7 +292,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              storageName: this.summary.key,
+              key: this.summary.key,
             })
           : this.html;
       }

--- a/public/components/facets/FacetNumerical.vue
+++ b/public/components/facets/FacetNumerical.vue
@@ -197,8 +197,10 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, colName: string): boolean {
-      return this.isHighlightedInstance(highlight) && highlight.key === colName;
+    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
+      return (
+        this.isHighlightedInstance(highlight) && highlight.key === storageName
+      );
     },
     getRange(facet): { from: number; to: number; type: string } {
       if (!facet.selection) {
@@ -255,7 +257,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              colName: this.summary.key,
+              storageName: this.summary.key,
             })
           : this.html;
       }

--- a/public/components/facets/FacetNumerical.vue
+++ b/public/components/facets/FacetNumerical.vue
@@ -197,10 +197,8 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
-      return (
-        this.isHighlightedInstance(highlight) && highlight.key === storageName
-      );
+    isHighlightedGroup(highlight: Highlight, key: string): boolean {
+      return this.isHighlightedInstance(highlight) && highlight.key === key;
     },
     getRange(facet): { from: number; to: number; type: string } {
       if (!facet.selection) {
@@ -257,7 +255,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              storageName: this.summary.key,
+              key: this.summary.key,
             })
           : this.html;
       }

--- a/public/components/facets/FacetSparklines.vue
+++ b/public/components/facets/FacetSparklines.vue
@@ -252,8 +252,10 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, colName: string): boolean {
-      return this.isHighlightedInstance(highlight) && highlight.key === colName;
+    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
+      return (
+        this.isHighlightedInstance(highlight) && highlight.key === storageName
+      );
     },
     updateSelection(event) {
       if (!this.enableHighlighting) return;
@@ -295,7 +297,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              colName: this.summary.key,
+              storageName: this.summary.key,
             })
           : this.html;
       }

--- a/public/components/facets/FacetSparklines.vue
+++ b/public/components/facets/FacetSparklines.vue
@@ -252,10 +252,8 @@ export default Vue.extend({
     isHighlightedInstance(highlight: Highlight): boolean {
       return highlight && highlight.context === this.instanceName;
     },
-    isHighlightedGroup(highlight: Highlight, storageName: string): boolean {
-      return (
-        this.isHighlightedInstance(highlight) && highlight.key === storageName
-      );
+    isHighlightedGroup(highlight: Highlight, key: string): boolean {
+      return this.isHighlightedInstance(highlight) && highlight.key === key;
     },
     updateSelection(event) {
       if (!this.enableHighlighting) return;
@@ -297,7 +295,7 @@ export default Vue.extend({
       if (this.html) {
         return _.isFunction(this.html)
           ? this.html({
-              storageName: this.summary.key,
+              key: this.summary.key,
             })
           : this.html;
       }

--- a/public/components/facets/FacetTimeseries.vue
+++ b/public/components/facets/FacetTimeseries.vue
@@ -106,7 +106,7 @@ export default Vue.extend({
     },
 
     variable(): Variable {
-      return this.variables.find((v) => v.storageName === this.summary.key);
+      return this.variables.find((v) => v.key === this.summary.key);
     },
 
     grouping(): TimeseriesGrouping {
@@ -121,9 +121,7 @@ export default Vue.extend({
         return null;
       }
 
-      const summaryVar = this.variables.find(
-        (v) => v.storageName === this.summary.key
-      );
+      const summaryVar = this.variables.find((v) => v.key === this.summary.key);
 
       if (!summaryVar || !this.grouping || !this.variable) {
         return null;

--- a/public/components/facets/FacetTimeseries.vue
+++ b/public/components/facets/FacetTimeseries.vue
@@ -106,7 +106,7 @@ export default Vue.extend({
     },
 
     variable(): Variable {
-      return this.variables.find((v) => v.colName === this.summary.key);
+      return this.variables.find((v) => v.storageName === this.summary.key);
     },
 
     grouping(): TimeseriesGrouping {
@@ -122,7 +122,7 @@ export default Vue.extend({
       }
 
       const summaryVar = this.variables.find(
-        (v) => v.colName === this.summary.key
+        (v) => v.storageName === this.summary.key
       );
 
       if (!summaryVar || !this.grouping || !this.variable) {

--- a/public/components/facets/GeocoordinateFacet.vue
+++ b/public/components/facets/GeocoordinateFacet.vue
@@ -642,7 +642,7 @@ export default Vue.extend({
         });
 
         available.forEach((v) => {
-          varModesMap.set(v.colName, SummaryMode.MultiBandImage);
+          varModesMap.set(v.storageName, SummaryMode.MultiBandImage);
         });
 
         varModesMap.set(

--- a/public/components/facets/GeocoordinateFacet.vue
+++ b/public/components/facets/GeocoordinateFacet.vue
@@ -642,7 +642,7 @@ export default Vue.extend({
         });
 
         available.forEach((v) => {
-          varModesMap.set(v.storageName, SummaryMode.MultiBandImage);
+          varModesMap.set(v.key, SummaryMode.MultiBandImage);
         });
 
         varModesMap.set(

--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -284,7 +284,7 @@ export default Vue.extend({
         })
       );
       return this.variables.filter((v) => {
-        return checkMap.has(v.storageName);
+        return checkMap.has(v.key);
       });
     },
     highlight(): Highlight {
@@ -310,7 +310,7 @@ export default Vue.extend({
       }
       const ranking: Dictionary<number> = {};
       this.variables.forEach((variable) => {
-        ranking[variable.storageName] = this.isResultFeatures
+        ranking[variable.key] = this.isResultFeatures
           ? getSolutionFeatureImportance(
               variable,
               routeGetters.getRouteSolutionId(this.$store)
@@ -323,10 +323,8 @@ export default Vue.extend({
     enabledTypeChanges(): string[] {
       const typeChangeStatus: string[] = [];
       this.variables.forEach((variable) => {
-        if (this.enableTypeChange && !this.isSeriesID(variable.storageName)) {
-          typeChangeStatus.push(
-            `${variable.datasetName}:${variable.storageName}`
-          );
+        if (this.enableTypeChange && !this.isSeriesID(variable.key)) {
+          typeChangeStatus.push(`${variable.datasetName}:${variable.key}`);
         }
       });
       return typeChangeStatus;
@@ -359,7 +357,7 @@ export default Vue.extend({
         this.timeseriesSummaries.forEach(async (ts) => {
           const ids = ts.baseline.exemplars;
           const timeseriesVar = this.timeseriesVars.find((tsv) => {
-            return tsv.storageName === ts.key;
+            return tsv.key === ts.key;
           });
           const grouping = timeseriesVar.grouping as TimeseriesGrouping;
           await datasetActions.fetchTimeseries(this.$store, {
@@ -466,12 +464,12 @@ export default Vue.extend({
       this.$emit("numerical-click", key);
     },
 
-    isSeriesID(storageName: string): boolean {
+    isSeriesID(key: string): boolean {
       // Check to see if this facet is being used as a series ID
       const targetVar = routeGetters.getTargetVariable(this.$store);
       if (targetVar && targetVar.grouping) {
         if (targetVar.grouping.subIds.length > 0) {
-          return !!targetVar.grouping.subIds.find((v) => v === storageName);
+          return !!targetVar.grouping.subIds.find((v) => v === key);
         }
       }
       return false;

--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -284,7 +284,7 @@ export default Vue.extend({
         })
       );
       return this.variables.filter((v) => {
-        return checkMap.has(v.colName);
+        return checkMap.has(v.storageName);
       });
     },
     highlight(): Highlight {
@@ -310,7 +310,7 @@ export default Vue.extend({
       }
       const ranking: Dictionary<number> = {};
       this.variables.forEach((variable) => {
-        ranking[variable.colName] = this.isResultFeatures
+        ranking[variable.storageName] = this.isResultFeatures
           ? getSolutionFeatureImportance(
               variable,
               routeGetters.getRouteSolutionId(this.$store)
@@ -323,8 +323,10 @@ export default Vue.extend({
     enabledTypeChanges(): string[] {
       const typeChangeStatus: string[] = [];
       this.variables.forEach((variable) => {
-        if (this.enableTypeChange && !this.isSeriesID(variable.colName)) {
-          typeChangeStatus.push(`${variable.datasetName}:${variable.colName}`);
+        if (this.enableTypeChange && !this.isSeriesID(variable.storageName)) {
+          typeChangeStatus.push(
+            `${variable.datasetName}:${variable.storageName}`
+          );
         }
       });
       return typeChangeStatus;
@@ -357,7 +359,7 @@ export default Vue.extend({
         this.timeseriesSummaries.forEach(async (ts) => {
           const ids = ts.baseline.exemplars;
           const timeseriesVar = this.timeseriesVars.find((tsv) => {
-            return tsv.colName === ts.key;
+            return tsv.storageName === ts.key;
           });
           const grouping = timeseriesVar.grouping as TimeseriesGrouping;
           await datasetActions.fetchTimeseries(this.$store, {
@@ -464,12 +466,12 @@ export default Vue.extend({
       this.$emit("numerical-click", key);
     },
 
-    isSeriesID(colName: string): boolean {
+    isSeriesID(storageName: string): boolean {
       // Check to see if this facet is being used as a series ID
       const targetVar = routeGetters.getTargetVariable(this.$store);
       if (targetVar && targetVar.grouping) {
         if (targetVar.grouping.subIds.length > 0) {
-          return !!targetVar.grouping.subIds.find((v) => v === colName);
+          return !!targetVar.grouping.subIds.find((v) => v === storageName);
         }
       }
       return false;

--- a/public/components/panel/FacetListPane.vue
+++ b/public/components/panel/FacetListPane.vue
@@ -68,7 +68,7 @@ export default Vue.extend({
 
     button(): (group: Group) => HTMLElement {
       return (group: Group) => {
-        const variable = group.storageName;
+        const variable = group.key;
         const training = routeGetters.getDecodedTrainingVariableNames(
           this.$store
         );
@@ -126,7 +126,7 @@ export default Vue.extend({
     searchedActiveVariables(): Variable[] {
       // remove variables used in groupedFeature;
       const activeVariables = this.variables.filter(
-        (v) => !this.groupedFeatures.includes(v.storageName)
+        (v) => !this.groupedFeatures.includes(v.key)
       );
 
       return searchVariables(activeVariables, this.search);

--- a/public/components/panel/FacetListPane.vue
+++ b/public/components/panel/FacetListPane.vue
@@ -68,7 +68,7 @@ export default Vue.extend({
 
     button(): (group: Group) => HTMLElement {
       return (group: Group) => {
-        const variable = group.colName;
+        const variable = group.storageName;
         const training = routeGetters.getDecodedTrainingVariableNames(
           this.$store
         );
@@ -126,7 +126,7 @@ export default Vue.extend({
     searchedActiveVariables(): Variable[] {
       // remove variables used in groupedFeature;
       const activeVariables = this.variables.filter(
-        (v) => !this.groupedFeatures.includes(v.colName)
+        (v) => !this.groupedFeatures.includes(v.storageName)
       );
 
       return searchVariables(activeVariables, this.search);

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -317,10 +317,7 @@ export const actions = {
           {}
         );
       } else if (isImageType(v.colType)) {
-        return axios.post(
-          `/distil/cluster/${args.dataset}/${v.storageName}`,
-          {}
-        );
+        return axios.post(`/distil/cluster/${args.dataset}/${v.key}`, {});
       }
       return null;
     });
@@ -860,26 +857,26 @@ export const actions = {
 
     args.variables.forEach((variable) => {
       const existingVariableSummary =
-        summariesByVariable?.[variable.storageName]?.[routeKey];
+        summariesByVariable?.[variable.key]?.[routeKey];
 
       if (existingVariableSummary) {
         promises.push(existingVariableSummary);
       } else {
-        if (summariesByVariable[variable.storageName]) {
+        if (summariesByVariable[variable.key]) {
           // if we have any saved state for that variable
           // use that as placeholder due to vue lifecycle
           const tempVariableSummaryKey = Object.keys(
-            summariesByVariable[variable.storageName]
+            summariesByVariable[variable.key]
           )[0];
           promises.push(
-            summariesByVariable[variable.storageName][tempVariableSummaryKey]
+            summariesByVariable[variable.key][tempVariableSummaryKey]
           );
         } else {
           // add a loading placeholder if nothing exists for that variable
           mutator(
             context,
             createPendingSummary(
-              variable.storageName,
+              variable.key,
               variable.colDisplayName,
               variable.colDescription,
               args.dataset
@@ -888,15 +885,15 @@ export const actions = {
         }
 
         // Get the mode or default
-        const mode = args.varModes.has(variable.storageName)
-          ? args.varModes.get(variable.storageName)
+        const mode = args.varModes.has(variable.key)
+          ? args.varModes.get(variable.key)
           : SummaryMode.Default;
 
         // fetch summary
         promises.push(
           actions.fetchVariableSummary(context, {
             dataset: args.dataset,
-            variable: variable.storageName,
+            variable: variable.key,
             filterParams: args.filterParams,
             highlight: args.highlight,
             include: args.include,
@@ -976,11 +973,7 @@ export const actions = {
     const target = getters.getVariablesMap(context)[args.target];
     const rankableVariables = getters
       .getVariables(context)
-      .filter(
-        (f) =>
-          f.storageName !== target.storageName &&
-          isRankableVariableType(f.colType)
-      );
+      .filter((f) => f.key !== target.key && isRankableVariableType(f.colType));
     if (
       !isRankableVariableType(target.colType) ||
       rankableVariables.length === 0

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -317,7 +317,10 @@ export const actions = {
           {}
         );
       } else if (isImageType(v.colType)) {
-        return axios.post(`/distil/cluster/${args.dataset}/${v.colName}`, {});
+        return axios.post(
+          `/distil/cluster/${args.dataset}/${v.storageName}`,
+          {}
+        );
       }
       return null;
     });
@@ -857,26 +860,26 @@ export const actions = {
 
     args.variables.forEach((variable) => {
       const existingVariableSummary =
-        summariesByVariable?.[variable.colName]?.[routeKey];
+        summariesByVariable?.[variable.storageName]?.[routeKey];
 
       if (existingVariableSummary) {
         promises.push(existingVariableSummary);
       } else {
-        if (summariesByVariable[variable.colName]) {
+        if (summariesByVariable[variable.storageName]) {
           // if we have any saved state for that variable
           // use that as placeholder due to vue lifecycle
           const tempVariableSummaryKey = Object.keys(
-            summariesByVariable[variable.colName]
+            summariesByVariable[variable.storageName]
           )[0];
           promises.push(
-            summariesByVariable[variable.colName][tempVariableSummaryKey]
+            summariesByVariable[variable.storageName][tempVariableSummaryKey]
           );
         } else {
           // add a loading placeholder if nothing exists for that variable
           mutator(
             context,
             createPendingSummary(
-              variable.colName,
+              variable.storageName,
               variable.colDisplayName,
               variable.colDescription,
               args.dataset
@@ -885,15 +888,15 @@ export const actions = {
         }
 
         // Get the mode or default
-        const mode = args.varModes.has(variable.colName)
-          ? args.varModes.get(variable.colName)
+        const mode = args.varModes.has(variable.storageName)
+          ? args.varModes.get(variable.storageName)
           : SummaryMode.Default;
 
         // fetch summary
         promises.push(
           actions.fetchVariableSummary(context, {
             dataset: args.dataset,
-            variable: variable.colName,
+            variable: variable.storageName,
             filterParams: args.filterParams,
             highlight: args.highlight,
             include: args.include,
@@ -974,7 +977,9 @@ export const actions = {
     const rankableVariables = getters
       .getVariables(context)
       .filter(
-        (f) => f.colName !== target.colName && isRankableVariableType(f.colType)
+        (f) =>
+          f.storageName !== target.storageName &&
+          isRankableVariableType(f.colType)
       );
     if (
       !isRankableVariableType(target.colType) ||

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -63,8 +63,8 @@ export const getters = {
   getVariablesMap(state: DatasetState): Dictionary<Variable> {
     const map = {};
     state.variables.forEach((variable) => {
-      map[variable.colName] = variable;
-      map[variable.colName.toLowerCase()] = variable;
+      map[variable.storageName] = variable;
+      map[variable.storageName.toLowerCase()] = variable;
     });
     return map;
   },
@@ -72,8 +72,8 @@ export const getters = {
   getVariableTypesMap(state: DatasetState): Dictionary<string> {
     const map = {};
     state.variables.forEach((variable) => {
-      map[variable.colName] = variable.colType;
-      map[variable.colName.toLowerCase()] = variable.colType;
+      map[variable.storageName] = variable.colType;
+      map[variable.storageName.toLowerCase()] = variable.colType;
     });
     return map;
   },

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -63,8 +63,8 @@ export const getters = {
   getVariablesMap(state: DatasetState): Dictionary<Variable> {
     const map = {};
     state.variables.forEach((variable) => {
-      map[variable.storageName] = variable;
-      map[variable.storageName.toLowerCase()] = variable;
+      map[variable.key] = variable;
+      map[variable.key.toLowerCase()] = variable;
     });
     return map;
   },
@@ -72,8 +72,8 @@ export const getters = {
   getVariableTypesMap(state: DatasetState): Dictionary<string> {
     const map = {};
     state.variables.forEach((variable) => {
-      map[variable.storageName] = variable.colType;
-      map[variable.storageName.toLowerCase()] = variable.colType;
+      map[variable.key] = variable.colType;
+      map[variable.key.toLowerCase()] = variable.colType;
     });
     return map;
   },

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -75,6 +75,7 @@ export interface Variable {
   datasetName: string;
   colDisplayName: string;
   colName: string;
+  storageName: string;
   colType: string;
   importance: number;
   ranking?: number;

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -75,7 +75,7 @@ export interface Variable {
   datasetName: string;
   colDisplayName: string;
   colName: string;
-  storageName: string;
+  key: string;
   colType: string;
   importance: number;
   ranking?: number;

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -91,13 +91,13 @@ export const mutations = {
     const oldVariables = new Map();
 
     state.variables.forEach((variable) => {
-      const { datasetName, colName } = variable;
-      oldVariables.set(`${datasetName}:${colName}`, variable);
+      const { datasetName, storageName } = variable;
+      oldVariables.set(`${datasetName}:${storageName}`, variable);
     });
 
     const newVariables = variables.map((variable) => {
-      const { datasetName, colName } = variable;
-      const variableKey = `${datasetName}:${colName}`;
+      const { datasetName, storageName } = variable;
+      const variableKey = `${datasetName}:${storageName}`;
       const oldVariable = oldVariables.get(variableKey);
 
       if (oldVariable) {
@@ -128,7 +128,9 @@ export const mutations = {
     // update dataset variables
     const dataset = state.datasets.find((d) => d.name === args.dataset);
     if (dataset) {
-      const variable = dataset.variables.find((v) => v.colName === args.field);
+      const variable = dataset.variables.find(
+        (v) => v.storageName === args.field
+      );
       if (variable) {
         variable.colType = args.type;
       }
@@ -136,7 +138,7 @@ export const mutations = {
 
     // update variables
     const variable = state.variables.find((v) => {
-      return v.colName === args.field && v.datasetName === args.dataset;
+      return v.storageName === args.field && v.datasetName === args.dataset;
     });
 
     if (variable) {
@@ -171,7 +173,7 @@ export const mutations = {
   },
   reviewVariableType(state: DatasetState, update) {
     const index = _.findIndex(state.variables, (v) => {
-      return v.colName === update.field;
+      return v.storageName === update.field;
     });
     state.variables[index].isColTypeReviewed = update.isColTypeReviewed;
   },
@@ -213,8 +215,8 @@ export const mutations = {
     if (!_.isEmpty(rankings)) {
       state.variables.forEach((v) => {
         let rank = 0;
-        if (rankings[v.colName]) {
-          rank = rankings[v.colName];
+        if (rankings[v.storageName]) {
+          rank = rankings[v.storageName];
         }
         Vue.set(v, "ranking", rank);
       });

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -91,13 +91,13 @@ export const mutations = {
     const oldVariables = new Map();
 
     state.variables.forEach((variable) => {
-      const { datasetName, storageName } = variable;
-      oldVariables.set(`${datasetName}:${storageName}`, variable);
+      const { datasetName, key } = variable;
+      oldVariables.set(`${datasetName}:${key}`, variable);
     });
 
     const newVariables = variables.map((variable) => {
-      const { datasetName, storageName } = variable;
-      const variableKey = `${datasetName}:${storageName}`;
+      const { datasetName, key } = variable;
+      const variableKey = `${datasetName}:${key}`;
       const oldVariable = oldVariables.get(variableKey);
 
       if (oldVariable) {
@@ -128,9 +128,7 @@ export const mutations = {
     // update dataset variables
     const dataset = state.datasets.find((d) => d.name === args.dataset);
     if (dataset) {
-      const variable = dataset.variables.find(
-        (v) => v.storageName === args.field
-      );
+      const variable = dataset.variables.find((v) => v.key === args.field);
       if (variable) {
         variable.colType = args.type;
       }
@@ -138,7 +136,7 @@ export const mutations = {
 
     // update variables
     const variable = state.variables.find((v) => {
-      return v.storageName === args.field && v.datasetName === args.dataset;
+      return v.key === args.field && v.datasetName === args.dataset;
     });
 
     if (variable) {
@@ -173,7 +171,7 @@ export const mutations = {
   },
   reviewVariableType(state: DatasetState, update) {
     const index = _.findIndex(state.variables, (v) => {
-      return v.storageName === update.field;
+      return v.key === update.field;
     });
     state.variables[index].isColTypeReviewed = update.isColTypeReviewed;
   },
@@ -215,8 +213,8 @@ export const mutations = {
     if (!_.isEmpty(rankings)) {
       state.variables.forEach((v) => {
         let rank = 0;
-        if (rankings[v.storageName]) {
-          rank = rankings[v.storageName];
+        if (rankings[v.key]) {
+          rank = rankings[v.key];
         }
         Vue.set(v, "ranking", rank);
       });

--- a/public/store/predictions/actions.ts
+++ b/public/store/predictions/actions.ts
@@ -70,28 +70,28 @@ export const actions = {
     const routeKey = minimumRouteKey();
 
     args.training.forEach((variable) => {
-      const key = variable.colName;
+      const key = variable.storageName;
       const label = variable.colDisplayName;
       const description = variable.colDescription;
       const existingVariableSummary =
-        summariesByVariable?.[variable.colName]?.[routeKey];
+        summariesByVariable?.[variable.storageName]?.[routeKey];
 
       if (existingVariableSummary) {
         promises.push(existingVariableSummary);
       } else {
-        if (summariesByVariable[variable.colName]) {
+        if (summariesByVariable[variable.storageName]) {
           // if we have any saved state for that variable
           // use that as placeholder due to vue lifecycle
           const tempVariableSummaryKey = Object.keys(
-            summariesByVariable[variable.colName]
+            summariesByVariable[variable.storageName]
           )[0];
           promises.push(
-            summariesByVariable[variable.colName][tempVariableSummaryKey]
+            summariesByVariable[variable.storageName][tempVariableSummaryKey]
           );
         } else {
           // add a loading placeholder if nothing exists for that variable
           createPendingSummary(
-            variable.colName,
+            variable.storageName,
             variable.colDisplayName,
             variable.colDescription,
             args.dataset
@@ -105,8 +105,8 @@ export const actions = {
             variable: variable,
             resultID: resultId,
             highlight: args.highlight,
-            varMode: args.varModes.has(variable.colName)
-              ? args.varModes.get(variable.colName)
+            varMode: args.varModes.has(variable.storageName)
+              ? args.varModes.get(variable.storageName)
               : SummaryMode.Default,
           })
         );
@@ -150,18 +150,22 @@ export const actions = {
     filterParams = addHighlightToFilterParams(filterParams, args.highlight);
     try {
       const response = await axios.post(
-        `/distil/training-summary/${args.dataset}/${args.variable.colName}/${args.resultID}/${args.varMode}`,
+        `/distil/training-summary/${args.dataset}/${args.variable.storageName}/${args.resultID}/${args.varMode}`,
         filterParams
       );
       const summary = response.data.summary;
-      await fetchSummaryExemplars(args.dataset, args.variable.colName, summary);
+      await fetchSummaryExemplars(
+        args.dataset,
+        args.variable.storageName,
+        summary
+      );
       mutations.updateTrainingSummary(context, summary);
     } catch (error) {
       console.error(error);
       mutations.updateTrainingSummary(
         context,
         createErrorSummary(
-          args.variable.colName,
+          args.variable.storageName,
           args.variable.colDisplayName,
           args.dataset,
           error

--- a/public/store/predictions/actions.ts
+++ b/public/store/predictions/actions.ts
@@ -70,28 +70,28 @@ export const actions = {
     const routeKey = minimumRouteKey();
 
     args.training.forEach((variable) => {
-      const key = variable.storageName;
+      const key = variable.key;
       const label = variable.colDisplayName;
       const description = variable.colDescription;
       const existingVariableSummary =
-        summariesByVariable?.[variable.storageName]?.[routeKey];
+        summariesByVariable?.[variable.key]?.[routeKey];
 
       if (existingVariableSummary) {
         promises.push(existingVariableSummary);
       } else {
-        if (summariesByVariable[variable.storageName]) {
+        if (summariesByVariable[variable.key]) {
           // if we have any saved state for that variable
           // use that as placeholder due to vue lifecycle
           const tempVariableSummaryKey = Object.keys(
-            summariesByVariable[variable.storageName]
+            summariesByVariable[variable.key]
           )[0];
           promises.push(
-            summariesByVariable[variable.storageName][tempVariableSummaryKey]
+            summariesByVariable[variable.key][tempVariableSummaryKey]
           );
         } else {
           // add a loading placeholder if nothing exists for that variable
           createPendingSummary(
-            variable.storageName,
+            variable.key,
             variable.colDisplayName,
             variable.colDescription,
             args.dataset
@@ -105,8 +105,8 @@ export const actions = {
             variable: variable,
             resultID: resultId,
             highlight: args.highlight,
-            varMode: args.varModes.has(variable.storageName)
-              ? args.varModes.get(variable.storageName)
+            varMode: args.varModes.has(variable.key)
+              ? args.varModes.get(variable.key)
               : SummaryMode.Default,
           })
         );
@@ -150,22 +150,18 @@ export const actions = {
     filterParams = addHighlightToFilterParams(filterParams, args.highlight);
     try {
       const response = await axios.post(
-        `/distil/training-summary/${args.dataset}/${args.variable.storageName}/${args.resultID}/${args.varMode}`,
+        `/distil/training-summary/${args.dataset}/${args.variable.key}/${args.resultID}/${args.varMode}`,
         filterParams
       );
       const summary = response.data.summary;
-      await fetchSummaryExemplars(
-        args.dataset,
-        args.variable.storageName,
-        summary
-      );
+      await fetchSummaryExemplars(args.dataset, args.variable.key, summary);
       mutations.updateTrainingSummary(context, summary);
     } catch (error) {
       console.error(error);
       mutations.updateTrainingSummary(
         context,
         createErrorSummary(
-          args.variable.storageName,
+          args.variable.key,
           args.variable.colDisplayName,
           args.dataset,
           error

--- a/public/store/requests/getters.ts
+++ b/public/store/requests/getters.ts
@@ -123,7 +123,7 @@ export const getters = {
   ): Variable[] {
     const target = <string>getters.getRouteTargetVariable;
     const variables = <Variable[]>getters.getVariables;
-    return variables.filter((variable) => variable.colName === target);
+    return variables.filter((variable) => variable.storageName === target);
   },
 
   // Returns in-progress predictions.

--- a/public/store/requests/getters.ts
+++ b/public/store/requests/getters.ts
@@ -123,7 +123,7 @@ export const getters = {
   ): Variable[] {
     const target = <string>getters.getRouteTargetVariable;
     const variables = <Variable[]>getters.getVariables;
-    return variables.filter((variable) => variable.storageName === target);
+    return variables.filter((variable) => variable.key === target);
   },
 
   // Returns in-progress predictions.

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -76,24 +76,24 @@ export const actions = {
 
     args.training.forEach((variable) => {
       const existingVariableSummary =
-        summariesByVariable?.[variable.storageName]?.[routeKey];
+        summariesByVariable?.[variable.key]?.[routeKey];
 
       if (existingVariableSummary) {
         promises.push(existingVariableSummary);
       } else {
-        if (summariesByVariable[variable.storageName]) {
+        if (summariesByVariable[variable.key]) {
           // if we have any saved state for that variable
           // use that as placeholder due to vue lifecycle
           const tempVariableSummaryKey = Object.keys(
-            summariesByVariable[variable.storageName]
+            summariesByVariable[variable.key]
           )[0];
           promises.push(
-            summariesByVariable[variable.storageName][tempVariableSummaryKey]
+            summariesByVariable[variable.key][tempVariableSummaryKey]
           );
         } else {
           // add a loading placeholder if nothing exists for that variable
           createPendingSummary(
-            variable.storageName,
+            variable.key,
             variable.colDisplayName,
             variable.colDescription,
             args.dataset
@@ -108,8 +108,8 @@ export const actions = {
             resultID: solution.resultId,
             highlight: args.highlight,
             dataMode: dataMode,
-            varMode: args.varModes.has(variable.storageName)
-              ? args.varModes.get(variable.storageName)
+            varMode: args.varModes.has(variable.key)
+              ? args.varModes.get(variable.key)
               : SummaryMode.Default,
           })
         );
@@ -157,22 +157,18 @@ export const actions = {
 
     try {
       const response = await axios.post(
-        `/distil/training-summary/${args.dataset}/${args.variable.storageName}/${args.resultID}/${args.varMode}`,
+        `/distil/training-summary/${args.dataset}/${args.variable.key}/${args.resultID}/${args.varMode}`,
         filterParams
       );
       const summary = response.data.summary;
-      await fetchSummaryExemplars(
-        args.dataset,
-        args.variable.storageName,
-        summary
-      );
+      await fetchSummaryExemplars(args.dataset, args.variable.key, summary);
       mutations.updateTrainingSummary(context, summary);
     } catch (error) {
       console.error(error);
       mutations.updateTrainingSummary(
         context,
         createErrorSummary(
-          args.variable.storageName,
+          args.variable.key,
           args.variable.colDisplayName,
           args.dataset,
           error

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -76,24 +76,24 @@ export const actions = {
 
     args.training.forEach((variable) => {
       const existingVariableSummary =
-        summariesByVariable?.[variable.colName]?.[routeKey];
+        summariesByVariable?.[variable.storageName]?.[routeKey];
 
       if (existingVariableSummary) {
         promises.push(existingVariableSummary);
       } else {
-        if (summariesByVariable[variable.colName]) {
+        if (summariesByVariable[variable.storageName]) {
           // if we have any saved state for that variable
           // use that as placeholder due to vue lifecycle
           const tempVariableSummaryKey = Object.keys(
-            summariesByVariable[variable.colName]
+            summariesByVariable[variable.storageName]
           )[0];
           promises.push(
-            summariesByVariable[variable.colName][tempVariableSummaryKey]
+            summariesByVariable[variable.storageName][tempVariableSummaryKey]
           );
         } else {
           // add a loading placeholder if nothing exists for that variable
           createPendingSummary(
-            variable.colName,
+            variable.storageName,
             variable.colDisplayName,
             variable.colDescription,
             args.dataset
@@ -108,8 +108,8 @@ export const actions = {
             resultID: solution.resultId,
             highlight: args.highlight,
             dataMode: dataMode,
-            varMode: args.varModes.has(variable.colName)
-              ? args.varModes.get(variable.colName)
+            varMode: args.varModes.has(variable.storageName)
+              ? args.varModes.get(variable.storageName)
               : SummaryMode.Default,
           })
         );
@@ -157,18 +157,22 @@ export const actions = {
 
     try {
       const response = await axios.post(
-        `/distil/training-summary/${args.dataset}/${args.variable.colName}/${args.resultID}/${args.varMode}`,
+        `/distil/training-summary/${args.dataset}/${args.variable.storageName}/${args.resultID}/${args.varMode}`,
         filterParams
       );
       const summary = response.data.summary;
-      await fetchSummaryExemplars(args.dataset, args.variable.colName, summary);
+      await fetchSummaryExemplars(
+        args.dataset,
+        args.variable.storageName,
+        summary
+      );
       mutations.updateTrainingSummary(context, summary);
     } catch (error) {
       console.error(error);
       mutations.updateTrainingSummary(
         context,
         createErrorSummary(
-          args.variable.colName,
+          args.variable.storageName,
           args.variable.colDisplayName,
           args.dataset,
           error

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -108,13 +108,13 @@ export const getters = {
     state: Route,
     getters: any
   ): VariableSummary[] {
-    function hashSummary(datasetName: string, storageName: string) {
-      return `${datasetName}:${storageName}`.toLowerCase();
+    function hashSummary(datasetName: string, key: string) {
+      return `${datasetName}:${key}`.toLowerCase();
     }
 
     const variables = getters.getJoinDatasetsVariables;
     const lookup = buildLookup(
-      variables.map((v) => hashSummary(v.datasetName, v.storageName))
+      variables.map((v) => hashSummary(v.datasetName, v.key))
     );
     const summaries = getters.getVariableSummaries ?? ([] as VariableSummary[]);
     return summaries.filter(
@@ -163,14 +163,14 @@ export const getters = {
         const filters = getters.getDecodedFilters;
 
         // only include filters for this dataset
-        const lookup = buildLookup(dataset.variables.map((v) => v.storageName));
+        const lookup = buildLookup(dataset.variables.map((v) => v.key));
         const filtersForDataset = filters.filter((f) => {
           return lookup[f.key];
         });
 
         const filterParams = _.cloneDeep({
           filters: filtersForDataset,
-          variables: dataset.variables.map((v) => v.storageName),
+          variables: dataset.variables.map((v) => v.key),
         });
         res[datasetID] = filterParams;
       }
@@ -397,9 +397,7 @@ export const getters = {
     const training = getters.getDecodedTrainingVariableNames;
     const lookup = buildLookup(training);
     const variables = getters.getVariables;
-    return variables.filter(
-      (variable) => lookup[variable.storageName.toLowerCase()]
-    );
+    return variables.filter((variable) => lookup[variable.key.toLowerCase()]);
   },
 
   getTrainingVariableSummaries(state: Route, getters: any): VariableSummary[] {
@@ -424,7 +422,7 @@ export const getters = {
     if (target) {
       const variables = getters.getVariables;
       const found = variables.filter(
-        (summary) => target.toLowerCase() === summary.storageName.toLowerCase()
+        (summary) => target.toLowerCase() === summary.key.toLowerCase()
       );
       if (found) {
         return found[0];
@@ -461,9 +459,7 @@ export const getters = {
     const lookup =
       training && target ? buildLookup(training.concat([target])) : null;
     if (!lookup) return variables ?? ([] as Variable[]);
-    return variables.filter(
-      (variable) => !lookup[variable.storageName.toLowerCase()]
-    );
+    return variables.filter((variable) => !lookup[variable.key.toLowerCase()]);
   },
 
   getActiveSolutionIndex(state: Route, getters: any): number {

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -108,13 +108,13 @@ export const getters = {
     state: Route,
     getters: any
   ): VariableSummary[] {
-    function hashSummary(datasetName: string, colName: string) {
-      return `${datasetName}:${colName}`.toLowerCase();
+    function hashSummary(datasetName: string, storageName: string) {
+      return `${datasetName}:${storageName}`.toLowerCase();
     }
 
     const variables = getters.getJoinDatasetsVariables;
     const lookup = buildLookup(
-      variables.map((v) => hashSummary(v.datasetName, v.colName))
+      variables.map((v) => hashSummary(v.datasetName, v.storageName))
     );
     const summaries = getters.getVariableSummaries ?? ([] as VariableSummary[]);
     return summaries.filter(
@@ -163,14 +163,14 @@ export const getters = {
         const filters = getters.getDecodedFilters;
 
         // only include filters for this dataset
-        const lookup = buildLookup(dataset.variables.map((v) => v.colName));
+        const lookup = buildLookup(dataset.variables.map((v) => v.storageName));
         const filtersForDataset = filters.filter((f) => {
           return lookup[f.key];
         });
 
         const filterParams = _.cloneDeep({
           filters: filtersForDataset,
-          variables: dataset.variables.map((v) => v.colName),
+          variables: dataset.variables.map((v) => v.storageName),
         });
         res[datasetID] = filterParams;
       }
@@ -398,7 +398,7 @@ export const getters = {
     const lookup = buildLookup(training);
     const variables = getters.getVariables;
     return variables.filter(
-      (variable) => lookup[variable.colName.toLowerCase()]
+      (variable) => lookup[variable.storageName.toLowerCase()]
     );
   },
 
@@ -424,7 +424,7 @@ export const getters = {
     if (target) {
       const variables = getters.getVariables;
       const found = variables.filter(
-        (summary) => target.toLowerCase() === summary.colName.toLowerCase()
+        (summary) => target.toLowerCase() === summary.storageName.toLowerCase()
       );
       if (found) {
         return found[0];
@@ -462,7 +462,7 @@ export const getters = {
       training && target ? buildLookup(training.concat([target])) : null;
     if (!lookup) return variables ?? ([] as Variable[]);
     return variables.filter(
-      (variable) => !lookup[variable.colName.toLowerCase()]
+      (variable) => !lookup[variable.storageName.toLowerCase()]
     );
   },
 

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -100,7 +100,7 @@ export enum LowShotLabels {
 // DatasetUpdate is an interface that contains the data to update existing data
 export interface DatasetUpdate {
   index: string; // d3mIndex
-  name: string; // colName
+  name: string; // storageName
   value: string; // new value to replace old value
 }
 
@@ -261,7 +261,7 @@ export function fetchSummaryExemplars(
   summary: VariableSummary
 ) {
   const variables = datasetGetters.getVariables(store);
-  const variable = variables.find((v) => v.colName === variableName);
+  const variable = variables.find((v) => v.storageName === variableName);
 
   const baselineExemplars = summary.baseline.exemplars;
   const filteredExemplars =
@@ -313,7 +313,7 @@ export function fetchResultExemplars(
   summary: VariableSummary
 ) {
   const variables = datasetGetters.getVariables(store);
-  const variable = variables.find((v) => v.colName === variableName);
+  const variable = variables.find((v) => v.storageName === variableName);
 
   const baselineExemplars = summary.baseline?.exemplars;
   const filteredExemplars = summary.filtered?.exemplars;
@@ -490,12 +490,14 @@ export function filterVariablesByFeature(variables: Variable[]): Variable[] {
   const hidden = new Map(hiddenFlat.map((v) => [v, v]));
 
   // the groupings that hide variables are themselves variables to display
-  const groupingDisplayed = new Map(groupingVars.map((v) => [v.colName, v]));
+  const groupingDisplayed = new Map(
+    groupingVars.map((v) => [v.storageName, v])
+  );
 
   return variables.filter(
     (v) =>
-      (v.distilRole === "data" && !hidden.has(v.colName)) ||
-      groupingDisplayed.has(v.colName)
+      (v.distilRole === "data" && !hidden.has(v.storageName)) ||
+      groupingDisplayed.has(v.storageName)
   );
 }
 
@@ -681,7 +683,7 @@ export function searchVariables(
     return (
       searchQuery === undefined ||
       searchQuery === "" ||
-      (v && v.colName.toLowerCase().includes(searchQuery.toLowerCase()))
+      (v && v.storageName.toLowerCase().includes(searchQuery.toLowerCase()))
     );
   });
 }
@@ -710,7 +712,7 @@ export function sortVariablesByImportance(variables: Variable[]): Variable[] {
     });
   }
   variables.sort((a, b) => {
-    return rankMap[b.colName] - rankMap[a.colName];
+    return rankMap[b.storageName] - rankMap[a.storageName];
   });
   return variables;
 }
@@ -732,7 +734,7 @@ export function getVariableSummariesByState(
 
   // remove any pattern cluster variables
   let sortedVariables = variables.filter((sv) => {
-    return sv.colName.indexOf(CLUSTER_PREFIX) < 0;
+    return sv.storageName.indexOf(CLUSTER_PREFIX) < 0;
   });
 
   if (ranked) {
@@ -745,22 +747,22 @@ export function getVariableSummariesByState(
 
   // map them back to the variable summary dictionary for the current route key
   const currentSummaries = sortedVariables.reduce((cs, vn) => {
-    if (!summaryDictionary[vn.colName]) {
+    if (!summaryDictionary[vn.storageName]) {
       const placeholder = createPendingSummary(
-        vn.colName,
+        vn.storageName,
         vn.colDisplayName,
         vn.colDescription,
         vn.datasetName
       );
       cs.push(placeholder);
     } else {
-      if (summaryDictionary[vn.colName][routeKey]) {
-        cs.push(summaryDictionary[vn.colName][routeKey]);
+      if (summaryDictionary[vn.storageName][routeKey]) {
+        cs.push(summaryDictionary[vn.storageName][routeKey]);
       } else {
         const tempVariableSummaryKey = Object.keys(
-          summaryDictionary[vn.colName]
+          summaryDictionary[vn.storageName]
         )[0];
-        cs.push(summaryDictionary[vn.colName][tempVariableSummaryKey]);
+        cs.push(summaryDictionary[vn.storageName][tempVariableSummaryKey]);
       }
     }
     return cs;
@@ -772,7 +774,7 @@ export function getVariableSummariesByState(
 export function getVariableImportance(v: Variable): number {
   const solutionID = routeGetters.getRouteSolutionId(store);
   const map = resultsGetters.getFeatureImportanceRanking(store)[solutionID];
-  return map[v.colName];
+  return map[v.storageName];
 }
 
 export function getVariableRanking(v: Variable): number {
@@ -781,7 +783,7 @@ export function getVariableRanking(v: Variable): number {
   if (!map) {
     return v.importance; // if MI ranking does not exist default to PCA
   }
-  return map[v.colName];
+  return map[v.storageName];
 }
 
 export function getSolutionFeatureImportance(
@@ -792,7 +794,7 @@ export function getSolutionFeatureImportance(
     solutionID
   ];
   if (solutionRanks) {
-    return solutionRanks[v.colName];
+    return solutionRanks[v.storageName];
   }
   return null;
 }
@@ -893,13 +895,13 @@ export function getTableDataItems(data: TableData): TableRow[] {
     const formattedTable = data.values.map((resultRow, rowIndex) => {
       const row = {} as TableRow;
       resultRow.forEach((colValue, colIndex) => {
-        const colName = data.columns[colIndex].key;
+        const storageName = data.columns[colIndex].key;
         const colType = data.columns[colIndex].type;
-        if (colName !== "d3mIndex") {
-          row[colName] = {};
-          row[colName].value = formatValue(colValue.value, colType);
+        if (storageName !== "d3mIndex") {
+          row[storageName] = {};
+          row[storageName].value = formatValue(colValue.value, colType);
           if (colValue.weight !== null && colValue.weight !== undefined) {
-            row[colName].weight = colValue.weight;
+            row[storageName].weight = colValue.weight;
           }
           if (colValue.confidence !== undefined) {
             const conKey = "confidence";
@@ -907,7 +909,7 @@ export function getTableDataItems(data: TableData): TableRow[] {
             row[conKey].value = colValue.confidence;
           }
         } else {
-          row[colName] = formatValue(colValue.value, colType);
+          row[storageName] = formatValue(colValue.value, colType);
         }
       });
       row._key = rowIndex;
@@ -946,20 +948,20 @@ export function getTableDataFields(data: TableData): Dictionary<TableColumn> {
       if (isPredictedCol(col.key)) {
         variable = requestGetters.getActiveSolutionTargetVariable(store)[0]; // always a single value
         label = variable.colDisplayName;
-        description = `Model predicted value for ${variable.colName}`;
+        description = `Model predicted value for ${variable.storageName}`;
 
         result.confidence = {
           label: "Confidence",
           key: "confidence",
           type: "numeric",
           weight: null,
-          headerTitle: `Prediction confidence ${variable.colName}`,
+          headerTitle: `Prediction confidence ${variable.storageName}`,
           sortable: true,
         };
       } else if (isErrorCol(col.key)) {
         variable = requestGetters.getActiveSolutionTargetVariable(store)[0];
         label = "Error";
-        description = `Difference between actual and predicted value for ${variable.colName}`;
+        description = `Difference between actual and predicted value for ${variable.storageName}`;
       } else {
         variable = variables[col.key];
         label = col.label;
@@ -1124,7 +1126,7 @@ export function hasTimeseriesFeatures(variables: Variable[]): boolean {
   if (
     (valueColumns.length === 1 &&
       timeColumns.length === 1 &&
-      valueColumns[0].colName !== timeColumns[0].colName) ||
+      valueColumns[0].storageName !== timeColumns[0].storageName) ||
     (valueColumns.length > 1 && timeColumns.length > 0) ||
     (valueColumns.length > 0 && timeColumns.length > 1)
   ) {
@@ -1140,7 +1142,7 @@ export function hasGeoordinateFeatures(variables: Variable[]): boolean {
   if (
     (latColumns.length === 1 &&
       lonColumns.length === 1 &&
-      latColumns[0].colName !== lonColumns[0].colName) ||
+      latColumns[0].storageName !== lonColumns[0].storageName) ||
     (latColumns.length > 1 && lonColumns.length > 0) ||
     (latColumns.length > 0 && lonColumns.length > 1)
   ) {

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -95,10 +95,10 @@ export interface NumericalFacet {
 
 export interface Group {
   dataset: string;
-  key: string;
   label: string;
   description: string;
   key: string;
+  groupKey: string;
   type: string;
   collapsible: boolean;
   collapsed: boolean;

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -95,7 +95,7 @@ export interface NumericalFacet {
 
 export interface Group {
   dataset: string;
-  colName: string;
+  storageName: string;
   label: string;
   description: string;
   key: string;

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -95,7 +95,7 @@ export interface NumericalFacet {
 
 export interface Group {
   dataset: string;
-  storageName: string;
+  key: string;
   label: string;
   description: string;
   key: string;

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -50,7 +50,7 @@ export function createFilterFromHighlight(
 
   const variables = datasetGetters.getVariables(store);
 
-  const variable = variables.find((v) => v.storageName === key);
+  const variable = variables.find((v) => v.key === key);
   let grouping = null;
   if (variable && variable.grouping) {
     grouping = variable.grouping;

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -50,7 +50,7 @@ export function createFilterFromHighlight(
 
   const variables = datasetGetters.getVariables(store);
 
-  const variable = variables.find((v) => v.colName === key);
+  const variable = variables.find((v) => v.storageName === key);
   let grouping = null;
   if (variable && variable.grouping) {
     grouping = variable.grouping;

--- a/public/util/lex.ts
+++ b/public/util/lex.ts
@@ -70,7 +70,7 @@ export function filterParamsToLexQuery(
 ) {
   const filters = decodeFilters(filter);
   const variableDict = allVariables.reduce((a, v) => {
-    a[v.colName] = v;
+    a[v.storageName] = v;
     return a;
   }, {});
   const filterVariables = filters.map((f) => {
@@ -106,7 +106,7 @@ export function lexQueryToFilters(
   allVariables: Variable[]
 ): Filter[] {
   const variableDict = allVariables.reduce((a, v) => {
-    a[v.colName] = v;
+    a[v.storageName] = v;
     return a;
   }, {});
 

--- a/public/util/lex.ts
+++ b/public/util/lex.ts
@@ -70,7 +70,7 @@ export function filterParamsToLexQuery(
 ) {
   const filters = decodeFilters(filter);
   const variableDict = allVariables.reduce((a, v) => {
-    a[v.storageName] = v;
+    a[v.key] = v;
     return a;
   }, {});
   const filterVariables = filters.map((f) => {
@@ -106,7 +106,7 @@ export function lexQueryToFilters(
   allVariables: Variable[]
 ): Filter[] {
   const variableDict = allVariables.reduce((a, v) => {
-    a[v.storageName] = v;
+    a[v.key] = v;
     return a;
   }, {});
 

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -228,7 +228,7 @@ export default Vue.extend({
 
     selectedVariables(): Variable[] {
       return this.variables.filter((v) =>
-        this.cleanTraining.includes(v.storageName.toLowerCase())
+        this.cleanTraining.includes(v.key.toLowerCase())
       );
     },
 
@@ -254,7 +254,7 @@ export default Vue.extend({
 
     variablesPerActions(): any {
       const nonSelectedVariables = this.variables.filter(
-        (v) => !this.cleanTraining.includes(v.storageName.toLowerCase())
+        (v) => !this.cleanTraining.includes(v.key.toLowerCase())
       );
 
       const variables = {};

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -228,7 +228,7 @@ export default Vue.extend({
 
     selectedVariables(): Variable[] {
       return this.variables.filter((v) =>
-        this.cleanTraining.includes(v.colName.toLowerCase())
+        this.cleanTraining.includes(v.storageName.toLowerCase())
       );
     },
 
@@ -254,7 +254,7 @@ export default Vue.extend({
 
     variablesPerActions(): any {
       const nonSelectedVariables = this.variables.filter(
-        (v) => !this.cleanTraining.includes(v.colName.toLowerCase())
+        (v) => !this.cleanTraining.includes(v.storageName.toLowerCase())
       );
 
       const variables = {};

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -148,7 +148,7 @@ export default Vue.extend({
     searchedActiveVariables(): Variable[] {
       // remove variables used in groupedFeature;
       const activeVariables = this.variables.filter(
-        (v) => !this.groupedFeatures.includes(v.colName)
+        (v) => !this.groupedFeatures.includes(v.storageName)
       );
 
       return searchVariables(activeVariables, this.availableTargetVarsSearch);
@@ -363,7 +363,7 @@ export default Vue.extend({
       const taskResponse = await datasetActions.fetchTask(this.$store, {
         dataset: this.dataset,
         targetName: LOW_SHOT_LABEL_COLUMN_NAME,
-        variableNames: this.variables.map((v) => v.colName),
+        variableNames: this.variables.map((v) => v.storageName),
       });
       const training = routeGetters.getDecodedTrainingVariableNames(
         this.$store
@@ -375,8 +375,8 @@ export default Vue.extend({
         })
       );
       this.variables.forEach((variable) => {
-        if (!trainingMap.has(variable.colName)) {
-          training.push(variable.colName);
+        if (!trainingMap.has(variable.storageName)) {
+          training.push(variable.storageName);
         }
       });
       if (check === training.length) {

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -141,7 +141,7 @@ export default Vue.extend({
     searchedActiveVariables(): Variable[] {
       // remove variables used in groupedFeature;
       const activeVariables = this.variables.filter(
-        (v) => !this.groupedFeatures.includes(v.storageName)
+        (v) => !this.groupedFeatures.includes(v.key)
       );
 
       return searchVariables(activeVariables, this.availableTargetVarsSearch);
@@ -382,7 +382,7 @@ export default Vue.extend({
       const taskResponse = await datasetActions.fetchTask(this.$store, {
         dataset: this.dataset,
         targetName: LOW_SHOT_LABEL_COLUMN_NAME,
-        variableNames: this.variables.map((v) => v.storageName),
+        variableNames: this.variables.map((v) => v.key),
       });
       const training = routeGetters.getDecodedTrainingVariableNames(
         this.$store
@@ -394,8 +394,8 @@ export default Vue.extend({
         })
       );
       this.variables.forEach((variable) => {
-        if (!trainingMap.has(variable.storageName)) {
-          training.push(variable.storageName);
+        if (!trainingMap.has(variable.key)) {
+          training.push(variable.key);
         }
       });
       if (check === training.length) {

--- a/public/views/SelectTarget.vue
+++ b/public/views/SelectTarget.vue
@@ -115,7 +115,7 @@ export default Vue.extend({
         const container = document.createElement("div");
         const targetElem = document.createElement("button");
 
-        const unsupported = this.unsupportedTargets.has(group.storageName);
+        const unsupported = this.unsupportedTargets.has(group.key);
         targetElem.className += "btn btn-sm btn-success mb-2";
         if (unsupported) {
           targetElem.className += " disabled";
@@ -125,7 +125,7 @@ export default Vue.extend({
         if (!unsupported) {
           // only add listener on supported target types
           targetElem.addEventListener("click", () => {
-            const target = group.storageName;
+            const target = group.key;
             // remove from training
             const training = routeGetters.getDecodedTrainingVariableNames(
               this.$store
@@ -136,7 +136,7 @@ export default Vue.extend({
             }
 
             const v = this.variables.find((v) => {
-              return v.storageName === group.storageName;
+              return v.key === group.key;
             });
             if (v && v.grouping) {
               if (v.grouping.subIds.length > 0) {
@@ -163,7 +163,7 @@ export default Vue.extend({
             datasetActions
               .fetchTask(this.$store, {
                 dataset: dataset,
-                targetName: group.storageName,
+                targetName: group.key,
                 variableNames: [],
               })
               .then((response) => {
@@ -174,7 +174,7 @@ export default Vue.extend({
                 );
                 if (task.includes("timeseries")) {
                   training.forEach((v) => {
-                    if (v !== group.storageName) {
+                    if (v !== group.key) {
                       varModesMap.set(v, SummaryMode.Timeseries);
                     }
                   });
@@ -182,7 +182,7 @@ export default Vue.extend({
                 const varModesStr = varModesToString(varModesMap);
 
                 const routeArgs = {
-                  target: group.storageName,
+                  target: group.key,
                   dataset: dataset,
                   filters: routeGetters.getRouteFilters(this.$store),
                   training: training.join(","),
@@ -194,7 +194,7 @@ export default Vue.extend({
                   feature: Feature.SELECT_TARGET,
                   activity: Activity.PROBLEM_DEFINITION,
                   subActivity: SubActivity.PROBLEM_SPECIFICATION,
-                  details: { target: group.storageName },
+                  details: { target: group.key },
                 });
 
                 const entry = createRouteEntry(
@@ -256,8 +256,8 @@ export default Vue.extend({
     unsupportedTargets(): Set<string> {
       return new Set(
         this.variables
-          .filter((v) => isUnsupportedTargetVar(v.storageName, v.colType))
-          .map((v) => v.storageName)
+          .filter((v) => isUnsupportedTargetVar(v.key, v.colType))
+          .map((v) => v.key)
       );
     },
 
@@ -268,7 +268,7 @@ export default Vue.extend({
     searchedActiveVariables(): Variable[] {
       // remove variables used in groupedFeature;
       const activeVariables = this.variables.filter(
-        (v) => !this.groupedFeatures.includes(v.storageName)
+        (v) => !this.groupedFeatures.includes(v.key)
       );
 
       return searchVariables(activeVariables, this.availableTargetVarsSearch);

--- a/public/views/SelectTarget.vue
+++ b/public/views/SelectTarget.vue
@@ -115,7 +115,7 @@ export default Vue.extend({
         const container = document.createElement("div");
         const targetElem = document.createElement("button");
 
-        const unsupported = this.unsupportedTargets.has(group.colName);
+        const unsupported = this.unsupportedTargets.has(group.storageName);
         targetElem.className += "btn btn-sm btn-success mb-2";
         if (unsupported) {
           targetElem.className += " disabled";
@@ -125,7 +125,7 @@ export default Vue.extend({
         if (!unsupported) {
           // only add listener on supported target types
           targetElem.addEventListener("click", () => {
-            const target = group.colName;
+            const target = group.storageName;
             // remove from training
             const training = routeGetters.getDecodedTrainingVariableNames(
               this.$store
@@ -136,7 +136,7 @@ export default Vue.extend({
             }
 
             const v = this.variables.find((v) => {
-              return v.colName === group.colName;
+              return v.storageName === group.storageName;
             });
             if (v && v.grouping) {
               if (v.grouping.subIds.length > 0) {
@@ -163,7 +163,7 @@ export default Vue.extend({
             datasetActions
               .fetchTask(this.$store, {
                 dataset: dataset,
-                targetName: group.colName,
+                targetName: group.storageName,
                 variableNames: [],
               })
               .then((response) => {
@@ -174,7 +174,7 @@ export default Vue.extend({
                 );
                 if (task.includes("timeseries")) {
                   training.forEach((v) => {
-                    if (v !== group.colName) {
+                    if (v !== group.storageName) {
                       varModesMap.set(v, SummaryMode.Timeseries);
                     }
                   });
@@ -182,7 +182,7 @@ export default Vue.extend({
                 const varModesStr = varModesToString(varModesMap);
 
                 const routeArgs = {
-                  target: group.colName,
+                  target: group.storageName,
                   dataset: dataset,
                   filters: routeGetters.getRouteFilters(this.$store),
                   training: training.join(","),
@@ -194,7 +194,7 @@ export default Vue.extend({
                   feature: Feature.SELECT_TARGET,
                   activity: Activity.PROBLEM_DEFINITION,
                   subActivity: SubActivity.PROBLEM_SPECIFICATION,
-                  details: { target: group.colName },
+                  details: { target: group.storageName },
                 });
 
                 const entry = createRouteEntry(
@@ -256,8 +256,8 @@ export default Vue.extend({
     unsupportedTargets(): Set<string> {
       return new Set(
         this.variables
-          .filter((v) => isUnsupportedTargetVar(v.colName, v.colType))
-          .map((v) => v.colName)
+          .filter((v) => isUnsupportedTargetVar(v.storageName, v.colType))
+          .map((v) => v.storageName)
       );
     },
 
@@ -268,7 +268,7 @@ export default Vue.extend({
     searchedActiveVariables(): Variable[] {
       // remove variables used in groupedFeature;
       const activeVariables = this.variables.filter(
-        (v) => !this.groupedFeatures.includes(v.colName)
+        (v) => !this.groupedFeatures.includes(v.storageName)
       );
 
       return searchVariables(activeVariables, this.availableTargetVarsSearch);

--- a/public/views/VariableGrouping.vue
+++ b/public/views/VariableGrouping.vue
@@ -322,10 +322,10 @@ export default Vue.extend({
 
       const suggestions = this.variables
         .filter((v) => xFilterFunction(v.colType))
-        .filter((v) => !this.isIDCol(v.storageName))
-        .filter((v) => !this.isYCol(v.storageName))
+        .filter((v) => !this.isIDCol(v.key))
+        .filter((v) => !this.isYCol(v.key))
         .map((v) => {
-          return { value: v.storageName, text: v.colDisplayName };
+          return { value: v.key, text: v.colDisplayName };
         });
       return [].concat([def], suggestions);
     },
@@ -352,10 +352,10 @@ export default Vue.extend({
 
       const suggestions = this.variables
         .filter((v) => yFilterFunction(v.colType))
-        .filter((v) => !this.isIDCol(v.storageName))
-        .filter((v) => !this.isXCol(v.storageName))
+        .filter((v) => !this.isIDCol(v.key))
+        .filter((v) => !this.isXCol(v.key))
         .map((v) => {
-          return { value: v.storageName, text: v.colDisplayName };
+          return { value: v.key, text: v.colDisplayName };
         });
       return [].concat(def, suggestions);
     },
@@ -426,9 +426,9 @@ export default Vue.extend({
       };
       const suggestions = this.variables
         .filter((v) => ID_COL_TYPES[v.colType])
-        .filter((v) => v.storageName === idCol || !this.isIDCol(v.storageName))
+        .filter((v) => v.key === idCol || !this.isIDCol(v.key))
         .map((v) => {
-          return { value: v.storageName, text: v.colDisplayName };
+          return { value: v.key, text: v.colDisplayName };
         });
 
       if (suggestions.length > 0) {

--- a/public/views/VariableGrouping.vue
+++ b/public/views/VariableGrouping.vue
@@ -322,10 +322,10 @@ export default Vue.extend({
 
       const suggestions = this.variables
         .filter((v) => xFilterFunction(v.colType))
-        .filter((v) => !this.isIDCol(v.colName))
-        .filter((v) => !this.isYCol(v.colName))
+        .filter((v) => !this.isIDCol(v.storageName))
+        .filter((v) => !this.isYCol(v.storageName))
         .map((v) => {
-          return { value: v.colName, text: v.colDisplayName };
+          return { value: v.storageName, text: v.colDisplayName };
         });
       return [].concat([def], suggestions);
     },
@@ -352,10 +352,10 @@ export default Vue.extend({
 
       const suggestions = this.variables
         .filter((v) => yFilterFunction(v.colType))
-        .filter((v) => !this.isIDCol(v.colName))
-        .filter((v) => !this.isXCol(v.colName))
+        .filter((v) => !this.isIDCol(v.storageName))
+        .filter((v) => !this.isXCol(v.storageName))
         .map((v) => {
-          return { value: v.colName, text: v.colDisplayName };
+          return { value: v.storageName, text: v.colDisplayName };
         });
       return [].concat(def, suggestions);
     },
@@ -426,9 +426,9 @@ export default Vue.extend({
       };
       const suggestions = this.variables
         .filter((v) => ID_COL_TYPES[v.colType])
-        .filter((v) => v.colName === idCol || !this.isIDCol(v.colName))
+        .filter((v) => v.storageName === idCol || !this.isIDCol(v.storageName))
         .map((v) => {
-          return { value: v.colName, text: v.colDisplayName };
+          return { value: v.storageName, text: v.colDisplayName };
         });
 
       if (suggestions.length > 0) {


### PR DESCRIPTION
The commercial datasets were not being ingested in part due to invisible characters in the header leading to discrepancies between the header row field name and the metadata field name. Invisible characters are now stripped from the header row.

The same datasets also highlighted issues with spaces in the header. These were caused by the introduction of the storage name fields to separate the name used by TA2 and the name used by our storage (ES, PG). When that change was done, `colName` was able to have any character, whereas the new field was limited by PH naming restrictions. As part of this PR, the client was changed to use a variable storage name as key rather than `colName`. `colName` refers to the name of the column in the header row of the file (used by TA2) but the server uses the storage name as variable key. Ideally, we would have a set of structures that handle the client-server I/O and represent the necessary data exchanged, but since none of that exists it was more feasible to update the client.

The relevant issue should not be closed yet. It should only be closed once we confirm that staging works.