### PR TITLE
Image query UI fixes

### DIFF
--- a/api/routes/save_dataset.go
+++ b/api/routes/save_dataset.go
@@ -42,6 +42,16 @@ func SaveDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStora
 			handleError(w, err)
 			return
 		}
+		shouldRename := false
+		datasetName, ok := params["datasetName"].(string)
+		if ok {
+			// check if the new name is not equal to previous
+			if datasetName != dataset {
+				// update meta info to new name
+				shouldRename = true
+			}
+		}
+
 		// get storage clients
 		metaStorage, err := metaCtor()
 		if err != nil {
@@ -64,7 +74,7 @@ func SaveDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStora
 			handleError(w, err)
 			return
 		}
-		if ds.Immutable{
+		if ds.Immutable {
 			handleError(w, errors.New("can not mutate an immutable dataset"))
 			return
 		}
@@ -83,6 +93,9 @@ func SaveDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStora
 		ds.Immutable = true
 		// is no longer a clone due to the dropping of the filterParams
 		ds.Clone = false
+		if shouldRename {
+			ds.Name = datasetName
+		}
 		err = metaStorage.UpdateDataset(ds)
 		if err != nil {
 			handleError(w, err)

--- a/public/components/labelingComponents/CreateLabelingForm.vue
+++ b/public/components/labelingComponents/CreateLabelingForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="form-container">
-    <div class="control-group">
+    <div>
       <b-button :disabled="isLoading" size="lg" @click="onEvent(applyEvent)">
         <template v-if="isLoading">
           <div v-html="spinnerHTML" />
@@ -44,6 +44,9 @@ export default Vue.extend({
     exportEvent(): string {
       return COMPONENT_EVENT.EXPORT;
     },
+    annotationHasChanged(): boolean {
+      return true;
+    },
   },
   methods: {
     onEvent(event: COMPONENT_EVENT) {
@@ -57,13 +60,9 @@ export default Vue.extend({
 .form-container {
   display: flex;
   justify-content: space-between;
+  height: 15%;
 }
 
-.control-group {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
 .check-box {
   margin-left: 16px;
 }

--- a/public/components/labelingComponents/CreateLabelingForm.vue
+++ b/public/components/labelingComponents/CreateLabelingForm.vue
@@ -1,7 +1,14 @@
 <template>
   <div class="form-container">
     <div>
-      <b-button :disabled="isLoading" size="lg" @click="onEvent(applyEvent)">
+      <b-button
+        :disabled="
+          isLoading || !minimumRequirementsMet || !annotationHasChanged
+        "
+        size="lg"
+        @click="onEvent(applyEvent)"
+        title="must have 1 positive and negative label"
+      >
         <template v-if="isLoading">
           <div v-html="spinnerHTML" />
         </template>
@@ -20,7 +27,11 @@
 <script lang="ts">
 import Vue from "vue";
 import { circleSpinnerHTML } from "../../util/spinner";
-
+import { getters as datasetGetters } from "../../store/dataset/module";
+import { VariableSummary } from "../../store/dataset";
+import { Dictionary } from "../../util/dict";
+import { LowShotLabels, LOW_SHOT_LABEL_COLUMN_NAME } from "../../util/data";
+import { getters as routeGetters } from "../../store/route/module";
 const enum COMPONENT_EVENT {
   EXPORT = "export",
   SAVE = "save",
@@ -30,6 +41,7 @@ export default Vue.extend({
   name: "create-labeling-form",
   props: {
     isLoading: { type: Boolean as () => boolean, default: false },
+    lowShotSummary: Object as () => VariableSummary,
   },
   computed: {
     spinnerHTML(): string {
@@ -45,7 +57,26 @@ export default Vue.extend({
       return COMPONENT_EVENT.EXPORT;
     },
     annotationHasChanged(): boolean {
-      return true;
+      return routeGetters.getAnnotationHasChanged(this.$store);
+    },
+    minimumRequirementsMet(): boolean {
+      const keys = new Map(
+        this.lowShotSummary?.baseline?.buckets.map((b) => [b.key, true])
+      );
+      if (!keys) {
+        return false;
+      }
+      return (
+        keys.has(LowShotLabels.positive) && keys.has(LowShotLabels.negative)
+      );
+    },
+    lowShotLabel(): Dictionary<VariableSummary> {
+      const summaryDictionary = datasetGetters.getVariableSummariesDictionary(
+        this.$store
+      );
+      return summaryDictionary
+        ? summaryDictionary[LOW_SHOT_LABEL_COLUMN_NAME]
+        : null;
     },
   },
   methods: {

--- a/public/components/labelingComponents/LabelingDataSlot.vue
+++ b/public/components/labelingComponents/LabelingDataSlot.vue
@@ -1,6 +1,21 @@
 <template>
-  <div class="h-75">
-    <div class="d-flex justify-content-around m-1">
+  <div class="flex-1 d-flex flex-column pb-1 pt-2">
+    <div class="fake-search-input">
+      <filter-badge v-if="activeFilter" active-filter :filter="activeFilter" />
+      <filter-badge
+        v-for="(filter, index) in filters"
+        :key="index"
+        :filter="filter"
+      />
+    </div>
+    <div class="d-flex justify-content-between m-1">
+      <p class="selection-data-slot-summary">
+        <strong class="matching-color">matching</strong> samples of
+        {{ numRows }} to model<template v-if="selectionNumRows > 0">
+          , {{ selectionNumRows }}
+          <strong class="selected-color">selected</strong>
+        </template>
+      </p>
       <label-header-buttons
         @button-event="onAnnotationClicked"
         @select-all="onSelectAll"
@@ -40,6 +55,7 @@ import {
   TableRow,
   TableColumn,
   RowSelection,
+  Highlight,
 } from "../../store/dataset/index";
 import { getters as datasetGetters } from "../../store/dataset/module";
 import { getters as routeGetters } from "../../store/route/module";
@@ -49,7 +65,11 @@ import {
   LOW_SHOT_SCORE_COLUMN_NAME,
   getAllDataItems,
 } from "../../util/data";
+import { createFilterFromHighlight } from "../../util/highlights";
+import { Filter, INCLUDE_FILTER } from "../../util/filters";
 import LabelHeaderButtons from "./LabelHeaderButtons.vue";
+import FilterBadge from "../FilterBadge.vue";
+import { getNumIncludedRows } from "../../util/row";
 
 const GEO_VIEW = "geo";
 const IMAGE_VIEW = "image";
@@ -65,6 +85,7 @@ export default Vue.extend({
     ImageMosaic,
     SelectDataTable,
     LabelHeaderButtons,
+    FilterBadge,
   },
   props: {
     variables: Array as () => Variable[],
@@ -78,6 +99,26 @@ export default Vue.extend({
     };
   },
   computed: {
+    activeFilter(): Filter {
+      if (!this.highlight || !this.highlight.value) {
+        return null;
+      }
+      return createFilterFromHighlight(this.highlight, INCLUDE_FILTER);
+    },
+    highlight(): Highlight {
+      return routeGetters.getDecodedHighlight(this.$store);
+    },
+    filters(): Filter[] {
+      return routeGetters
+        .getDecodedFilters(this.$store)
+        .filter((f) => f.type !== "row");
+    },
+    numRows(): number {
+      return datasetGetters.getIncludedTableDataNumRows(this.$store);
+    },
+    selectionNumRows(): number {
+      return getNumIncludedRows(this.rowSelection);
+    },
     viewComponent(): string {
       if (this.viewTypeModel === GEO_VIEW) return "LabelGeoPlot";
       if (this.viewTypeModel === IMAGE_VIEW) return "ImageMosaic";
@@ -111,6 +152,9 @@ export default Vue.extend({
         });
       }
       return items;
+    },
+    numItems(): number {
+      return this.dataItems?.length;
     },
     dataFields(): Dictionary<TableColumn> {
       return datasetGetters.getIncludedTableDataFields(this.$store);
@@ -150,7 +194,7 @@ export default Vue.extend({
 .label-data-container {
   display: flex;
   flex-flow: wrap;
-  height: 90%;
+  height: 80%;
   position: relative;
   width: 100%;
   background: #eee;
@@ -159,5 +203,18 @@ export default Vue.extend({
   margin: 5px;
   display: flex;
   justify-content: space-around;
+}
+.fake-search-input {
+  background-color: var(--gray-300);
+  border: 1px solid var(--gray-500);
+  border-radius: 0.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  min-height: 2.5rem;
+  padding: 3px;
+}
+.selection-data-slot-summary {
+  font-size: 90%;
+  margin: auto 5px -3px 0; /* Display against the table */
 }
 </style>

--- a/public/components/labelingComponents/LoadingSpinner.vue
+++ b/public/components/labelingComponents/LoadingSpinner.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="w-100 h-100 d-flex justify-content-center align-items-center">
+    <div class="d-flex justify-content-center align-items-center flex-column">
+      <p>
+        <strong>{{ state }}</strong>
+      </p>
+      <b-spinner />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+export default Vue.extend({
+  name: "loading-spinner",
+  props: {
+    state: { type: String as () => string, default: "" },
+  },
+});
+</script>

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -1,46 +1,46 @@
+import _ from "lodash";
+import { $enum } from "ts-enum-util";
+import { Route } from "vue-router";
+import { ColorScaleNames, minimumRouteKey } from "../../util/data";
+import { Dictionary } from "../../util/dict";
+import { decodeFilters, Filter, FilterParams } from "../../util/filters";
+import { decodeHighlights } from "../../util/highlights";
+import { buildLookup } from "../../util/lookup";
+import { decodeRowSelection } from "../../util/row";
+import { GEOBOUNDS_TYPE, GEOCOORDINATE_TYPE } from "../../util/types";
 import {
-  Variable,
-  VariableSummary,
+  BandID,
+  DataMode,
   Highlight,
   RowSelection,
   SummaryMode,
-  DataMode,
   TaskTypes,
-  BandID,
+  Variable,
+  VariableSummary,
 } from "../dataset/index";
+import { ModelQuality } from "../requests/index";
 import {
-  DATA_EXPLORER_ROUTE,
-  JOIN_DATASETS_ROUTE,
-  RESULTS_ROUTE,
-  SELECT_TARGET_ROUTE,
-  SELECT_TRAINING_ROUTE,
-  JOINED_VARS_INSTANCE_PAGE,
   AVAILABLE_TARGET_VARS_INSTANCE_PAGE,
+  AVAILABLE_TARGET_VARS_INSTANCE_SEARCH,
   AVAILABLE_TRAINING_VARS_INSTANCE_PAGE,
-  TRAINING_VARS_INSTANCE_PAGE,
-  RESULT_TRAINING_VARS_INSTANCE_PAGE,
+  AVAILABLE_TRAINING_VARS_INSTANCE_SEARCH,
+  DATA_EXPLORER_ROUTE,
   DATA_EXPLORER_VARS_INSTANCE_PAGE,
+  DATA_EXPLORER_VARS_INSTANCE_SEARCH,
   DATA_SIZE_DEFAULT,
   DATA_SIZE_REMOTE_SENSING_DEFAULT,
-  AVAILABLE_TARGET_VARS_INSTANCE_SEARCH,
+  JOINED_VARS_INSTANCE_PAGE,
   JOINED_VARS_INSTANCE_SEARCH,
-  AVAILABLE_TRAINING_VARS_INSTANCE_SEARCH,
-  TRAINING_VARS_INSTANCE_SEARCH,
-  RESULT_TRAINING_VARS_INSTANCE_SEARCH,
-  DATA_EXPLORER_VARS_INSTANCE_SEARCH,
+  JOIN_DATASETS_ROUTE,
   LABEL_FEATURE_VARS_INSTANCE_PAGE,
+  RESULTS_ROUTE,
+  RESULT_TRAINING_VARS_INSTANCE_PAGE,
+  RESULT_TRAINING_VARS_INSTANCE_SEARCH,
+  SELECT_TARGET_ROUTE,
+  SELECT_TRAINING_ROUTE,
+  TRAINING_VARS_INSTANCE_PAGE,
+  TRAINING_VARS_INSTANCE_SEARCH,
 } from "../route/index";
-import { ModelQuality } from "../requests/index";
-import { decodeFilters, Filter, FilterParams } from "../../util/filters";
-import { decodeHighlights } from "../../util/highlights";
-import { decodeRowSelection } from "../../util/row";
-import { Dictionary } from "../../util/dict";
-import { buildLookup } from "../../util/lookup";
-import { Route } from "vue-router";
-import _ from "lodash";
-import { $enum } from "ts-enum-util";
-import { ColorScaleNames, minimumRouteKey } from "../../util/data";
-import { GEOBOUNDS_TYPE, GEOCOORDINATE_TYPE } from "../../util/types";
 
 export const getters = {
   getRoute(state: Route): Route {
@@ -103,7 +103,12 @@ export const getters = {
     }
     return variables;
   },
-
+  getAnnotationHasChanged(state: Route) {
+    const hasChanged =
+      state.query.annotationHasChanged === "true" ||
+      !state.query.annotationHasChanged;
+    return hasChanged;
+  },
   getJoinDatasetsVariableSummaries(
     state: Route,
     getters: any

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -1,8 +1,8 @@
-import { Module } from "vuex";
 import { Route } from "vue-router";
-import { getters as moduleGetters } from "./getters";
-import { DistilState } from "../store";
+import { Module } from "vuex";
 import { getStoreAccessors } from "vuex-typescript";
+import { DistilState } from "../store";
+import { getters as moduleGetters } from "./getters";
 
 export const routeModule: Module<Route, DistilState> = {
   getters: moduleGetters,
@@ -25,6 +25,7 @@ export const getters = {
   getDecodedJoinDatasetsFilterParams: read(
     moduleGetters.getDecodedJoinDatasetsFilterParams
   ),
+  getAnnotationHasChanged: read(moduleGetters.getAnnotationHasChanged),
   getRouteJoinDatasetsHash: read(moduleGetters.getRouteJoinDatasetsHash),
   getJoinDatasetsVariables: read(moduleGetters.getJoinDatasetsVariables),
   getJoinDatasetsVariableSummaries: read(

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -479,6 +479,7 @@ export const actions = {
     const varModes = context.getters.getDecodedVarModes;
     const orderBy = routeGetters.getOrderBy(store);
     clearVariableSummaries(context);
+    filterParams.variables = variables.map((v) => v.key);
     return Promise.all([
       datasetActions.fetchIncludedVariableSummaries(store, {
         dataset,

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -53,6 +53,7 @@ export interface RouteArgs {
   metrics?: string;
   trainTestSplit?: number;
   timestampSplit?: number;
+  annotationHasChanged?: boolean;
   // orderBy contains variable names that will order the dataset
   orderBy?: string;
 }

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -31,6 +31,7 @@
         />
         <create-labeling-form
           :is-loading="isLoadingData"
+          :low-shot-summary="labelSummary"
           @export="onExport"
           @apply="onApply"
           @save="onSaveClick"
@@ -281,7 +282,10 @@ export default Vue.extend({
       addOrderBy(LOW_SHOT_SCORE_COLUMN_NAME);
       this.isLoadingData = false;
       await this.fetchData();
-      this.$bvModal.show(this.scorePopUpId);
+      const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
+        annotationHasChanged: false,
+      });
+      this.$router.push(entry).catch((err) => console.warn(err));
     },
     async onExport() {
       const highlight = {
@@ -378,12 +382,19 @@ export default Vue.extend({
           value: label,
         };
       });
+      if (!updateData.length) {
+        return;
+      }
       datasetMutations.updateAreaOfInterestIncludeInner(this.$store, innerData);
       datasetActions.updateDataset(this.$store, {
         dataset: this.dataset,
         updateData,
       });
       clearRowSelection(this.$router);
+      const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
+        annotationHasChanged: true,
+      });
+      this.$router.push(entry).catch((err) => console.warn(err));
       this.onDataChanged();
     },
     async updateRoute() {

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -13,11 +13,11 @@
       <variable-facets
         enable-highlighting
         enable-type-filtering
-        :summaries="summaries"
+        :summaries="featureSummaries"
         :pagination="
-          summaries && searchedActiveVariables.length > numRowsPerPage
+          featureSummaries && searchedActiveVariables.length > numRowsPerPage
         "
-        :facet-count="summaries && searchedActiveVariables.length"
+        :facet-count="featureSummaries && searchedActiveVariables.length"
         :rows-per-page="numRowsPerPage"
         :instance-name="instance"
       />
@@ -184,6 +184,12 @@ export default Vue.extend({
       const tableData = datasetGetters.getIncludedTableDataItems(this.$store);
       return tableData ? tableData.length : 0;
     },
+    // filters out the low shot labels
+    featureSummaries(): VariableSummary[] {
+      return this.summaries.filter((s) => {
+        return s.key !== LOW_SHOT_LABEL_COLUMN_NAME;
+      });
+    },
     summaries(): VariableSummary[] {
       const pageIndex = routeGetters.getLabelFeaturesVarsPage(this.$store);
 
@@ -221,8 +227,10 @@ export default Vue.extend({
     highlight() {
       this.onDataChanged();
     },
-    training() {
-      this.fetchData();
+    training(prev: string[], cur: string[]) {
+      if (prev.length !== cur.length) {
+        this.fetchData();
+      }
     },
   },
   async mounted() {


### PR DESCRIPTION
closes #2173 
- Added loading screen to avoid the constant UI changes from cloning and checking data
![Peek 2021-01-12 11-56](https://user-images.githubusercontent.com/25306965/104346431-68e81080-54cd-11eb-9756-2c357cebbaec.gif)
- Added toast notification to show error from the websocket (probably temporary)
![Peek 2021-01-12 11-57](https://user-images.githubusercontent.com/25306965/104346496-7e5d3a80-54cd-11eb-9f6d-3ddee77c00d0.gif)
- Fixed issue with table data not loading properly intermittently 
- Added feature to only enable search similar button when results will return something valid and new
- Removed lowshot label from feature list (as it exists in the label list)
- Added highlight pill
- Added number of items in highlighted dataset