### PR TITLE
Ingest sampling crash

### DIFF
--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -294,9 +294,9 @@ func SplitTimeSeries(timeseries []*api.TimeseriesObservation, trainPercentage fl
 
 // SampleData shuffles a dataset's rows and takes a subsample, returning
 // the raw byte data of the sampled dataset.
-func SampleData(rawData [][]string, maxRows int, stratify bool) [][]string {
+func SampleData(rawData [][]string, maxRows int) [][]string {
 
-	sampler := createSampler(stratify, -1, -1)
+	sampler := createSampler(false, -1, -1)
 	return sampler.sample(rawData, maxRows)
 }
 

--- a/api/compute/dataset_persist.go
+++ b/api/compute/dataset_persist.go
@@ -297,7 +297,10 @@ func SplitTimeSeries(timeseries []*api.TimeseriesObservation, trainPercentage fl
 func SampleData(rawData [][]string, maxRows int) [][]string {
 
 	sampler := createSampler(false, -1, -1)
-	return sampler.sample(rawData, maxRows)
+	sampled := sampler.sample(rawData, maxRows)
+	complete := [][]string{rawData[0]}
+	complete = append(complete, sampled...)
+	return complete
 }
 
 // SampleDataset shuffles a dataset's rows and stores a subsample, the schema doc URI.

--- a/api/task/sample.go
+++ b/api/task/sample.go
@@ -51,7 +51,7 @@ func Sample(originalSchemaFile string, schemaFile string, dataset string, config
 		return schemaFile, false, len(csvData), nil
 	}
 
-	sampledData := compute.SampleData(csvData, config.SampleRowLimit, true)
+	sampledData := compute.SampleData(csvData, config.SampleRowLimit)
 
 	// copy the full csv to keep it if needed
 	err = util.CopyFile(originalCSVFilePath, path.Join(path.Dir(originalCSVFilePath), "learningData-full.csv"))


### PR DESCRIPTION
Commercial datasets were failing due to ingest sampling trying to do stratified sampling. It now does random sampling and outputs the header properly.