### PR TITLE
Geoplot turbo fix

### DIFF
--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -199,7 +199,7 @@ export default Vue.extend({
   },
 
   methods: {
-    addAll() {
+    async addAll() {
       // log UI event on server
       appActions.logUserEvent(this.$store, {
         feature: Feature.ADD_ALL_FEATURES,
@@ -215,10 +215,18 @@ export default Vue.extend({
       this.availableVariables.forEach((variable) => {
         training.push(variable.key);
       });
-
+      const dataset = routeGetters.getRouteDataset(this.$store);
+      const targetName = routeGetters.getRouteTargetVariable(this.$store);
+      // update task based on the current training data
+      const taskResponse = await datasetActions.fetchTask(this.$store, {
+        dataset,
+        targetName,
+        variableNames: training,
+      });
       const entry = overlayRouteEntry(routeGetters.getRoute(this.$store), {
         training: training.join(","),
         availableTrainingVarsPage: 1,
+        task: taskResponse.data.task.join(","),
       });
 
       this.$router.push(entry).catch((err) => console.warn(err));

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -1143,6 +1143,9 @@ export default Vue.extend({
         return "#999999";
       }
       if (this.isColoringByConfidence) {
+        if (item.confidence === undefined) {
+          return undefined;
+        }
         return this.colorScale(item.confidence?.value);
       }
       if (item[this.targetField] && item[this.predictedField]) {


### PR DESCRIPTION
closes #2177, #2138 

- Fixes turbo color by confidence failing
- Note: The turbo color function was added by a different author who did not conform to the other functions in that they return a string hex value instead the turbo function returns rgb(val,val,val). This is fine because we use the color parser library; however, in the event of undefined instead of returning '#000000' it returns rgb(nan,nan,nan). The fix was to add a default behaviour in our code base in the event of an undefined
- Fixed the add all not updating the task list