### PR TITLE
Highlight the predicted column in the table view.

### DIFF
--- a/public/components/PredictionsDataTable.vue
+++ b/public/components/PredictionsDataTable.vue
@@ -430,6 +430,5 @@ table tr {
 /* Highlight the predicted column */
 .table td.predicted-value {
   border-right: 2px solid var(--gray-900);
-  border-left: 2px solid var(--gray-900);
 }
 </style>

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -206,6 +206,8 @@ export interface TableColumn {
   weight: number;
   headerTitle: string;
   sortable?: boolean;
+  class?: string;
+  tdClass?: string;
   variant?: string;
 }
 


### PR DESCRIPTION
fix #2189 

I'm not sure if that design solution is working? I think this is something to ask Pascale to address. Maybe she can work on a solution or colour scheme to highlight a column.

<img width="445" alt="Screen Shot 2021-01-19 at 13 01 37" src="https://user-images.githubusercontent.com/636801/105074585-8d586580-5a56-11eb-8fb7-693cc72f19c6.png">
