### PR TITLE
Split On New Label

### DIFF
--- a/api/compute/search.go
+++ b/api/compute/search.go
@@ -290,8 +290,11 @@ func (s *SolutionRequest) dispatchSolutionSearchPipeline(statusChan chan Solutio
 
 		// persist results
 		log.Infof("persisting results in URI '%s'", resultURI)
-		s.persistSolutionResults(statusChan, client, solutionStorage, dataStorage, searchContext.searchID,
+		err = s.persistSolutionResults(statusChan, client, solutionStorage, dataStorage, searchContext.searchID,
 			searchContext.dataset, searchContext.storageName, searchSolutionID, fittedSolutionID, produceRequestID, resultID, resultURI)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -65,6 +65,7 @@ type Dataset struct {
 	LearningDataset string                 `json:"learningDataset"`
 	Clone           bool                   `json:"clone"`
 	Immutable       bool                   `json:"immutable"`
+	ParentDataset   string                 `json:"parentDataset"`
 }
 
 // QueriedDataset wraps dataset querying components into a single entity.

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -51,6 +51,7 @@ func (s *Storage) CloneDataset(dataset string, datasetNew string, storageNameNew
 	ds.Name = datasetNew
 	ds.Folder = folderNew
 	ds.Source = metadata.Augmented
+	ds.ParentDataset = dataset
 	// cloned datasets CAN be altered
 	ds.Immutable = false
 	ds.Clone = true
@@ -77,6 +78,7 @@ func (s *Storage) UpdateDataset(dataset *api.Dataset) error {
 		"learningDataset": dataset.LearningDataset,
 		"clone":           dataset.Clone,
 		"immutable":       dataset.Immutable,
+		"parentDataset":   dataset.ParentDataset,
 	}
 
 	bytes, err := json.Marshal(source)
@@ -140,6 +142,7 @@ func (s *Storage) IngestDataset(datasetSource metadata.DatasetSource, meta *mode
 		"learningDataset":  meta.LearningDataset,
 		"clone":            meta.Clone,
 		"immutable":        meta.Immutable,
+		"parentDataset":    "",
 	}
 
 	bytes, err := json.Marshal(source)
@@ -209,6 +212,11 @@ func (s *Storage) parseDatasets(res *elastic.SearchResult, includeIndex bool, in
 		learningDataset, ok := json.String(src, "learningDataset")
 		if !ok {
 			learningDataset = ""
+		}
+		// extract the learning dataset
+		parentDataset, ok := json.String(src, "parentDataset")
+		if !ok {
+			parentDataset = ""
 		}
 		// extract the machine learned summary
 		summaryMachine, ok := json.String(src, "summaryMachine")
@@ -304,6 +312,7 @@ func (s *Storage) parseDatasets(res *elastic.SearchResult, includeIndex bool, in
 			LearningDataset: learningDataset,
 			Immutable:       immutable,
 			Clone:           clone,
+			ParentDataset:   parentDataset,
 		})
 	}
 	return datasets, nil

--- a/api/model/storage/elastic/storage.go
+++ b/api/model/storage/elastic/storage.go
@@ -207,6 +207,9 @@ func (s *Storage) InitializeMetadataStorage(overwrite bool) error {
 				"learningDataset": {
 					"type": "text"
 				},
+				"parentDataset": {
+					"type": "text"
+				},
 				"clone": {
 					"type": "boolean"
 				},

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -272,7 +272,7 @@ func (s *Storage) PersistResult(dataset string, storageName string, resultURI st
 	}
 
 	// Translate from display name to storage name.
-	targetDisplayName, err := s.getDisplayName(dataset, targetVariable.Key)
+	targetHeaderName, err := s.getHeaderName(dataset, targetVariable.Key)
 	if err != nil {
 		return errors.Wrap(err, "unable to map target name")
 	}
@@ -283,9 +283,9 @@ func (s *Storage) PersistResult(dataset string, storageName string, resultURI st
 	for i, v := range records[0] {
 		fieldsHeader[v] = i
 	}
-	targetIndex, ok := fieldsHeader[targetDisplayName]
+	targetIndex, ok := fieldsHeader[targetHeaderName]
 	if !ok {
-		return errors.Wrapf(err, "unable to find target col '%s' in result header", targetDisplayName)
+		return errors.Wrapf(err, "unable to find target col '%s' in result header", targetHeaderName)
 	}
 	d3mIndexIndex, ok := fieldsHeader[model.D3MIndexFieldName]
 	if !ok {
@@ -980,20 +980,13 @@ func (s *Storage) getIsWeighted(resultURI string, weightTableName string) (bool,
 	return bool(values[0].(bool)), nil
 }
 
-func (s *Storage) getDisplayName(dataset string, key string) (string, error) {
-	displayName := ""
-	variables, err := s.metadata.FetchVariables(dataset, false, false, false)
+func (s *Storage) getHeaderName(dataset string, key string) (string, error) {
+	variable, err := s.metadata.FetchVariable(dataset, key)
 	if err != nil {
-		return "", errors.Wrap(err, "unable fetch variables for name mapping")
+		return "", errors.Wrap(err, "unable fetch variable for name mapping")
 	}
 
-	for _, v := range variables {
-		if v.Key == key {
-			displayName = v.DisplayName
-		}
-	}
-
-	return displayName, nil
+	return variable.HeaderName, nil
 }
 
 func mapFields(fields []*model.Variable) map[string]*model.Variable {

--- a/api/routes/save_dataset.go
+++ b/api/routes/save_dataset.go
@@ -89,7 +89,13 @@ func SaveDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStora
 			handleError(w, err)
 			return
 		}
-		// version dataset
+
+		// update properties on the dataset (pull latest from store to pick up any other changes)
+		ds, err = metaStorage.FetchDataset(dataset, true, true, true)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
 		ds.Immutable = true
 		// is no longer a clone due to the dropping of the filterParams
 		ds.Clone = false

--- a/api/serialization/csv.go
+++ b/api/serialization/csv.go
@@ -45,18 +45,20 @@ func NewCSV() *CSV {
 
 // ReadDataset reads a raw dataset from the file system, loading the csv
 // data into memory.
-func (d *CSV) ReadDataset(uri string) (*api.RawDataset, error) {
-	data, err := d.ReadData(uri)
+func (d *CSV) ReadDataset(schemaFile string) (*api.RawDataset, error) {
+	meta, err := d.ReadMetadata(schemaFile)
 	if err != nil {
 		return nil, err
 	}
 
-	meta, err := d.ReadMetadata(uri)
+	data, err := d.ReadData(model.GetResourcePath(schemaFile, meta.GetMainDataResource()))
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.RawDataset{
+		ID:       meta.ID,
+		Name:     meta.Name,
 		Data:     data,
 		Metadata: meta,
 	}, nil

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -49,18 +49,20 @@ func NewParquet() *Parquet {
 
 // ReadDataset reads a raw dataset from the file system, loading the parquet
 // data into memory.
-func (d *Parquet) ReadDataset(uri string) (*api.RawDataset, error) {
-	data, err := d.ReadData(uri)
+func (d *Parquet) ReadDataset(schemaFile string) (*api.RawDataset, error) {
+	meta, err := d.ReadMetadata(schemaFile)
 	if err != nil {
 		return nil, err
 	}
 
-	meta, err := d.ReadMetadata(uri)
+	data, err := d.ReadData(model.GetResourcePath(schemaFile, meta.GetMainDataResource()))
 	if err != nil {
 		return nil, err
 	}
 
 	return &api.RawDataset{
+		ID:       meta.ID,
+		Name:     meta.Name,
 		Data:     data,
 		Metadata: meta,
 	}, nil

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -78,18 +78,7 @@ func ReadDataset(schemaPath string) (*api.RawDataset, error) {
 	}
 
 	dataPath := model.GetResourcePath(schemaPath, meta.GetMainDataResource())
-	storage := GetStorage(dataPath)
-	data, err := storage.ReadData(dataPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return &api.RawDataset{
-		Name:     meta.Name,
-		ID:       meta.ID,
-		Data:     data,
-		Metadata: meta,
-	}, nil
+	return GetStorage(dataPath).ReadDataset(schemaPath)
 }
 
 // WriteDataset determines which storage engine to use and then writes out the

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -69,8 +69,8 @@ func GetParquetStorage() Storage {
 	return parquetStorage
 }
 
-// ReadData reads the metadata to find the main data reference, then reads that.
-func ReadData(schemaPath string) ([][]string, error) {
+// ReadDataset reads the metadata to find the main data reference, then reads that.
+func ReadDataset(schemaPath string) (*api.RawDataset, error) {
 	// metadata can be read by CSV storage
 	meta, err := csvStorage.ReadMetadata(schemaPath)
 	if err != nil {
@@ -84,5 +84,19 @@ func ReadData(schemaPath string) ([][]string, error) {
 		return nil, err
 	}
 
-	return data, nil
+	return &api.RawDataset{
+		Name:     meta.Name,
+		ID:       meta.ID,
+		Data:     data,
+		Metadata: meta,
+	}, nil
+}
+
+// WriteDataset determines which storage engine to use and then writes out the
+// metadata and the data using it.
+func WriteDataset(folderPath string, dataset *api.RawDataset) error {
+	// use the main data resource to determine the storage engine
+	storage := GetStorage(dataset.Metadata.GetMainDataResource().ResPath)
+
+	return storage.WriteDataset(folderPath, dataset)
 }

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -68,3 +68,21 @@ func GetCSVStorage() Storage {
 func GetParquetStorage() Storage {
 	return parquetStorage
 }
+
+// ReadData reads the metadata to find the main data reference, then reads that.
+func ReadData(schemaPath string) ([][]string, error) {
+	// metadata can be read by CSV storage
+	meta, err := csvStorage.ReadMetadata(schemaPath)
+	if err != nil {
+		return nil, err
+	}
+
+	dataPath := model.GetResourcePath(schemaPath, meta.GetMainDataResource())
+	storage := GetStorage(dataPath)
+	data, err := storage.ReadData(dataPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -204,20 +204,20 @@ func updateLearningDataset(newDataset *api.RawDataset, metaDataset *api.Dataset,
 			newDataMap[r[newDSD3MIndex]] = newVarsData
 		}
 
-		preFeaturizedOutput := [][]string{}
+		// add the new fields to the metadata to generate the proper header
+		for i := 0; i < len(newVars); i++ {
+			newVar := newVars[i]
+			newVar.Index = i + len(preFeaturizedMainDR.Variables)
+			preFeaturizedMainDR.Variables = append(preFeaturizedMainDR.Variables, newVar)
+		}
+
+		preFeaturizedOutput := [][]string{preFeaturizedMainDR.GenerateHeader()}
 		for _, row := range preFeaturizedDataset.Data[1:] {
 			d3mIndexPre := row[preFeaturizedD3MIndex]
 			if newDataMap[d3mIndexPre] != nil {
 				rowComplete := append(row, newDataMap[d3mIndexPre]...)
 				preFeaturizedOutput = append(preFeaturizedOutput, rowComplete)
 			}
-		}
-
-		// add the new fields to the metadata
-		for i := 0; i < len(newVars); i++ {
-			newVar := newVars[i]
-			newVar.Index = i + len(preFeaturizedMainDR.Variables)
-			preFeaturizedMainDR.Variables = append(preFeaturizedMainDR.Variables, newVar)
 		}
 
 		// output the new pre featurized data

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -185,7 +185,7 @@ func updateLearningDataset(newDataset *api.RawDataset, metaDataset *api.Dataset,
 		return err
 	}
 
-	// read the prefeaturized data (need to load the metadata to read the data)
+	// read the prefeaturized data
 	preFeaturizedDataset, err := serialization.ReadDataset(path.Join(learningFolder, compute.D3MDataSchema))
 	if err != nil {
 		return err
@@ -222,6 +222,11 @@ func updateLearningDataset(newDataset *api.RawDataset, metaDataset *api.Dataset,
 			preFeaturizedOutput = append(preFeaturizedOutput, rowComplete)
 		}
 	}
+
+	// prefeaturized metadata needs to match the new dataset
+	preFeaturizedDataset.Metadata.ID = newDataset.Metadata.ID
+	preFeaturizedDataset.Metadata.Name = newDataset.Metadata.Name
+	preFeaturizedDataset.Metadata.StorageName = newDataset.Metadata.StorageName
 
 	// output the new pre featurized data
 	preFeaturizedDataset.Data = preFeaturizedOutput


### PR DESCRIPTION
Fixes #2185 

Prefeaturized datasets were not cloning and updating the prefeaturized data when saving the new labels. Added the notion of parent dataset, and use it to identify the new fields to add to the prefeaturized data.

There were also a bunch of small problems made evident during this fix:
- result parsing errors were not propagated properly
- results from TA2 use the header name for the target name and not the display name
- parquet dataset reading was still using csv to read the metadata and augmenting fields assuming a csv data file
- saving a dataset was dropping unlabeled rows from the data table (correct) but labeled rows from the data on disk (incorrect)