### PR TITLE
Pipeline Cache Enabled Flag

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	MaxTestRows                        int     `env:"MAX_TEST_ROWS" envDefault:"100000"`
 	MinTrainingRows                    int     `env:"MIN_TRAINING_ROWS" envDefault:"100"`
 	MinTestRows                        int     `env:"MIN_TEST_ROWS" envDefault:"100"`
+	PipelineCacheEnabled               bool    `env:"PIPELINE_CACHE_ENABLED" envDefault:"true"`
 	PipelineCacheFilename              string  `env:"PIPELINE_CACHE_FILENAME" envDefault:"cache.bin"`
 	PipelineQueueSize                  int     `env:"PIPELINE_QUEUE_SIZE" envDefault:"10"`
 	PoolFeatures                       bool    `env:"POOL_FEATURES" envDefault:"true"`

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -175,7 +175,7 @@ func (s *Storage) cloneTable(existingTable string, newTable string, copyData boo
 		return errors.Wrapf(err, "unable to clone table")
 	}
 	// if copy data insert data from other table
-	if copyData{
+	if copyData {
 		sql = fmt.Sprintf("INSERT INTO %s SELECT * FROM %s;", newTable, existingTable)
 		_, err := s.client.Exec(sql)
 		if err != nil {
@@ -339,7 +339,7 @@ func (s *Storage) FetchDataset(dataset string, storageName string, invert bool, 
 
 	return s.parseData(res)
 }
-func (s *Storage) createIndex(storageName string, colName string, colType string) error{
+func (s *Storage) createIndex(storageName string, colName string, colType string) error {
 	sql := postgres.GetIndexStatement(storageName, colName, colType)
 
 	_, err := s.client.Exec(sql)
@@ -349,18 +349,19 @@ func (s *Storage) createIndex(storageName string, colName string, colType string
 
 	return nil
 }
+
 // CreateIndices generates indices for the suppled fields on the "dataset"_base table
-func (s *Storage) CreateIndices(dataset string, indexFields []string) error{
-	variables, err:=s.metadata.FetchVariables(dataset, true, true, true)
-	if err != nil{
+func (s *Storage) CreateIndices(dataset string, indexFields []string) error {
+	variables, err := s.metadata.FetchVariables(dataset, true, true, true)
+	if err != nil {
 		return err
 	}
-	ds,err:=s.metadata.FetchDataset(dataset, false, false, false)
-	if err != nil{
+	ds, err := s.metadata.FetchDataset(dataset, false, false, false)
+	if err != nil {
 		return err
 	}
-	mappedVariables:=map[string]*model.Variable{}
-	for _, v := range variables{
+	mappedVariables := map[string]*model.Variable{}
+	for _, v := range variables {
 		mappedVariables[v.Key] = v
 	}
 	for _, fieldName := range indexFields {
@@ -373,6 +374,7 @@ func (s *Storage) CreateIndices(dataset string, indexFields []string) error{
 	}
 	return nil
 }
+
 // IsValidDataType checks to see if a specified type is valid for a variable.
 // Multiple simultaneous calls to the function can result in inaccurate.
 func (s *Storage) IsValidDataType(dataset string, storageName string, varName string, varType string) (bool, error) {

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -169,7 +169,7 @@ type PredictParams struct {
 	FittedSolutionID   string
 	DatasetConstructor DatasetConstructor
 	OutputPath         string
-	IndexFields 	   []string
+	IndexFields        []string
 	Target             *model.Variable
 	MetaStorage        api.MetadataStorage
 	DataStorage        api.DataStorage
@@ -221,7 +221,7 @@ func ImportPredictionDataset(params *PredictParams) (string, string, error) {
 	meta.DatasetFolder = path.Base(datasetPath)
 	schemaPath = path.Join(datasetPath, compute.D3MDataSchema)
 	datasetStorage := serialization.GetStorage(rawDataPath)
-	variables:=updateMetaDataTypes(params.SolutionStorage, params.MetaStorage, params.DataStorage, meta, params.FittedSolutionID, params.Dataset, meta.StorageName)
+	variables := updateMetaDataTypes(params.SolutionStorage, params.MetaStorage, params.DataStorage, meta, params.FittedSolutionID, params.Dataset, meta.StorageName)
 	if err != nil {
 		return "", "", errors.Wrap(err, "unable to update metadata types")
 	}
@@ -230,7 +230,7 @@ func ImportPredictionDataset(params *PredictParams) (string, string, error) {
 		return "", "", errors.Wrap(err, "unable to update dataset doc")
 	}
 	log.Infof("wrote out schema doc for new dataset with id '%s' at location '%s'", meta.ID, schemaPath)
-	err=createClassification(params, datasetPath, variables)
+	err = createClassification(params, datasetPath, variables)
 	if err != nil {
 		return "", "", errors.Wrap(err, "unable to create classification")
 	}
@@ -249,7 +249,7 @@ func IngestPredictionDataset(params *PredictParams) error {
 	rawDataPath := path.Join(params.Meta.DatasetFolder, compute.D3MDataFolder, compute.D3MLearningData)
 	datasetStorage := serialization.GetStorage(rawDataPath)
 	err = datasetStorage.WriteMetadata(params.SchemaPath, params.Meta, true, false)
-	if err!=nil{
+	if err != nil {
 		return err
 	}
 	// copy the metadata from the source dataset as it should be an exact match
@@ -599,20 +599,20 @@ func createComposedFields(data []*api.FilteredDataValue, fields []string, mapped
 	}
 	return strings.Join(dataToJoin, separator)
 }
-func createClassification(params *PredictParams, datasetPath string, variables []*model.Variable) error{
+func createClassification(params *PredictParams, datasetPath string, variables []*model.Variable) error {
 	outputPath := path.Join(datasetPath, params.Config.ClassificationOutputPath)
 	log.Info("writing predicted dataset type classification to file")
 	classification := buildClassificationFromMetadata(variables)
 	classification.Path = outputPath
 	err := metadata.WriteClassification(classification, outputPath)
 	if err != nil {
-		return  err
+		return err
 	}
 	return nil
 }
 func updateMetaDataTypes(solutionStorage api.SolutionStorage, metaStorage api.MetadataStorage,
-	dataStorage api.DataStorage, meta *model.Metadata, fittedSolutionID string, dataset string, storageName string) [] *model.Variable {
-	variables:=meta.GetMainDataResource().Variables
+	dataStorage api.DataStorage, meta *model.Metadata, fittedSolutionID string, dataset string, storageName string) []*model.Variable {
+	variables := meta.GetMainDataResource().Variables
 	solutionRequest, err := solutionStorage.FetchRequestByFittedSolutionID(fittedSolutionID)
 	if err != nil {
 		return nil
@@ -622,14 +622,14 @@ func updateMetaDataTypes(solutionStorage api.SolutionStorage, metaStorage api.Me
 	if err != nil {
 		return nil
 	}
-	varMap := map[string] *model.Variable{}
-	for _,v:=range trainVariables{
+	varMap := map[string]*model.Variable{}
+	for _, v := range trainVariables {
 		varMap[v.Key] = v
 	}
-	result := [] *model.Variable{}
-	for _,v:=range variables{
+	result := []*model.Variable{}
+	for _, v := range variables {
 		tmp := varMap[v.Key]
-		if tmp != nil{
+		if tmp != nil {
 			tmp.Index = v.Index
 			result = append(result, tmp)
 		}

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -485,12 +485,12 @@ func getTarget(request *apiModel.Request) string {
 }
 
 func createPredictionDataset(requestTask *api.Task, request *api.PredictRequest,
-	predictParams *task.PredictParams) (task.DatasetConstructor, []string,error) {
+	predictParams *task.PredictParams) (task.DatasetConstructor, []string, error) {
 	datasetID := request.DatasetID
 	datasetPath := request.DatasetPath
 	var ds task.DatasetConstructor
 	var err error
-	indexFields:= []string{}
+	indexFields := []string{}
 	if api.HasTaskType(requestTask, compute.RemoteSensingTask) {
 		ds, err = dataset.NewSatelliteDataset(datasetID, "tif", datasetPath)
 		indexFields = dataset.GetSatelliteIndexFields()
@@ -502,12 +502,12 @@ func createPredictionDataset(requestTask *api.Task, request *api.PredictRequest,
 		var data []byte
 		data, err = ioutil.ReadFile(datasetPath)
 		if err != nil {
-			return nil, nil,errors.Wrapf(err, "unable to read raw tabular data")
+			return nil, nil, errors.Wrapf(err, "unable to read raw tabular data")
 		}
 		ds, err = dataset.NewTableDataset(datasetID, data, false)
 	}
 	if err != nil {
-		return nil, nil,err
+		return nil, nil, err
 	}
 
 	return ds, indexFields, nil

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	// initialize the pipeline cache and
 	pipelineCacheFilename := path.Join(env.GetTmpPath(), config.PipelineCacheFilename)
-	err = api.InitializeCache(pipelineCacheFilename)
+	err = api.InitializeCache(pipelineCacheFilename, config.PipelineCacheEnabled)
 	if err != nil {
 		log.Errorf("%+v", err)
 		os.Exit(1)


### PR DESCRIPTION
Added a simple flag to be able to enable (or disable) pipeline caching. Note that this only impacts the reading of the cache. Results are written to the cache and persisted to disk. Having this flag can simplify testing by eliminating the need to delete the cache when trying to test a specific pipelines.