### PR TITLE
Distil Labelled Dataset Display Names

### DIFF
--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -175,7 +175,7 @@ func (s *Storage) cloneTable(existingTable string, newTable string, copyData boo
 		return errors.Wrapf(err, "unable to clone table")
 	}
 	// if copy data insert data from other table
-	if copyData{
+	if copyData {
 		sql = fmt.Sprintf("INSERT INTO %s SELECT * FROM %s;", newTable, existingTable)
 		_, err := s.client.Exec(sql)
 		if err != nil {
@@ -339,7 +339,7 @@ func (s *Storage) FetchDataset(dataset string, storageName string, invert bool, 
 
 	return s.parseData(res)
 }
-func (s *Storage) createIndex(storageName string, colName string, colType string) error{
+func (s *Storage) createIndex(storageName string, colName string, colType string) error {
 	sql := postgres.GetIndexStatement(storageName, colName, colType)
 
 	_, err := s.client.Exec(sql)
@@ -349,18 +349,19 @@ func (s *Storage) createIndex(storageName string, colName string, colType string
 
 	return nil
 }
+
 // CreateIndices generates indices for the suppled fields on the "dataset"_base table
-func (s *Storage) CreateIndices(dataset string, indexFields []string) error{
-	variables, err:=s.metadata.FetchVariables(dataset, true, true, true)
-	if err != nil{
+func (s *Storage) CreateIndices(dataset string, indexFields []string) error {
+	variables, err := s.metadata.FetchVariables(dataset, true, true, true)
+	if err != nil {
 		return err
 	}
-	ds,err:=s.metadata.FetchDataset(dataset, false, false, false)
-	if err != nil{
+	ds, err := s.metadata.FetchDataset(dataset, false, false, false)
+	if err != nil {
 		return err
 	}
-	mappedVariables:=map[string]*model.Variable{}
-	for _, v := range variables{
+	mappedVariables := map[string]*model.Variable{}
+	for _, v := range variables {
 		mappedVariables[v.Key] = v
 	}
 	for _, fieldName := range indexFields {
@@ -373,6 +374,7 @@ func (s *Storage) CreateIndices(dataset string, indexFields []string) error{
 	}
 	return nil
 }
+
 // IsValidDataType checks to see if a specified type is valid for a variable.
 // Multiple simultaneous calls to the function can result in inaccurate.
 func (s *Storage) IsValidDataType(dataset string, storageName string, varName string, varType string) (bool, error) {

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -89,3 +89,24 @@ func WriteDataset(folderPath string, dataset *api.RawDataset) error {
 
 	return storage.WriteDataset(folderPath, dataset)
 }
+
+// ReadMetadata reads the metadata in the specified path.
+func ReadMetadata(schemaPath string) (*model.Metadata, error) {
+	// metadata can be read by CSV storage
+	meta, err := csvStorage.ReadMetadata(schemaPath)
+	if err != nil {
+		return nil, err
+	}
+	dataPath := model.GetResourcePath(schemaPath, meta.GetMainDataResource())
+
+	// check to make sure the backing storage is csv, and if not then read the
+	// metadata using the right backing storage
+	storage := GetStorage(dataPath)
+	if storage != csvStorage {
+		meta, err = storage.ReadMetadata(schemaPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return meta, nil
+}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -169,7 +169,7 @@ type PredictParams struct {
 	FittedSolutionID   string
 	DatasetConstructor DatasetConstructor
 	OutputPath         string
-	IndexFields 	   []string
+	IndexFields        []string
 	Target             *model.Variable
 	MetaStorage        api.MetadataStorage
 	DataStorage        api.DataStorage
@@ -221,7 +221,7 @@ func ImportPredictionDataset(params *PredictParams) (string, string, error) {
 	meta.DatasetFolder = path.Base(datasetPath)
 	schemaPath = path.Join(datasetPath, compute.D3MDataSchema)
 	datasetStorage := serialization.GetStorage(rawDataPath)
-	variables:=updateMetaDataTypes(params.SolutionStorage, params.MetaStorage, params.DataStorage, meta, params.FittedSolutionID, params.Dataset, meta.StorageName)
+	variables := updateMetaDataTypes(params.SolutionStorage, params.MetaStorage, params.DataStorage, meta, params.FittedSolutionID, params.Dataset, meta.StorageName)
 	if err != nil {
 		return "", "", errors.Wrap(err, "unable to update metadata types")
 	}
@@ -230,7 +230,7 @@ func ImportPredictionDataset(params *PredictParams) (string, string, error) {
 		return "", "", errors.Wrap(err, "unable to update dataset doc")
 	}
 	log.Infof("wrote out schema doc for new dataset with id '%s' at location '%s'", meta.ID, schemaPath)
-	err=createClassification(params, datasetPath, variables)
+	err = createClassification(params, datasetPath, variables)
 	if err != nil {
 		return "", "", errors.Wrap(err, "unable to create classification")
 	}
@@ -249,7 +249,7 @@ func IngestPredictionDataset(params *PredictParams) error {
 	rawDataPath := path.Join(params.Meta.DatasetFolder, compute.D3MDataFolder, compute.D3MLearningData)
 	datasetStorage := serialization.GetStorage(rawDataPath)
 	err = datasetStorage.WriteMetadata(params.SchemaPath, params.Meta, true, false)
-	if err!=nil{
+	if err != nil {
 		return err
 	}
 	// copy the metadata from the source dataset as it should be an exact match
@@ -599,20 +599,20 @@ func createComposedFields(data []*api.FilteredDataValue, fields []string, mapped
 	}
 	return strings.Join(dataToJoin, separator)
 }
-func createClassification(params *PredictParams, datasetPath string, variables []*model.Variable) error{
+func createClassification(params *PredictParams, datasetPath string, variables []*model.Variable) error {
 	outputPath := path.Join(datasetPath, params.Config.ClassificationOutputPath)
 	log.Info("writing predicted dataset type classification to file")
 	classification := buildClassificationFromMetadata(variables)
 	classification.Path = outputPath
 	err := metadata.WriteClassification(classification, outputPath)
 	if err != nil {
-		return  err
+		return err
 	}
 	return nil
 }
 func updateMetaDataTypes(solutionStorage api.SolutionStorage, metaStorage api.MetadataStorage,
-	dataStorage api.DataStorage, meta *model.Metadata, fittedSolutionID string, dataset string, storageName string) [] *model.Variable {
-	variables:=meta.GetMainDataResource().Variables
+	dataStorage api.DataStorage, meta *model.Metadata, fittedSolutionID string, dataset string, storageName string) []*model.Variable {
+	variables := meta.GetMainDataResource().Variables
 	solutionRequest, err := solutionStorage.FetchRequestByFittedSolutionID(fittedSolutionID)
 	if err != nil {
 		return nil
@@ -622,14 +622,14 @@ func updateMetaDataTypes(solutionStorage api.SolutionStorage, metaStorage api.Me
 	if err != nil {
 		return nil
 	}
-	varMap := map[string] *model.Variable{}
-	for _,v:=range trainVariables{
+	varMap := map[string]*model.Variable{}
+	for _, v := range trainVariables {
 		varMap[v.Key] = v
 	}
-	result := [] *model.Variable{}
-	for _,v:=range variables{
+	result := []*model.Variable{}
+	for _, v := range variables {
 		tmp := varMap[v.Key]
-		if tmp != nil{
+		if tmp != nil {
 			tmp.Index = v.Index
 			result = append(result, tmp)
 		}

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -485,12 +485,12 @@ func getTarget(request *apiModel.Request) string {
 }
 
 func createPredictionDataset(requestTask *api.Task, request *api.PredictRequest,
-	predictParams *task.PredictParams) (task.DatasetConstructor, []string,error) {
+	predictParams *task.PredictParams) (task.DatasetConstructor, []string, error) {
 	datasetID := request.DatasetID
 	datasetPath := request.DatasetPath
 	var ds task.DatasetConstructor
 	var err error
-	indexFields:= []string{}
+	indexFields := []string{}
 	if api.HasTaskType(requestTask, compute.RemoteSensingTask) {
 		ds, err = dataset.NewSatelliteDataset(datasetID, "tif", datasetPath)
 		indexFields = dataset.GetSatelliteIndexFields()
@@ -502,12 +502,12 @@ func createPredictionDataset(requestTask *api.Task, request *api.PredictRequest,
 		var data []byte
 		data, err = ioutil.ReadFile(datasetPath)
 		if err != nil {
-			return nil, nil,errors.Wrapf(err, "unable to read raw tabular data")
+			return nil, nil, errors.Wrapf(err, "unable to read raw tabular data")
 		}
 		ds, err = dataset.NewTableDataset(datasetID, data, false)
 	}
 	if err != nil {
-		return nil, nil,err
+		return nil, nil, err
 	}
 
 	return ds, indexFields, nil

--- a/main.go
+++ b/main.go
@@ -242,7 +242,7 @@ func main() {
 	registerRoute(mux, "/distil/models/:model", routes.ModelHandler(esExportedModelStorageCtor))
 	registerRoute(mux, "/distil/join-suggestions/:dataset", routes.JoinSuggestionHandler(esMetadataStorageCtor, datamartCtors))
 	registerRoute(mux, "/distil/solution/:solution-id", routes.SolutionHandler(pgSolutionStorageCtor))
-	registerRoute(mux, "/distil/solutions/:dataset/:target", routes.SolutionsHandler(pgSolutionStorageCtor))
+	registerRoute(mux, "/distil/solutions/:dataset/:target", routes.SolutionsHandler(pgSolutionStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/distil/solution-requests/:dataset/:target", routes.SolutionRequestsHandler(pgSolutionStorageCtor))
 	registerRoute(mux, "/distil/solution-request/:request-id", routes.SolutionRequestHandler(pgSolutionStorageCtor))
 	registerRoute(mux, "/distil/prediction/:request-id", routes.PredictionHandler(pgSolutionStorageCtor))

--- a/public/components/ResultFacets.vue
+++ b/public/components/ResultFacets.vue
@@ -172,7 +172,7 @@ export default Vue.extend({
         return {
           requestId: requestId,
           solutionId: solutionId,
-          groupName: solution.feature,
+          groupName: solution.featureLabel,
           predictedSummary: predictedSummary,
           residualsSummary: residualSummary,
           correctnessSummary: correctnessSummary,

--- a/public/store/requests/index.ts
+++ b/public/store/requests/index.ts
@@ -56,6 +56,7 @@ export interface Solution extends SolutionRequest {
   errorKey: string;
   confidenceKey: string;
   isBad: boolean;
+  featureLabel: string;
 }
 
 export interface Predictions extends Request {


### PR DESCRIPTION
Fixes #2210 

Result facets and data table header were using the field keys (indirectly). They have now been updated to use the display name. Issues with missing the non main data resources on exported datasets have now also been fixed.

Looks like a lot of formatting issues were fixed for some reason.