### PR TITLE
NYU Datamart Import & Search Fixes

### DIFF
--- a/api/model/storage/datamart/nyu.go
+++ b/api/model/storage/datamart/nyu.go
@@ -183,6 +183,7 @@ func parseNYUSearchResult(responseRaw []byte, baseDataset *api.Dataset) ([]*api.
 				Key:          c.Name,
 				DisplayName:  c.Name,
 				OriginalType: mapNYUDataTypesToDistil(c.StructuralType),
+				DistilRole:   model.VarDistilRoleData,
 			})
 		}
 
@@ -243,17 +244,5 @@ func materializeNYUDataset(datamart *Storage, id string, uri string) (string, er
 		return "", errors.Wrap(err, "unable to format datamart dataset")
 	}
 
-	// copy the formatted output to the datamart output path (delete existing copy)
-	err = util.RemoveContents(extractedArchivePath, false)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to delete raw datamart dataset")
-	}
-
-	err = util.Copy(formattedPath, extractedArchivePath)
-	if err != nil {
-		return "", errors.Wrap(err, "unable to copy formatted datamart dataset")
-	}
-
-	// return the location of the expanded dataset folder
 	return formattedPath, nil
 }


### PR DESCRIPTION
NYU datamart import was not working due to no longer copying data around when ingesting. The step that cleared the raw folder and copied the formatted output has been removed since formatted data is now written directly to the raw folder.

NYU datamart search was not setting the distil role properly on variables in available datasets. This led the client to displaying 0 features.