### PR TITLE
Multi-variable timeseries support

### DIFF
--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -16,6 +16,7 @@
 package model
 
 import (
+	encoding "encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -384,6 +385,15 @@ func parseFilter(filter map[string]interface{}) (*model.Filter, error) {
 	}
 
 	return nil, fmt.Errorf("filter not recognized")
+}
+
+// ParseFilterParamsFromJSONRaw parses filter parameters out of a json.RawMessage
+func ParseFilterParamsFromJSONRaw(raw encoding.RawMessage) (*FilterParams, error) {
+	filterParamsMap, err := json.Unmarshal(raw)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse raw filter params")
+	}
+	return ParseFilterParamsFromJSON(filterParamsMap)
 }
 
 // ParseFilterParamsFromJSON parses filter parameters out of a map[string]interface{}

--- a/api/model/grouped_variables.go
+++ b/api/model/grouped_variables.go
@@ -122,6 +122,8 @@ func ExpandFilterParams(dataset string, filterParams *FilterParams, includeHidde
 				for _, componentVarName := range componentVars {
 					updatedFilterParams.AddVariable(componentVarName)
 				}
+
+				updatedFilterParams.AddVariable(variable.Key)
 			} else if model.IsImage(variable.Type) {
 				// add the variable, and if it exists the cluster{
 				updatedFilterParams.AddVariable(variable.Key)

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -47,12 +47,31 @@ type TimeseriesObservation struct {
 
 // TimeseriesData represents the result of a timeseries request.
 type TimeseriesData struct {
-	Timeseries []*TimeseriesObservation
-	IsDateTime bool
-	Min        float64
-	Max        float64
-	Mean       float64
+	VarKey     string                   `json:"variableKey"`
+	SeriesID   string                   `json:"seriesID"`
+	Timeseries []*TimeseriesObservation `json:"timeseries"`
+	IsDateTime bool                     `json:"isDateTime"`
+	Min        float64                  `json:"min"`
+	Max        float64                  `json:"max"`
+	Mean       float64                  `json:"mean"`
 }
+
+// TimeseriesOp defines the operation to aggregate timeseries values that fall into the same
+// bucket.
+type TimeseriesOp string
+
+const (
+	// TimeseriesAddOp indicates that bucket values should be added
+	TimeseriesAddOp = "add"
+	// TimeseriesMinOp indicates that the min of bucket values should be taken
+	TimeseriesMinOp = "min"
+	// TimeseriesMaxOp indicates that the max of bucket values should be taken
+	TimeseriesMaxOp = "max"
+	// TimeseriesMeanOp indicates that the mean of bucket values should be taken
+	TimeseriesMeanOp = "mean"
+	// TimeseriesDefaultOp is the operation to use when none is specified
+	TimeseriesDefaultOp = TimeseriesAddOp
+)
 
 // DataStorageCtor represents a client constructor to instantiate a data
 // storage client.
@@ -78,8 +97,8 @@ type DataStorage interface {
 	FetchResidualsExtremaByURI(dataset string, storageName string, resultURI string) (*Extrema, error)
 	FetchExtrema(dataset string, storageName string, variable *model.Variable) (*Extrema, error)
 	FetchExtremaByURI(dataset string, storageName string, resultURI string, variable string) (*Extrema, error)
-	FetchTimeseries(dataset string, storageName string, timeseriesColName string, xColName string, yColName string, timeseriesURI []string, operation string, filterParams *FilterParams, invert bool) (*map[string]*TimeseriesData, error)
-	FetchTimeseriesForecast(dataset string, storageName string, timeseriesColName string, xColName string, yColName string, timeseriesURIs []string, resultUUID string, filterParams *FilterParams) (*map[string]*TimeseriesData, error)
+	FetchTimeseries(dataset string, storageName string, variableKey string, seriesIDColName string, xColName string, yColName string, timeseriesURI []string, operation TimeseriesOp, filterParams *FilterParams, invert bool) ([]*TimeseriesData, error)
+	FetchTimeseriesForecast(dataset string, storageName string, timeseriesColName string, seriesIDColName string, xColName string, yColName string, timeseriesURIs []string, resultUUID string, filterParams *FilterParams) ([]*TimeseriesData, error)
 	FetchCategoryCounts(storageName string, variable *model.Variable) (map[string]int, error)
 	FetchSolutionFeatureWeights(dataset string, storageName string, resultURI string, d3mIndex int64) (*SolutionFeatureWeight, error)
 	// Dataset manipulation

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -97,8 +97,10 @@ type DataStorage interface {
 	FetchResidualsExtremaByURI(dataset string, storageName string, resultURI string) (*Extrema, error)
 	FetchExtrema(dataset string, storageName string, variable *model.Variable) (*Extrema, error)
 	FetchExtremaByURI(dataset string, storageName string, resultURI string, variable string) (*Extrema, error)
-	FetchTimeseries(dataset string, storageName string, variableKey string, seriesIDColName string, xColName string, yColName string, timeseriesURI []string, operation TimeseriesOp, filterParams *FilterParams, invert bool) ([]*TimeseriesData, error)
-	FetchTimeseriesForecast(dataset string, storageName string, timeseriesColName string, seriesIDColName string, xColName string, yColName string, timeseriesURIs []string, resultUUID string, filterParams *FilterParams) ([]*TimeseriesData, error)
+	FetchTimeseries(dataset string, storageName string, variableKey string, seriesIDColName string, xColName string, yColName string,
+		seriesIDs []string, operation TimeseriesOp, filterParams *FilterParams, invert bool) ([]*TimeseriesData, error)
+	FetchTimeseriesForecast(dataset string, storageName string, variableKey string, seriesIDColName string, xColName string, yColName string,
+		seriesIDs []string, operation TimeseriesOp, resultUUID string, filterParams *FilterParams) ([]*TimeseriesData, error)
 	FetchCategoryCounts(storageName string, variable *model.Variable) (map[string]int, error)
 	FetchSolutionFeatureWeights(dataset string, storageName string, resultURI string, d3mIndex int64) (*SolutionFeatureWeight, error)
 	// Dataset manipulation

--- a/api/model/storage/elastic/variable.go
+++ b/api/model/storage/elastic/variable.go
@@ -426,7 +426,7 @@ func (s *Storage) FetchVariablesByName(dataset string, varKeys []string, include
 	// filter the returned variables to match our input list
 	filteredVariables := []*model.Variable{}
 	for _, variable := range fetchedVariables {
-		if varKeySet[variable.Key] {
+		if varKeySet[variable.Key] || (includeIndex && variable.DistilRole == model.VarDistilRoleIndex) {
 			filteredVariables = append(filteredVariables, variable)
 		}
 	}

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -647,10 +647,12 @@ func (s *Storage) fetchNumRowsJoined(storageName string, variables []*model.Vari
 
 	countTarget := "*"
 
-	// match order by for distinct
-	var groupings []string
+	// ensure distinct ordering matches order by
+	groupings := []string{}
+	groupingSet := map[string]bool{}
 	for _, v := range variables {
-		if v.IsGrouping() && v.Grouping.GetIDCol() != "" {
+		if v.IsGrouping() && v.Grouping.GetIDCol() != "" && !groupingSet[v.Grouping.GetIDCol()] {
+			groupingSet[v.Grouping.GetIDCol()] = true
 			groupings = append(groupings, v.Grouping.GetIDCol())
 		}
 	}

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -523,9 +523,18 @@ func (s *Storage) buildErrorResultWhere(wheres []string, params []interface{}, r
 		return nil, nil, err
 	}
 
+	// Fetch the target variable.  For grouped variables, the target will be one of the component
+	// variables.
 	targetVariable, err := s.getResultTargetVariable(request.Dataset, request.TargetFeature())
 	if err != nil {
 		return nil, nil, err
+	}
+	if targetVariable.IsGrouping() && model.IsTimeSeries(targetVariable.Grouping.GetType()) {
+		tsg := targetVariable.Grouping.(*model.TimeseriesGrouping)
+		targetVariable, err = s.getResultTargetVariable(request.Dataset, tsg.YCol)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	typedError := getErrorTyped("", targetVariable.Key)

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -432,14 +432,12 @@ func (s *Storage) buildFilteredQueryField(variables []*model.Variable, filterVar
 	distincts := make([]string, 0)
 	fields := make([]string, 0)
 	indexIncluded := false
-	groupingCols := map[string]bool{}
 	for _, variable := range api.GetFilterVariables(filterVariables, variables) {
 		if variable.IsGrouping() {
 			continue
 		}
 
-		if variable.DistilRole == model.VarDistilRoleGrouping && !groupingCols[variable.Key] {
-			groupingCols[variable.Key] = true
+		if variable.DistilRole == model.VarDistilRoleGrouping {
 			distincts = append(distincts, fmt.Sprintf("DISTINCT ON (\"%s\")", variable.Key))
 		}
 
@@ -466,11 +464,16 @@ func (s *Storage) buildFilteredResultQueryField(variables []*model.Variable, tar
 
 	distincts := make([]string, 0)
 	fields := make([]string, 0)
+	groupingCols := map[string]bool{}
 	for _, variable := range api.GetFilterVariables(filterVariables, variables) {
+		if variable.IsGrouping() {
+			continue
+		}
 
 		if strings.Compare(targetVariable.Key, variable.Key) != 0 {
 
-			if variable.DistilRole == model.VarDistilRoleGrouping {
+			if variable.DistilRole == model.VarDistilRoleGrouping && !groupingCols[variable.Key] {
+				groupingCols[variable.Key] = true // don't duplicate columns in our distinct
 				distincts = append(distincts, fmt.Sprintf("DISTINCT ON (\"%s\")", variable.Key))
 			}
 

--- a/api/model/storage/postgres/request.go
+++ b/api/model/storage/postgres/request.go
@@ -121,7 +121,9 @@ func (s *Storage) FetchRequestBySolutionID(solutionID string) (*api.Request, err
 	if rows != nil {
 		defer rows.Close()
 	}
-	rows.Next()
+	if !rows.Next() {
+		return nil, errors.Errorf("no request for solution %s", solutionID)
+	}
 	err = rows.Err()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading data from postgres")
@@ -144,7 +146,9 @@ func (s *Storage) FetchRequestByFittedSolutionID(fittedSolutionID string) (*api.
 	if rows != nil {
 		defer rows.Close()
 	}
-	rows.Next()
+	if !rows.Next() {
+		return nil, errors.Errorf("no request for solution %s", fittedSolutionID)
+	}
 	err = rows.Err()
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading data from postgres")

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -889,7 +889,7 @@ func (s *Storage) getAverageWeights(dataset string, storageName string, storageN
 	variables []*model.Variable, whereStatement string, params []interface{}) (map[string]float64, error) {
 	variablesSQL := []string{}
 	for _, v := range variables {
-		if model.IsTA2Field(v.DistilRole, v.SelectedRole) && !model.IsIndexRole(v.SelectedRole) {
+		if model.IsTA2Field(v.DistilRole, v.SelectedRole) && !model.IsIndexRole(v.SelectedRole) && !v.IsGrouping() {
 			variablesSQL = append(variablesSQL, fmt.Sprintf("AVG(weights.\"%s\") as \"%s\"", v.Key, v.Key))
 		}
 	}

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -80,11 +80,6 @@ func (s *Storage) getResultTargetVariable(dataset string, targetName string) (*m
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to get target variable information")
 	}
-	if variable.IsGrouping() && model.IsTimeSeries(variable.Type) {
-		// extract the time series value column
-		tsg := variable.Grouping.(*model.TimeseriesGrouping)
-		return s.metadata.FetchVariable(dataset, tsg.YCol)
-	}
 	return variable, nil
 }
 
@@ -340,7 +335,7 @@ func (s *Storage) PersistResult(dataset string, storageName string, resultURI st
 		}
 		indicesParsed[parsedVal] = true
 
-		dataForInsert := []interface{}{resultURI, parsedVal, targetVariable.Key, records[i][targetIndex]}
+		dataForInsert := []interface{}{resultURI, parsedVal, targetHeaderName, records[i][targetIndex]}
 		explainValues, err := s.parseExplainValues(records[i], confidenceIndex, rankIndex)
 		if err != nil {
 			return err
@@ -426,6 +421,7 @@ func (s *Storage) parseFilteredResults(variables []*model.Variable, rows pgx.Row
 						continue
 					} else {
 						v := getVariableByKey(key, variables)
+						key = v.Key
 						label = v.DisplayName
 						if key == target.Key {
 							typ = target.Type
@@ -1002,6 +998,14 @@ func (s *Storage) getHeaderName(dataset string, key string) (string, error) {
 	variable, err := s.metadata.FetchVariable(dataset, key)
 	if err != nil {
 		return "", errors.Wrap(err, "unable fetch variable for name mapping")
+	}
+
+	if variable.IsGrouping() && model.IsTimeSeries(variable.Grouping.GetType()) {
+		tsg := variable.Grouping.(*model.TimeseriesGrouping)
+		variable, err = s.metadata.FetchVariable(dataset, tsg.YCol)
+		if err != nil {
+			return "", errors.Wrap(err, "unable fetch variable for name mapping")
+		}
 	}
 
 	return variable.HeaderName, nil

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -402,7 +402,7 @@ func (s *Storage) FetchTimeseries(dataset string, storageName string, variableKe
 		// build ANY ARRAY values
 		paramString := ""
 		if len(timeseriesURI) == 0 {
-			return nil, errors.New("No timeseriesURIs passed in")
+			return nil, errors.New("No timeseries IDs passed in")
 		}
 		for _, v := range timeseriesURI {
 			paramString += "'" + v + "',"
@@ -481,12 +481,13 @@ func (s *Storage) FetchTimeseries(dataset string, storageName string, variableKe
 }
 
 // FetchTimeseriesForecast fetches a timeseries.
-func (s *Storage) FetchTimeseriesForecast(dataset string, storageName string, varKey string, seriesIDColName string, xColName string, yColName string, timeseriesURIs []string, resultURI string, filterParams *api.FilterParams) ([]*api.TimeseriesData, error) {
+func (s *Storage) FetchTimeseriesForecast(dataset string, storageName string, varKey string, seriesIDColName string, xColName string, yColName string,
+	seriesIDs []string, duplicateOperation api.TimeseriesOp, resultURI string, filterParams *api.FilterParams) ([]*api.TimeseriesData, error) {
 	// create the filter for the query.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
 	paramString := ""
-	for _, v := range timeseriesURIs {
+	for _, v := range seriesIDs {
 		paramString += "'" + v + "',"
 	}
 	paramString = paramString[:len(paramString)-1]

--- a/api/routes/grouping.go
+++ b/api/routes/grouping.go
@@ -125,16 +125,28 @@ func RemoveGroupingHandler(dataCtor api.DataStorageCtor, metaCtor api.MetadataSt
 			}
 		}
 
-		// If there was an ID col associated with this group that was built from SubIDs, delete it now
-		if variable.Grouping.GetIDCol() != "" && len(variable.Grouping.GetSubIDs()) != 0 {
-			err = meta.DeleteVariable(dataset, variable.Grouping.GetIDCol())
+		// If there was a new variable created that specifically has the grouping role, then delete it.
+		groupingVarExists, err := meta.DoesVariableExist(dataset, variable.Grouping.GetIDCol())
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		if groupingVarExists {
+			idColVariable, err := meta.FetchVariable(dataset, variable.Grouping.GetIDCol())
 			if err != nil {
 				handleError(w, err)
 				return
 			}
+			if idColVariable.DistilRole == model.VarDistilRoleGrouping {
+				err = meta.DeleteVariable(dataset, variable.Grouping.GetIDCol())
+				if err != nil {
+					handleError(w, err)
+					return
+				}
+			}
 		}
 
-		// Delete the gropuing variable itself
+		// Delete the grouping variable itself
 		err = meta.DeleteVariable(dataset, variableName)
 		if err != nil {
 			handleError(w, err)
@@ -203,15 +215,13 @@ func createGrouping(dataset string, storageName string, groupingType string, raw
 			return err
 		}
 
-		if tsg.IDCol != "" {
-			// Create a new variable and column for the time series key.
-			if err := task.CreateComposedVariable(meta, data, dataset, storageName, tsg.IDCol, tsg.YCol, tsg.SubIDs); err != nil {
-				return errors.Wrapf(err, "unable to create new variable %s", tsg.IDCol)
-			}
-
-			// Set the name of the expected cluster column - it doesn't necessarily exist.
-			tsg.ClusterCol = model.ClusterVarPrefix + tsg.IDCol
+		// Create a new variable and column for the time series key.
+		if err := task.CreateComposedVariable(meta, data, dataset, storageName, tsg.IDCol, tsg.IDCol, tsg.SubIDs); err != nil {
+			return errors.Wrapf(err, "unable to create new variable %s", tsg.IDCol)
 		}
+
+		// Set the name of the expected cluster column - it doesn't necessarily exist.
+		tsg.ClusterCol = model.ClusterVarPrefix + tsg.IDCol
 
 		// Create a new grouped variable for the time series.
 		groupingVarName := strings.Join([]string{tsg.XCol, tsg.YCol}, task.DefaultSeparator)

--- a/api/routes/grouping.go
+++ b/api/routes/grouping.go
@@ -225,7 +225,7 @@ func createGrouping(dataset string, storageName string, groupingType string, raw
 
 		// Create a new grouped variable for the time series.
 		groupingVarName := strings.Join([]string{tsg.XCol, tsg.YCol}, task.DefaultSeparator)
-		err = meta.AddGroupedVariable(dataset, groupingVarName, tsg.YCol, model.TimeSeriesType, model.VarDistilRoleGrouping, tsg)
+		err = meta.AddGroupedVariable(dataset, groupingVarName, tsg.YCol, model.TimeSeriesType, model.VarDistilRoleData, tsg)
 		if err != nil {
 			return err
 		}

--- a/api/routes/residuals_summary.go
+++ b/api/routes/residuals_summary.go
@@ -26,6 +26,7 @@ import (
 )
 
 // ResidualsSummary contains a fetch result histogram.
+// CDB: Does this extra level need to be here?
 type ResidualsSummary struct {
 	ResidualsSummary *api.VariableSummary `json:"summary"`
 }

--- a/api/routes/residuals_summary.go
+++ b/api/routes/residuals_summary.go
@@ -25,12 +25,6 @@ import (
 	api "github.com/uncharted-distil/distil/api/model"
 )
 
-// ResidualsSummary contains a fetch result histogram.
-// CDB: Does this extra level need to be here?
-type ResidualsSummary struct {
-	ResidualsSummary *api.VariableSummary `json:"summary"`
-}
-
 // ResidualsSummaryHandler bins predicted result data for consumption in a downstream summary view.
 func ResidualsSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.SolutionStorageCtor, dataCtor api.DataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/api/routes/timeseries.go
+++ b/api/routes/timeseries.go
@@ -90,7 +90,8 @@ func TimeseriesHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.DataSto
 			}
 
 			// fetch timeseries
-			timeseriesData, err := storage.FetchTimeseries(dataset, storageName, t.VarKey, variable.Grouping.GetIDCol(), xColName, yColName, []string{t.SeriesID}, operation, filterParams, invertBool)
+			timeseriesData, err := storage.FetchTimeseries(dataset, storageName, t.VarKey, variable.Grouping.GetIDCol(),
+				xColName, yColName, []string{t.SeriesID}, operation, filterParams, invertBool)
 			if err != nil {
 				handleError(w, err)
 				return

--- a/api/routes/timeseries_forecast.go
+++ b/api/routes/timeseries_forecast.go
@@ -125,20 +125,22 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 			}
 
 			// fetch timeseries and forecast
-			timeseries, err = data.FetchTimeseries(truthDataset, truthStorageName, t.VarKey, variable.Grouping.GetIDCol(),
+			timeseriesData, err := data.FetchTimeseries(truthDataset, truthStorageName, t.VarKey, variable.Grouping.GetIDCol(),
 				xColName, yColName, []string{t.SeriesID}, operation, filterParams, false)
 			if err != nil {
 				handleError(w, err)
 				return
 			}
+			timeseries = append(timeseries, timeseriesData...)
 
 			// fetch the predicted timeseries
-			forecasts, err = data.FetchTimeseriesForecast(forecastDataset, forecastStorageName, t.VarKey, variable.Grouping.GetIDCol(),
+			forecastData, err := data.FetchTimeseriesForecast(forecastDataset, forecastStorageName, t.VarKey, variable.Grouping.GetIDCol(),
 				xColName, yColName, []string{t.SeriesID}, operation, res.ResultURI, filterParams)
 			if err != nil {
 				handleError(w, err)
 				return
 			}
+			forecasts = append(forecasts, forecastData...)
 		}
 
 		result := []*TimeseriesForecastResult{}

--- a/api/routes/timeseries_forecast.go
+++ b/api/routes/timeseries_forecast.go
@@ -20,19 +20,19 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil/api/compute"
+	"github.com/uncharted-distil/distil/api/model"
 	api "github.com/uncharted-distil/distil/api/model"
 	"goji.io/v3/pat"
 )
 
 // TimeseriesForecastResult represents the result of a timeseries request.
 type TimeseriesForecastResult struct {
+	VarKey            string                       `json:"variableKey"`
+	SeriesID          string                       `json:"seriesID"`
 	Timeseries        []*api.TimeseriesObservation `json:"timeseries"`
 	Forecast          []*api.TimeseriesObservation `json:"forecast"`
 	ForecastTestRange []float64                    `json:"forecastTestRange"`
 	IsDateTime        bool                         `json:"isDateTime"`
-	Min               api.NullableFloat64          `json:"min"`
-	Max               api.NullableFloat64          `json:"max"`
-	Mean              api.NullableFloat64          `json:"mean"`
 }
 
 // TimeseriesForecastHandler returns timeseries data.
@@ -41,39 +41,31 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 
 		truthDataset := pat.Param(r, "truthDataset")
 		forecastDataset := pat.Param(r, "forecastDataset")
-		timeseriesColName := pat.Param(r, "timeseriesColName")
 		xColName := pat.Param(r, "xColName")
 		yColName := pat.Param(r, "yColName")
 		resultUUID := pat.Param(r, "result-uuid")
-		result := map[string]TimeseriesForecastResult{}
+
 		// parse POST params
-		params, err := getPostParameters(r)
+		params, err := parsePostParms(r)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "Unable to parse post parameters"))
 			return
 		}
-		t, ok := params["timeseriesUris"].([]interface{})
-		if !ok {
-			handleError(w, errors.New("Missing timeseriesUris from query"))
-			return
+
+		// validate the bucket operation
+		operation := api.TimeseriesOp(params.DuplicateOperation)
+		if operation == "" {
+			operation = model.TimeseriesDefaultOp //default
 		}
-		operation, ok := params["duplicateOperation"].(string)
-		if !ok {
-			operation = "add" //default
-		}
-		timeseriesUris := []string{}
-		for _, v := range t {
-			s, ok := v.(string)
-			if !ok {
+
+		// get variable names and ranges out of the params
+		var filterParams *model.FilterParams
+		if params.FilterParams != nil {
+			filterParams, err = api.ParseFilterParamsFromJSONRaw(params.FilterParams)
+			if err != nil {
+				handleError(w, err)
 				return
 			}
-			timeseriesUris = append(timeseriesUris, s)
-		}
-		// get variable names and ranges out of the params
-		filterParams, err := api.ParseFilterParamsFromJSON(params)
-		if err != nil {
-			handleError(w, err)
-			return
 		}
 
 		// get storage client
@@ -107,42 +99,61 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 			handleError(w, err)
 			return
 		}
-		predictedStorageName := dsf.StorageName
-
-		// fetch the ground truth timeseries
-		timeseries, err := data.FetchTimeseries(truthDataset, truthStorageName, "", timeseriesColName, xColName, yColName, timeseriesUris, api.TimeseriesOp(operation), filterParams, false)
+		forecastStorageName := dsf.StorageName
 
 		if err != nil {
 			handleError(w, err)
 			return
 		}
 
-		// get the result URI. Error ignored to make it ES compatible.
+		// get the result UUID
 		res, err := solution.FetchSolutionResultByUUID(resultUUID)
 		if err != nil {
 			handleError(w, err)
 			return
 		}
 
-		// fetch the predicted timeseries
-		forecasts, err := data.FetchTimeseriesForecast(forecastDataset, predictedStorageName, "", timeseriesColName, xColName, yColName, timeseriesUris, res.ResultURI, filterParams)
-		if err != nil {
-			handleError(w, err)
-			return
+		// CDB TODO: - need to optimize query for multiple series, mutliple variables
+		timeseries := []*model.TimeseriesData{}
+		forecasts := []*model.TimeseriesData{}
+		for _, t := range params.TimeseriesIDs {
+			// fetch the timeseries variable and find the grouping col
+			variable, err := meta.FetchVariable(forecastDataset, t.VarKey)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+
+			// fetch timeseries and forecast
+			timeseries, err = data.FetchTimeseries(truthDataset, truthStorageName, t.VarKey, variable.Grouping.GetIDCol(),
+				xColName, yColName, []string{t.SeriesID}, operation, filterParams, false)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+
+			// fetch the predicted timeseries
+			forecasts, err = data.FetchTimeseriesForecast(forecastDataset, forecastStorageName, t.VarKey, variable.Grouping.GetIDCol(),
+				xColName, yColName, []string{t.SeriesID}, operation, res.ResultURI, filterParams)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
 		}
+
+		result := []*TimeseriesForecastResult{}
 		for idx, t := range timeseries {
 			// Recompute train/test split info for visualization purposes
 			split := compute.SplitTimeSeries(t.Timeseries, trainTestSplitTimeSeries)
 			forecast := forecasts[idx]
-			result[t.SeriesID] = TimeseriesForecastResult{
+			result = append(result, &TimeseriesForecastResult{
+				VarKey:            t.VarKey,
+				SeriesID:          t.SeriesID,
 				Timeseries:        t.Timeseries,
 				Forecast:          forecast.Timeseries,
 				ForecastTestRange: []float64{split.SplitValue, split.EndValue},
 				IsDateTime:        true,
-				Min:               api.NullableFloat64(forecast.Min),
-				Max:               api.NullableFloat64(forecast.Max),
-				Mean:              api.NullableFloat64(forecast.Mean),
-			}
+			})
 		}
 		err = handleJSON(w, result)
 		if err != nil {

--- a/public/components/ResultFacets.vue
+++ b/public/components/ResultFacets.vue
@@ -189,7 +189,7 @@ export default Vue.extend({
       // with their groups sorted by Scores DESC.
       return _.map(summariesByRequestId, (groups, requestId) => ({
         groups: groups.sort(this.sortByScoreDESC),
-        progress: requestsMap[requestId].progress,
+        progress: requestsMap[requestId]?.progress,
         requestId: requestId,
         requestIndex: this.getRequestIndex(requestId),
       })).sort(this.sortByRequestIndexDESC);

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -527,9 +527,9 @@ export default Vue.extend({
       this.timeseriesGroupings.forEach((tsg) => {
         resultsActions.fetchForecastedTimeseries(this.$store, {
           dataset: this.dataset,
+          variableKey: tsg.idCol,
           xColName: tsg.xCol,
           yColName: tsg.yCol,
-          timeseriesColName: tsg.idCol,
           solutionId: this.solutionId,
           uniqueTrail: this.uniqueTrail,
           timeseriesIds: this.pageItems.map((item) => {

--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -67,7 +67,7 @@ export default Vue.extend({
     forecastDataset: String as () => string,
     xCol: String as () => string,
     yCol: String as () => string,
-    timeseriesCol: String as () => string,
+    variableKey: String as () => string,
     timeseriesId: String as () => string,
     solutionId: String as () => string,
     predictionsId: String as () => string,
@@ -88,7 +88,7 @@ export default Vue.extend({
         : "sparkline-preview-container";
     },
     timeseriesUniqueId(): string {
-      return this.timeseriesId + this.uniqueTrail;
+      return this.variableKey + this.timeseriesId + this.uniqueTrail;
     },
     timeseries(): TimeSeriesValue[] {
       if (this.solutionId) {

--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -7,9 +7,9 @@
       :forecast-extrema="forecastExtrema"
       :highlight-range="highlightRange"
       :join-forecast="!!predictionsId"
-      :isDateTime="isDateTime()"
+      :is-date-time="isDateTime()"
     />
-    <i class="fa fa-plus zoom-sparkline-icon" @click.stop="onClick"></i>
+    <i class="fa fa-plus zoom-sparkline-icon" @click.stop="onClick" />
     <b-modal
       id="sparkline-zoom-modal"
       hide-footer
@@ -18,15 +18,15 @@
       @hide="hideModal"
     >
       <div v-if="forecast" class="sparkline-legend">
-        <div class="sparkline-legend-historical"></div>
+        <div class="sparkline-legend-historical" />
         <div class="sparkline-legend-label">Historical</div>
-        <div class="sparkline-legend-missing"></div>
+        <div class="sparkline-legend-missing" />
         <div class="sparkline-legend-label">Missing</div>
-        <div class="sparkline-legend-predicted"></div>
+        <div class="sparkline-legend-predicted" />
         <div class="sparkline-legend-label">Predicted</div>
-        <div class="sparkline-legend-variability"></div>
+        <div class="sparkline-legend-variability" />
         <div class="sparkline-legend-label">Variability</div>
-        <div class="sparkline-legend-scoring"></div>
+        <div class="sparkline-legend-scoring" />
         <div class="sparkline-legend-label">Scoring</div>
       </div>
       <sparkline-chart
@@ -54,7 +54,7 @@ import { getters as resultsGetters } from "../store/results/module";
 import { getters as predictionsGetters } from "../store/predictions/module";
 
 export default Vue.extend({
-  name: "sparkline-preview",
+  name: "SparklinePreview",
 
   components: {
     SparklineSvg,

--- a/public/components/facets/FacetSparklines.vue
+++ b/public/components/facets/FacetSparklines.vue
@@ -60,6 +60,7 @@ import {
   Highlight,
   RowSelection,
   TimeseriesGrouping,
+  Variable,
   VariableSummary,
 } from "../../store/dataset";
 import {
@@ -72,14 +73,12 @@ import {
   facetTypeChangeState,
 } from "../../util/facets";
 import _ from "lodash";
-import { IMAGE_TYPE } from "../../util/types";
 
 export default Vue.extend({
   name: "facet-sparklines",
 
   components: {
     TypeChangeMenu,
-    SparklinePreview,
   },
 
   directives: {
@@ -96,7 +95,7 @@ export default Vue.extend({
     enableHighlighting: Boolean as () => boolean,
     expandCollapse: Function as () => Function,
     highlight: Object as () => Highlight,
-    grouping: Object as () => TimeseriesGrouping,
+    variable: Object as () => Variable,
     html: [
       String as () => string,
       Object as () => any,
@@ -105,7 +104,7 @@ export default Vue.extend({
     instanceName: String as () => string,
     rowSelection: Object as () => RowSelection,
     summary: Object as () => VariableSummary,
-    expand: Boolean as () => Boolean,
+    expand: Boolean as () => boolean,
   },
 
   data() {
@@ -118,7 +117,7 @@ export default Vue.extend({
   computed: {
     facetData(): FacetTermsData {
       let values = [];
-      if (hasBaseline(this.summary) && this.grouping) {
+      if (hasBaseline(this.summary)) {
         values = this.getFacetValues();
       }
       return {
@@ -212,16 +211,17 @@ export default Vue.extend({
       return facetData;
     },
     getSparkline(sparklineId: string) {
+      const grouping = this.variable.grouping as TimeseriesGrouping;
       const sp = new SparklinePreview({
         store: this.$store,
         router: this.$router,
         propsData: {
           facetView: true,
-          timeseriesCol: this.grouping.idCol,
+          variableKey: this.variable.key,
           timeseriesId: sparklineId,
           truthDataset: this.summary.dataset,
-          xCol: this.grouping.xCol,
-          yCol: this.grouping.yCol,
+          xCol: grouping.xCol,
+          yCol: grouping.yCol,
         },
       });
       sp.$mount();

--- a/public/components/facets/FacetSparklines.vue
+++ b/public/components/facets/FacetSparklines.vue
@@ -211,6 +211,9 @@ export default Vue.extend({
       return facetData;
     },
     getSparkline(sparklineId: string) {
+      if (!this.variable) {
+        return;
+      }
       const grouping = this.variable.grouping as TimeseriesGrouping;
       const sp = new SparklinePreview({
         store: this.$store,

--- a/public/components/facets/FacetTimeseries.vue
+++ b/public/components/facets/FacetTimeseries.vue
@@ -9,10 +9,10 @@
         Boolean(enableHighlighting) && enableHighlighting[0]
       "
       :ignore-highlights="Boolean(ignoreHighlights) && ignoreHighlights[0]"
-      :instanceName="instanceName"
+      :instance-name="instanceName"
       :html="customHtml"
-      :expandCollapse="expandCollapse"
-      :grouping="grouping"
+      :expand-collapse="expandCollapse"
+      :variable="variable"
       :expand="expand"
       @html-appended="onHtmlAppend"
       @numerical-click="onNumericalClick"
@@ -27,7 +27,7 @@
       :highlight="highlight"
       :row-selection="rowSelection"
       :enabled-type-changes="enabledTypeChanges"
-      :instanceName="instanceName"
+      :instance-name="instanceName"
       :enable-highlighting="
         Boolean(enableHighlighting) && enableHighlighting[1]
       "
@@ -46,22 +46,15 @@ import FacetDateTime from "./FacetDateTime.vue";
 import FacetNumerical from "./FacetNumerical.vue";
 import FacetSparklines from "./FacetSparklines.vue";
 import { getters as datasetGetters } from "../../store/dataset/module";
-import { getters as routeGetters } from "../../store/route/module";
 import {
-  Dataset,
   Variable,
   VariableSummary,
   Highlight,
   RowSelection,
-  Row,
   NUMERICAL_SUMMARY,
   TimeseriesGrouping,
 } from "../../store/dataset";
-import {
-  INTEGER_TYPE,
-  EXPAND_ACTION_TYPE,
-  COLLAPSE_ACTION_TYPE,
-} from "../../util/types";
+import { EXPAND_ACTION_TYPE, COLLAPSE_ACTION_TYPE } from "../../util/types";
 
 /**
  * Timeseries Facet.

--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -352,9 +352,9 @@ export default Vue.extend({
           const grouping = timeseriesVar.grouping as TimeseriesGrouping;
           await datasetActions.fetchTimeseries(this.$store, {
             dataset: this.dataset,
+            variableKey: timeseriesVar.key,
             xColName: grouping.xCol,
             yColName: grouping.yCol,
-            timeseriesColName: grouping.idCol,
             timeseriesIds: ids,
           });
         });

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -61,6 +61,11 @@ export interface TimeSeriesUpdate {
   mean: number;
 }
 
+export interface TimeSeriesForecastUpdate extends TimeSeriesUpdate {
+  forecast: TimeSeriesValue[];
+  forecastTestRange: number[];
+}
+
 export const mutations = {
   setDataset(state: DatasetState, dataset: Dataset) {
     const index = _.findIndex(state.datasets, (d) => {

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -21,10 +21,7 @@ import {
 } from "../../util/solutions";
 import { DataMode, Highlight, SummaryMode, Variable } from "../dataset/index";
 import { getters as dataGetters } from "../dataset/module";
-import {
-  TimeSeriesForecastUpdate,
-  TimeSeriesUpdate,
-} from "../dataset/mutations";
+import { TimeSeriesForecastUpdate } from "../dataset/mutations";
 import { getters as resultGetters } from "../results/module";
 import store, { DistilState } from "../store";
 import { ResultsState } from "./index";

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -925,9 +925,9 @@ export const actions = {
     context: ResultsContext,
     args: {
       dataset: string;
+      variableKey: string;
       xColName: string;
       yColName: string;
-      timeseriesColName: string;
       solutionId: string;
       timeseriesIds: string[];
       uniqueTrail?: string;
@@ -949,7 +949,7 @@ export const actions = {
       console.warn("`timeseriesIds` argument is missing");
       return null;
     }
-    if (!args.timeseriesColName) {
+    if (!args.variableKey) {
       console.warn("`timeseriesColName` argument is missing");
       return null;
     }
@@ -972,7 +972,7 @@ export const actions = {
         `distil/timeseries-forecast/` +
           `${encodeURIComponent(args.dataset)}/` +
           `${encodeURIComponent(args.dataset)}/` +
-          `${encodeURIComponent(args.timeseriesColName)}/` +
+          `${encodeURIComponent(args.variableKey)}/` +
           `${encodeURIComponent(args.xColName)}/` +
           `${encodeURIComponent(args.yColName)}/` +
           `${encodeURIComponent(solution.resultId)}`,

--- a/public/store/results/mutations.ts
+++ b/public/store/results/mutations.ts
@@ -182,14 +182,14 @@ export const mutations = {
   bulkUpdatePredictedForecast(
     state: ResultsState,
     args: {
-      solutionID: string;
+      solutionId: string;
       uniqueTrail?: string;
       updates: TimeSeriesForecastUpdate[];
     }
   ) {
     args.updates.forEach((update) => {
       mutations.updatePredictedForecast(state, {
-        solutionId: args.solutionID,
+        solutionId: args.solutionId,
         uniqueTrail: args.uniqueTrail,
         update: update,
       });

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -772,15 +772,6 @@ export const actions = {
       solutionID: solutionId,
     });
 
-    resultActions.fetchConfidenceSummaries(store, {
-      dataset: dataset,
-      target: target,
-      requestIds: requestIds,
-      highlight: highlight,
-      dataMode: dataMode,
-      varModes: varModes,
-    });
-
     const task = routeGetters.getRouteTask(store);
 
     if (!task) {
@@ -804,6 +795,15 @@ export const actions = {
       });
     } else if (task.includes(TaskTypes.CLASSIFICATION)) {
       resultActions.fetchCorrectnessSummaries(store, {
+        dataset: dataset,
+        target: target,
+        requestIds: requestIds,
+        highlight: highlight,
+        dataMode: dataMode,
+        varModes: varModes,
+      });
+
+      resultActions.fetchConfidenceSummaries(store, {
         dataset: dataset,
         target: target,
         requestIds: requestIds,

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -319,8 +319,8 @@ export async function fetchResultExemplars(
   const variables = datasetGetters.getVariables(store);
   const variable = variables.find((v) => v.key === variableName);
 
-  const baselineExemplars = summary.baseline?.exemplars;
-  const filteredExemplars = summary.filtered?.exemplars;
+  const baselineExemplars = summary?.baseline?.exemplars;
+  const filteredExemplars = summary?.filtered?.exemplars;
   const exemplars = filteredExemplars ? filteredExemplars : baselineExemplars;
 
   if (exemplars) {
@@ -330,7 +330,7 @@ export async function fetchResultExemplars(
         // if there a linked exemplars, fetch those before resolving
         return await resultsActions.fetchForecastedTimeseries(store, {
           dataset: datasetName,
-          variableKey: grouping.idCol,
+          variableKey: variable.key,
           xColName: grouping.xCol,
           yColName: grouping.yCol,
           timeseriesIds: exemplars,
@@ -606,8 +606,11 @@ export async function fetchSolutionResultSummary(
       completeEndpoint,
       filterParams ? filterParams : {}
     );
-    // save the histogram data
+    // save the histogram data if this is summary data
     const summary = response.data[resultProperty];
+    if (!summary) {
+      return;
+    }
     await fetchResultExemplars(dataset, target, key, solutionId, summary);
     summary.solutionId = solutionId;
     summary.dataset = dataset;

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -255,7 +255,7 @@ export function getTimeseriesAnalysisIntervals(
   ];
 }
 
-export function fetchSummaryExemplars(
+export async function fetchSummaryExemplars(
   datasetName: string,
   variableName: string,
   summary: VariableSummary
@@ -284,28 +284,24 @@ export function fetchSummaryExemplars(
           timeseriesIds: exemplars,
           solutionId: solutionId,
         };
-        return () => {
-          if (solutionId) {
-            return resultsActions.fetchForecastedTimeseries(store, args);
-          } else {
-            return datasetActions.fetchTimeseries(store, args);
-          }
-        };
+        if (solutionId) {
+          return await resultsActions.fetchForecastedTimeseries(store, args);
+        } else {
+          return await datasetActions.fetchTimeseries(store, args);
+        }
       }
     } else {
       // if there are linked files, fetch some of them before resolving
-      return datasetActions.fetchFiles(store, {
+      return await datasetActions.fetchFiles(store, {
         dataset: datasetName,
         variable: variableName,
         urls: exemplars.slice(0, 5),
       });
     }
   }
-
-  return new Promise<void>((res) => res());
 }
 
-export function fetchResultExemplars(
+export async function fetchResultExemplars(
   datasetName: string,
   variableName: string,
   key: string,
@@ -324,7 +320,7 @@ export function fetchResultExemplars(
       if (variable.grouping.type === TIMESERIES_TYPE) {
         const grouping = variable.grouping as TimeseriesGrouping;
         // if there a linked exemplars, fetch those before resolving
-        return resultsActions.fetchForecastedTimeseries(store, {
+        return await resultsActions.fetchForecastedTimeseries(store, {
           dataset: datasetName,
           timeseriesColName: grouping.idCol,
           xColName: grouping.xCol,
@@ -335,15 +331,13 @@ export function fetchResultExemplars(
       }
     } else {
       // if there a linked files, fetch those before resolving
-      return datasetActions.fetchFiles(store, {
+      return await datasetActions.fetchFiles(store, {
         dataset: datasetName,
         variable: variableName,
         urls: exemplars,
       });
     }
   }
-
-  return new Promise<void>((res) => res());
 }
 
 /*

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -158,21 +158,29 @@ export function getTimeseriesSummaryTopCategories(
 export function getRandomInt(max: number): number {
   return Math.floor(Math.random() * Math.floor(max));
 }
+
 export function getTimeseriesGroupingsFromFields(
   variables: Variable[],
   fields: Dictionary<TableColumn>
 ): TimeseriesGrouping[] {
+  return getTimeseriesVariablesFromFields(variables, fields).map(
+    (v) => v.grouping as TimeseriesGrouping
+  );
+}
+
+export function getTimeseriesVariablesFromFields(
+  variables: Variable[],
+  fields: Dictionary<TableColumn>
+): Variable[] {
   // Check to see if any of the fields are the ID column of one of our variables
   const fieldKeys = _.map(fields, (_, key) => key);
-  return variables
-    .filter(
-      (v) =>
-        v.grouping &&
-        v.grouping.idCol &&
-        v.colType === TIMESERIES_TYPE &&
-        _.includes(fieldKeys, v.grouping.idCol)
-    )
-    .map((v) => v.grouping as TimeseriesGrouping);
+  return variables.filter(
+    (v) =>
+      v.grouping &&
+      v.grouping.idCol &&
+      v.colType === TIMESERIES_TYPE &&
+      _.includes(fieldKeys, v.key)
+  );
 }
 
 export function getComposedVariableKey(keys: string[]): string {
@@ -278,7 +286,7 @@ export async function fetchSummaryExemplars(
         const grouping = variable.grouping as TimeseriesGrouping;
         const args = {
           dataset: datasetName,
-          timeseriesColName: grouping.idCol,
+          variableKey: variable.key,
           xColName: grouping.xCol,
           yColName: grouping.yCol,
           timeseriesIds: exemplars,
@@ -322,7 +330,7 @@ export async function fetchResultExemplars(
         // if there a linked exemplars, fetch those before resolving
         return await resultsActions.fetchForecastedTimeseries(store, {
           dataset: datasetName,
-          timeseriesColName: grouping.idCol,
+          variableKey: grouping.idCol,
           xColName: grouping.xCol,
           yColName: grouping.yCol,
           timeseriesIds: exemplars,

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -1084,9 +1084,9 @@ export function getImageFields(
         v.grouping &&
         v.grouping.idCol &&
         v.colType === MULTIBAND_IMAGE_TYPE &&
-        _.includes(fieldKeys, v.grouping.idCol)
+        _.includes(fieldKeys, v.key)
     )
-    .map((v) => ({ key: v.grouping.idCol, type: v.colType }));
+    .map((v) => ({ key: v.key, type: v.colType }));
 
   // the two are probably mutually exclusive, but it doesn't hurt anything to allow for both
   return imageFields.concat(multiBandImageFields);

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -375,6 +375,10 @@ export function isImageType(type: string): boolean {
   return IMAGE_TYPES.indexOf(type) !== -1;
 }
 
+export function isTimeSeriesType(type: string): boolean {
+  return type === TIMESERIES_TYPE;
+}
+
 export function hasComputedVarPrefix(varName: string): boolean {
   return Boolean(
     COMPUTED_VAR_PREFIXES.find((prefix) => varName.indexOf(prefix) === 0)

--- a/public/views/VariableGrouping.vue
+++ b/public/views/VariableGrouping.vue
@@ -529,7 +529,7 @@ export default Vue.extend({
       const groupings = [] as Grouping[];
 
       if (this.isTimeseries) {
-        const tsGrouping = _.cloneDeep(grouping) as TimeseriesGrouping;
+        const tsGrouping = { ...grouping } as TimeseriesGrouping;
         tsGrouping.xCol = this.xCol;
         tsGrouping.yCol = this.yCol;
         tsGrouping.clusterCol = null;
@@ -551,7 +551,7 @@ export default Vue.extend({
             .forEach((v) => {
               // create a new grouping entry for each value variable and add it to
               // the list to create
-              const tsGrouping = _.cloneDeep(grouping) as TimeseriesGrouping;
+              const tsGrouping = { ...grouping } as TimeseriesGrouping;
               tsGrouping.hidden = gotoTarget
                 ? this.getHiddenCols(idCol, this.xCol, v)
                 : [];


### PR DESCRIPTION
fixes #1757 fixes #1421

We needed to support situations were we have multiple measures per series in a dataset.  An example would be an extension to the terra dataset, where we have series per sector, and would want to include plant height AND soil moisture measurements for each timestamp.  The result would be a time/height series, and a time/moisture series, for each sector.  This required changing the way we reference timeseries variables - previously we did it using the grouping column name, but this meant that we could only support a single variable per series.  We now reference the variables using the top level variable key.  Other grouped variables (geocoords, images, satellite images) should be handled the same way, but that can be done as follow-on work.  I'm hoping we can stop sending the grouping variables down to the client when it requests the variables from the server, but that will need to some testing, and this PR was already getting big enough.