### PR TITLE
Replaces fixed names for grouping and coord cols with values from vars

### DIFF
--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -66,6 +66,10 @@ export interface GeoCoordinateGrouping extends Grouping {
   yCol: string;
 }
 
+export interface GeoBoundsGrouping extends Grouping {
+  coordinatesCol: string;
+}
+
 export interface MultiBandImageGrouping extends ClusteredGrouping {
   imageCol: string;
   bandCol: string;


### PR DESCRIPTION
Grouping and coord col names were fixed, and broke when some aspects of group variables were refactored as part of #2221.  This fix gets the name of the coord col from the coord variable, and the group col from the multiband image variable.