### PR TITLE
Image scaling in drill down

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -96,7 +96,7 @@ type Config struct {
 	TrainTestSplitTimeSeries           float64 `env:"TRAIN_TEST_SPLIT_TIMESERIES" envDefault:"0.9"`
 	UserProblemPath                    string  `env:"USER_PROBLEM_PATH" envDefault:"outputs/problems"`
 	VerboseError                       bool    `env:"VERBOSE_ERROR" envDefault:"false"`
-	ShouldScaleImages				   bool    `env:"SHOULD_SCALE_IMAGES" envDefault:"false"` // enables and disables image scaling
+	ShouldScaleImages                  bool    `env:"SHOULD_SCALE_IMAGES" envDefault:"false"` // enables and disables image scaling
 }
 
 // LoadConfig loads the config from the environment if necessary and returns a copy.

--- a/api/env/config.go
+++ b/api/env/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	TrainTestSplitTimeSeries           float64 `env:"TRAIN_TEST_SPLIT_TIMESERIES" envDefault:"0.9"`
 	UserProblemPath                    string  `env:"USER_PROBLEM_PATH" envDefault:"outputs/problems"`
 	VerboseError                       bool    `env:"VERBOSE_ERROR" envDefault:"false"`
+	ShouldScaleImages				   bool    `env:"SHOULD_SCALE_IMAGES" envDefault:"false"` // enables and disables image scaling
 }
 
 // LoadConfig loads the config from the environment if necessary and returns a copy.

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -91,7 +91,7 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, config env.Config) func
 		if isThumbnail {
 			imageScale = util.ImageScale{Width: ThumbnailDimensions, Height: ThumbnailDimensions}
 			// if thumbnail scale should be 0
-			options.Scale=0
+			options.Scale = 0
 		}
 		img, err := util.ImageFromCombination(sourcePath, imageID, bandCombo, imageScale, options)
 		if err != nil {
@@ -104,7 +104,7 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, config env.Config) func
 				options.Scale = 3
 			}
 			// multiple passes for increasing scale dramatically
-			for i:=0; i < options.Scale; i++ {
+			for i := 0; i < options.Scale; i++ {
 				img = util.UpscaleImage(img)
 			}
 		}

--- a/api/task/query.go
+++ b/api/task/query.go
@@ -101,25 +101,25 @@ func Query(params QueryParams) (map[string]interface{}, error) {
 
 	return nil, nil
 }
-func convertResultToRanking(results *[][]string) error{
+func convertResultToRanking(results *[][]string) error {
 	// index for result values
 	valueIdx := 1
-	end := len(*results)-1
+	end := len(*results) - 1
 	bitSize := 64
 	// max extrema
-	maxValue,err := strconv.ParseFloat((*results)[valueIdx][valueIdx],bitSize)
+	maxValue, err := strconv.ParseFloat((*results)[valueIdx][valueIdx], bitSize)
 	// if err while parsing normalize by index instead
 	if err != nil {
 		return err
 	}
 	// min extrema
-	minValue,err := strconv.ParseFloat((*results)[end][valueIdx], bitSize)
+	minValue, err := strconv.ParseFloat((*results)[end][valueIdx], bitSize)
 	if err != nil {
 		return err
 	}
 	// denominator
 	diff := maxValue - minValue
-	for _, res := range(*results)[1:]{
+	for _, res := range (*results)[1:] {
 		value, err := strconv.ParseFloat(res[valueIdx], bitSize)
 		if err != nil {
 			return err

--- a/api/util/color_correction.go
+++ b/api/util/color_correction.go
@@ -7,6 +7,7 @@ type Options struct {
 	Gain  float64 `json:"gain"`
 	Gamma float64 `json:"gamma"`
 	GainL float64 `json:"gainL"`
+	Scale int     `json:"scale"`
 }
 
 // ConvertS2ToRgb bands: [b02, b03, b04], Options gain amount, gamma correction amount, gainL light gain

--- a/main.go
+++ b/main.go
@@ -254,7 +254,7 @@ func main() {
 	registerRoute(mux, "/distil/export/:solution-id", routes.ExportHandler(solutionClient, config.D3MOutputDir, discoveryLogger))
 	registerRoute(mux, "/distil/config", routes.ConfigHandler(config, version, timestamp, problemPath, datasetDocPath, ta2Version))
 	registerRoute(mux, "/distil/task/:dataset/:target/:variables", routes.TaskHandler(pgDataStorageCtor, esMetadataStorageCtor))
-	registerRoute(mux, "/distil/multiband-image/:dataset/:image-id/:band-combination/:is-thumbnail/*", routes.MultiBandImageHandler(esMetadataStorageCtor))
+	registerRoute(mux, "/distil/multiband-image/:dataset/:image-id/:band-combination/:is-thumbnail/*", routes.MultiBandImageHandler(esMetadataStorageCtor, config))
 	registerRoute(mux, "/distil/multiband-combinations/:dataset", routes.MultiBandCombinationsHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/distil/load/:solution-id/:fitted", routes.LoadHandler(esExportedModelStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/distil/solution-variable-rankings/:solution-id", routes.SolutionVariableRankingHandler(esMetadataStorageCtor, pgSolutionStorageCtor))

--- a/public/components/DrillDown.vue
+++ b/public/components/DrillDown.vue
@@ -88,6 +88,7 @@ interface Dimensions {
   width: number;
   height: number;
 }
+
 export default Vue.extend({
   name: "drill-down",
 

--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -231,7 +231,7 @@ export default Vue.extend({
         this.hidden = false;
         this.isFilteredToggled = this.hasImageAttention;
         this.carouselPosition = this.initialPosition;
-        this.requestImage();
+        this.requestImage({ gainL: 1.0, gamma: 2.2, gain: 2.5, scale: 1 });
         if (this.hasImageAttention) {
           this.requestFilter();
         }
@@ -260,7 +260,7 @@ export default Vue.extend({
       const val = Number(e) / this.brightnessMax;
       const gainL = val * MAX_GAINL;
       this.currentBrightness = val;
-      this.requestImage({ gainL, gamma: 2.2, gain: 2.5 }); // gamma, gain, are default. They are here if we need to edit them later down the road
+      this.requestImage({ gainL, gamma: 2.2, gain: 2.5, scale: 1 }); // gamma, gain, are default. They are here if we need to edit them later down the road
     },
 
     cleanUp() {
@@ -283,6 +283,7 @@ export default Vue.extend({
       gamma: number;
       gain: number;
       gainL: number;
+      scale: number;
     }) {
       if (this.isMultiBandImage) {
         await datasetActions.fetchMultiBandImage(this.$store, {


### PR DESCRIPTION
- Added support for image upscaling in image drill down
- Added config var for disabling image upscaling defaults to off (false)
- Bigearth image runs in 800ms, locust 18000ms (on cpu)
- Bigearth image runs in 130ms, locust 1800ms (on gpu)
- If running on mac and using high resolution images should definitely have the variable off
![Peek 2021-02-05 16-10](https://user-images.githubusercontent.com/25306965/107091038-15689a00-67cf-11eb-9f4e-d6769cc277a3.gif)
