### PR TITLE
Prediction Dataset Features

### DIFF
--- a/api/routes/clone.go
+++ b/api/routes/clone.go
@@ -225,14 +225,17 @@ func getCloningParams(predictionRequestID string, metaStorage api.MetadataStorag
 
 	if includeDatasetFeatures {
 		// just select every feature in the source dataset
-		ds, err := metaStorage.FetchDataset(req.Dataset, false, false, false)
+		ds, err := metaStorage.FetchDataset(req.Dataset, true, false, false)
 		if err != nil {
 			return nil, err
 		}
 
-		features = make([]string, len(ds.Variables))
+		features = make([]string, len(ds.Variables)-1)
 		for i, v := range ds.Variables {
-			features[i] = v.Key
+			// the target is not a feature!
+			if v.Key != targetName {
+				features[i] = v.Key
+			}
 		}
 	}
 

--- a/api/routes/clone.go
+++ b/api/routes/clone.go
@@ -114,6 +114,13 @@ func CloningHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCt
 	}
 }
 
+type cloningParams struct {
+	sourceDataset     string
+	predictionDataset string
+	targetName        string
+	features          []string
+}
+
 // CloningResultsHandler generates a route handler that enables cloning
 // of a result + dataset in the data storage and metadata storage, creating
 // a new dataset based on results.
@@ -139,6 +146,10 @@ func CloningResultsHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataSt
 			return
 		}
 		newDatasetName := params["datasetName"].(string)
+		includeDatasetFeatures := false
+		if params["includeDatasetFeatures"] != nil {
+			includeDatasetFeatures = params["includeDatasetFeatures"].(bool)
+		}
 
 		metaStorage, err := metaCtor()
 		if err != nil {
@@ -157,24 +168,10 @@ func CloningResultsHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataSt
 		}
 
 		// get the features from the request
-		prediction, err := solutionStorage.FetchPrediction(predictionRequestID)
+		parsedParams, err := getCloningParams(predictionRequestID, metaStorage, solutionStorage, includeDatasetFeatures)
 		if err != nil {
 			handleError(w, err)
 			return
-		}
-		request, err := solutionStorage.FetchRequestByFittedSolutionID(prediction.FittedSolutionID)
-		if err != nil {
-			handleError(w, err)
-			return
-		}
-		targetName := ""
-		features := []string{model.D3MIndexFieldName}
-		for _, f := range request.Features {
-			if f.FeatureType != model.FeatureTypeTarget {
-				features = append(features, f.FeatureName)
-			} else {
-				targetName = f.FeatureName
-			}
 		}
 
 		// get needed request info
@@ -184,14 +181,8 @@ func CloningResultsHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataSt
 			return
 		}
 
-		// read the source metadata for typing information
-		req, err := solutionStorage.FetchRequestByFittedSolutionID(prediction.FittedSolutionID)
-		if err != nil {
-			handleError(w, err)
-			return
-		}
-
-		newDatasetID, err := task.CreateDatasetFromResult(newDatasetName, prediction.Dataset, req.Dataset, features, targetName, pred.ResultURI, metaStorage, dataStorage, config)
+		newDatasetID, err := task.CreateDatasetFromResult(newDatasetName, parsedParams.predictionDataset,
+			parsedParams.sourceDataset, parsedParams.features, parsedParams.targetName, pred.ResultURI, metaStorage, dataStorage, config)
 		if err != nil {
 			handleError(w, err)
 			return
@@ -204,4 +195,53 @@ func CloningResultsHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataSt
 			return
 		}
 	}
+}
+
+func getCloningParams(predictionRequestID string, metaStorage api.MetadataStorage, solutionStorage api.SolutionStorage, includeDatasetFeatures bool) (*cloningParams, error) {
+	// get the features from the request
+	prediction, err := solutionStorage.FetchPrediction(predictionRequestID)
+	if err != nil {
+		return nil, err
+	}
+	request, err := solutionStorage.FetchRequestByFittedSolutionID(prediction.FittedSolutionID)
+	if err != nil {
+		return nil, err
+	}
+	targetName := ""
+	features := []string{model.D3MIndexFieldName}
+	for _, f := range request.Features {
+		if !includeDatasetFeatures && f.FeatureType != model.FeatureTypeTarget {
+			features = append(features, f.FeatureName)
+		} else {
+			targetName = f.FeatureName
+		}
+	}
+
+	// read the source metadata for typing information
+	req, err := solutionStorage.FetchRequestByFittedSolutionID(prediction.FittedSolutionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if includeDatasetFeatures {
+		// just select every feature in the source dataset
+		ds, err := metaStorage.FetchDataset(req.Dataset, false, false, false)
+		if err != nil {
+			return nil, err
+		}
+
+		features = make([]string, len(ds.Variables))
+		for i, v := range ds.Variables {
+			features[i] = v.Key
+		}
+	}
+
+	parsedParams := &cloningParams{
+		predictionDataset: prediction.Dataset,
+		sourceDataset:     req.Dataset,
+		targetName:        targetName,
+		features:          features,
+	}
+
+	return parsedParams, nil
 }


### PR DESCRIPTION
Added backend support to optionally include features not in the model but in the dataset to be included in the new dataset when created from the prediction screen. This let's the user add new features to a dataset without having to add all existing features to a dataset. For example, if multiple labels created by the user are modelled and need to be added to a single dataset, then running the models one after another and using the latest dataset at each step is now possible.

Note that for now, the backend either uses the source dataset features or the model features. It is not built to allow for selection of which features to include from the source dataset. It will include all source dataset features if the option is specified.

Client side work needs to be done to add the `includeDatasetFeatures` in the post request. When set to true, the features in the new dataset will match the features in the source dataset rather than the features in the model.