### PR TITLE
Client side hidden variable filtering

### DIFF
--- a/api/routes/variables.go
+++ b/api/routes/variables.go
@@ -56,7 +56,7 @@ func VariablesHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 			return
 		}
 
-		variables, err := api.FetchSummaryVariables(dataset, meta)
+		variables, err := meta.FetchVariables(dataset, false, true, false)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/public/components/AvailableTrainingVariables.vue
+++ b/public/components/AvailableTrainingVariables.vue
@@ -12,10 +12,10 @@
       enable-highlighting
       enable-search
       enable-type-change
-      :facetCount="availableVariables && availableVariables.length"
+      :facet-count="availableVariables && availableVariables.length"
       :html="html"
-      :isAvailableFeatures="true"
-      :isFeaturesToModel="false"
+      :is-available-features="true"
+      :is-features-to-model="false"
       :instance-name="instanceName"
       :pagination="
         availableVariables && availableVariables.length > numRowsPerPage
@@ -49,6 +49,7 @@ import {
 } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
 import {
+  filterHiddenVariables,
   getComposedVariableKey,
   getVariableSummariesByState,
   NUM_PER_PAGE,
@@ -61,7 +62,7 @@ import { actions as appActions } from "../store/app/module";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 
 export default Vue.extend({
-  name: "available-training-variables",
+  name: "AvailableTrainingVariables",
 
   components: {
     VariableFacets,
@@ -100,10 +101,11 @@ export default Vue.extend({
     },
 
     availableVariables(): Variable[] {
-      return searchVariables(
+      const searchVars = searchVariables(
         routeGetters.getAvailableVariables(this.$store),
         this.availableTrainingVarsSearch
       );
+      return filterHiddenVariables(this.variables, searchVars);
     },
 
     variables(): Variable[] {

--- a/public/components/PredictionsDataSlot.vue
+++ b/public/components/PredictionsDataSlot.vue
@@ -77,7 +77,10 @@ import LayerSelection from "./LayerSelection.vue";
 import { Filter, INCLUDE_FILTER } from "../util/filters";
 import { actions as viewActions } from "../store/view/module";
 import { isGeoLocatedType } from "../util/types";
-import { getVariableSummariesByState } from "../util/data";
+import {
+  filterHiddenVariables,
+  getVariableSummariesByState,
+} from "../util/data";
 const TABLE_VIEW = "table";
 const IMAGE_VIEW = "image";
 const GRAPH_VIEW = "graph";
@@ -126,7 +129,10 @@ export default Vue.extend({
       });
     },
     trainingVariables(): Variable[] {
-      return requestGetters.getActivePredictionTrainingVariables(this.$store);
+      const trainingVars = requestGetters.getActivePredictionTrainingVariables(
+        this.$store
+      );
+      return filterHiddenVariables(this.variables, trainingVars);
     },
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -62,7 +62,11 @@ import { getters as requestsGetters } from "../store/requests/module";
 import { Dictionary } from "../util/dict";
 import { updateTableRowSelection } from "../util/row";
 import { spinnerHTML } from "../util/spinner";
-import { getVariableSummariesByState, searchVariables } from "../util/data";
+import {
+  filterHiddenVariables,
+  getVariableSummariesByState,
+  searchVariables,
+} from "../util/data";
 import { isGeoLocatedType } from "../util/types";
 import { Filter, INCLUDE_FILTER } from "../util/filters";
 
@@ -257,10 +261,11 @@ export default Vue.extend({
       return routeGetters.getRouteResultTrainingVarsSearch(this.$store);
     },
     trainingVariables(): Variable[] {
-      return searchVariables(
+      const searchVars = searchVariables(
         requestsGetters.getActiveSolutionTrainingVariables(this.$store),
         this.resultTrainingVarsSearch
       );
+      return filterHiddenVariables(this.variables, searchVars);
     },
     trainingSummaries(): VariableSummary[] {
       const summaryDictionary = resultsGetters.getTrainingSummariesDictionary(

--- a/public/components/TrainingVariables.vue
+++ b/public/components/TrainingVariables.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="training-variables"
-    v-bind:class="{ included: includedActive, excluded: !includedActive }"
+    :class="{ included: includedActive, excluded: !includedActive }"
   >
     <p class="nav-link font-weight-bold">
       Features to Model
@@ -12,10 +12,10 @@
       enable-highlighting
       enable-search
       enable-type-change
-      :facetCount="trainingVariables.length"
+      :facet-count="trainingVariables.length"
       :html="html"
-      :isAvailableFeatures="false"
-      :isFeaturesToModel="true"
+      :is-available-features="false"
+      :is-features-to-model="true"
       :log-activity="logActivity"
       :instance-name="instanceName"
       :pagination="trainingVariables.length > numRowsPerPage"
@@ -57,6 +57,7 @@ import {
   NUM_PER_PAGE,
   getVariableSummariesByState,
   searchVariables,
+  filterHiddenVariables,
 } from "../util/data";
 import { overlayRouteEntry } from "../util/routes";
 import { removeFiltersByName } from "../util/filters";
@@ -64,7 +65,7 @@ import { actions as appActions } from "../store/app/module";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 
 export default Vue.extend({
-  name: "training-variables",
+  name: "TrainingVariables",
 
   components: {
     VariableFacets,
@@ -96,10 +97,11 @@ export default Vue.extend({
       return routeGetters.getRouteTrainingVarsSearch(this.$store);
     },
     trainingVariables(): Variable[] {
-      return searchVariables(
+      const searchVars = searchVariables(
         routeGetters.getTrainingVariables(this.$store),
         this.trainingVarsSearch
       );
+      return filterHiddenVariables(this.variables, searchVars);
     },
     trainingVariableSummaries(): VariableSummary[] {
       const pageIndex = routeGetters.getRouteTrainingVarsPage(this.$store);


### PR DESCRIPTION
I'm not 100% sure this the way we really want to handle this, but as a first pass, I've updated the server to no longer filter out variables marked as hidden when it responds to the `distil/variables` route.  This gives the client access to all the component variables of something like a timeseries grouped var for computational purposes.  The filtering of the component variables from the various facet views is now the responsibility of the client.