### PR TITLE
Model Target Display Name

### DIFF
--- a/api/model/model.go
+++ b/api/model/model.go
@@ -42,7 +42,7 @@ type ExportedModel struct {
 	FittedSolutionID string              `json:"fittedSolutionId"`
 	DatasetID        string              `json:"datasetId"`
 	DatasetName      string              `json:"datasetName"`
-	Target           string              `json:"target"`
+	Target           *SolutionVariable   `json:"target"`
 	Variables        []string            `json:"variables"`
 	VariableDetails  []*SolutionVariable `json:"variableDetails"`
 }
@@ -170,9 +170,22 @@ type SolutionScore struct {
 
 // SolutionVariable represents the basic variable data for a solution
 type SolutionVariable struct {
-	Name string  `json:"name"`
-	Rank float64 `json:"rank"`
-	Type string  `json:"varType"`
+	Key         string  `json:"key"`
+	DisplayName string  `json:"displayName"`
+	HeaderName  string  `json:"headerName"`
+	Rank        float64 `json:"rank"`
+	Type        string  `json:"varType"`
+}
+
+// SolutionVariableFromModelVariable creates a solution variable from a model variable.
+func SolutionVariableFromModelVariable(variable *model.Variable, rank float64) *SolutionVariable {
+	return &SolutionVariable{
+		Key:         variable.Key,
+		DisplayName: variable.DisplayName,
+		HeaderName:  variable.HeaderName,
+		Rank:        rank,
+		Type:        variable.Type,
+	}
 }
 
 // PredictionResult represents the output from a model prediction.

--- a/api/model/storage/elastic/storage.go
+++ b/api/model/storage/elastic/storage.go
@@ -387,10 +387,37 @@ func (s *Storage) InitializeModelStorage(overwrite bool) error {
 				},
 				"variableDetails": {
 					"properties": {
-						"name": {
+						"displayName": {
 							"type": "text",
 							"analyzer": "search_analyzer",
 							"term_vector": "yes"
+						},
+						"headerName": {
+							"type": "text"
+						},
+						"key": {
+							"type": "text"
+						},
+						"rank": {
+							"type": "integer"
+						},
+						"varType": {
+							"type": "text"
+						}
+					}
+				},
+				"target": {
+					"properties": {
+						"displayName": {
+							"type": "text",
+							"analyzer": "search_analyzer",
+							"term_vector": "yes"
+						},
+						"headerName": {
+							"type": "text"
+						},
+						"key": {
+							"type": "text"
 						},
 						"rank": {
 							"type": "integer"

--- a/api/task/solution.go
+++ b/api/task/solution.go
@@ -60,26 +60,22 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 		}
 	}
 
-	types := make(map[string]string)
-
+	varMap := make(map[string]*model.Variable)
 	for _, vt := range dataset.Variables {
-		types[vt.Key] = vt.Type
+		varMap[vt.Key] = vt
 	}
 
 	vars := make([]string, len(request.Features)-1)
 	varDetails := make([]*api.SolutionVariable, len(request.Features)-1)
-	target := ""
+	target := &api.SolutionVariable{}
 	c := 0
 	for _, v := range request.Features {
 		if v.FeatureType == model.FeatureTypeTarget {
-			target = v.FeatureName
+			target = api.SolutionVariableFromModelVariable(varMap[v.FeatureName], float64(-1))
 		} else {
 			vars[c] = v.FeatureName
-			varDetails[c] = &api.SolutionVariable{
-				Name: v.FeatureName,
-				Rank: ranks[v.FeatureName],
-				Type: types[v.FeatureName],
-			}
+			variable := varMap[v.FeatureName]
+			varDetails[c] = api.SolutionVariableFromModelVariable(variable, ranks[v.FeatureName])
 			c = c + 1
 		}
 	}

--- a/public/components/ModelPreview.vue
+++ b/public/components/ModelPreview.vue
@@ -11,7 +11,7 @@
       </a>
       <a class="nav-link"><b>Dateset Name:</b> {{ model.datasetName }}</a>
       <a class="nav-link"><b>Features:</b> {{ model.variables.length }}</a>
-      <a class="nav-link"><b>Target:</b> {{ model.target }}</a>
+      <a class="nav-link"><b>Target:</b> {{ model.target.displayName }}</a>
     </div>
     <div class="card-body">
       <div class="row">
@@ -44,9 +44,13 @@
         <div v-if="expanded" class="col-12">
           <span><b>All Variables:</b></span>
           <p>
-            <span v-for="(variable, i) in sortedVariables" :key="variable.name">
+            <span
+              v-for="(variable, i) in sortedVariables"
+              :key="variable.displayName"
+            >
               {{
-                variable.name + (i !== model.variables.length - 1 ? ", " : ".")
+                variable.displayName +
+                (i !== model.variables.length - 1 ? ", " : ".")
               }}
             </span>
           </p>
@@ -89,7 +93,9 @@ export default Vue.extend({
       return this.model.variableDetails.slice().sort((a, b) => b.rank - a.rank);
     },
     topVariables(): string[] {
-      return this.sortedVariables.slice(0, NUM_TOP_FEATURES).map((a) => a.name);
+      return this.sortedVariables
+        .slice(0, NUM_TOP_FEATURES)
+        .map((a) => a.displayName);
     },
   },
 
@@ -97,7 +103,7 @@ export default Vue.extend({
     onResult() {
       openModelSolution(this.$router, {
         datasetId: this.model.datasetId,
-        targetFeature: this.model.target,
+        targetFeature: this.model.target.displayName,
         fittedSolutionId: this.model.fittedSolutionId,
         variableFeatures: this.model.variables,
       });

--- a/public/store/model/index.ts
+++ b/public/store/model/index.ts
@@ -7,7 +7,7 @@ export interface Model {
   fittedSolutionId: string;
   datasetId: string;
   datasetName: string;
-  target: string;
+  target: VariableDetail;
   variables: string[];
   variableDetails: VariableDetail[];
 }
@@ -20,7 +20,9 @@ export interface ModelState {
 }
 
 export interface VariableDetail {
-  name: string;
+  key: string;
+  headerName: string;
+  displayName: string;
   rank: number;
   varType: string;
 }


### PR DESCRIPTION
Fixes #2244 

Model info was using keys instead of display names. The structures needed to be updated to have the 3 different names, and the target needed to become a variable detail.

Note that a rebuild of the ES container should eventually be done to have the proper mapping for searching.