### PR TITLE
Minor Cleanup

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	MaxTestRows                        int     `env:"MAX_TEST_ROWS" envDefault:"100000"`
 	MinTrainingRows                    int     `env:"MIN_TRAINING_ROWS" envDefault:"100"`
 	MinTestRows                        int     `env:"MIN_TEST_ROWS" envDefault:"100"`
+	ModelType                          int     `env:"MODEL_TYPE" envDefault:"1"` // 0 is NOISE_CANCEL x2, 1 is GAN x4
 	PipelineCacheEnabled               bool    `env:"PIPELINE_CACHE_ENABLED" envDefault:"true"`
 	PipelineCacheFilename              string  `env:"PIPELINE_CACHE_FILENAME" envDefault:"cache.bin"`
 	PipelineQueueSize                  int     `env:"PIPELINE_QUEUE_SIZE" envDefault:"10"`
@@ -80,6 +81,7 @@ type Config struct {
 	RemoteSensingGPUBatchSize          int     `env:"REMOTE_SENSING_GPU_BATCH_SIZE" envDefault:"32"`
 	RemoteSensingNumJobs               int     `env:"REMOTE_SENSING_NUM_JOBS" envDefault:"-1"` // -1 sets num jobs = num cpus
 	SchemaPath                         string  `env:"SCHEMA_PATH" envDefault:"datasetDoc.json"`
+	ShouldScaleImages                  bool    `env:"SHOULD_SCALE_IMAGES" envDefault:"false"` // enables and disables image scaling
 	SkipIngest                         bool    `env:"SKIP_INGEST" envDefault:"false"`
 	SkipPreprocessing                  bool    `env:"SKIP_PREPROCESSING" envDefault:"false"`
 	SolutionComputeEndpoint            string  `env:"SOLUTION_COMPUTE_ENDPOINT" envDefault:"localhost:50051"`
@@ -96,8 +98,6 @@ type Config struct {
 	TrainTestSplitTimeSeries           float64 `env:"TRAIN_TEST_SPLIT_TIMESERIES" envDefault:"0.9"`
 	UserProblemPath                    string  `env:"USER_PROBLEM_PATH" envDefault:"outputs/problems"`
 	VerboseError                       bool    `env:"VERBOSE_ERROR" envDefault:"false"`
-	ShouldScaleImages                  bool    `env:"SHOULD_SCALE_IMAGES" envDefault:"false"` // enables and disables image scaling
-	ModelType                          int     `env:"MODEL_TYPE" envDefault:"1"`              // 0 is NOISE_CANCEL x2, 1 is GAN x4
 }
 
 // LoadConfig loads the config from the environment if necessary and returns a copy.

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,6 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/uncharted-distil/distil-compute v0.0.0-20210208222927-a7ae5d433614 h1:GUHDkf0VWeRcNe91fIWHINGD3MEJyY+AP3p6b19POZo=
 github.com/uncharted-distil/distil-compute v0.0.0-20210208222927-a7ae5d433614/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
-github.com/uncharted-distil/distil-image-upscale v0.0.0-20210209203820-68ca1e23ab72 h1:Al+GwY0VR2PAodYf60cxHAZLSjyOnXucIbR60HQ9AMs=
-github.com/uncharted-distil/distil-image-upscale v0.0.0-20210209203820-68ca1e23ab72/go.mod h1:G5ygnZ86P6T2iRh4gUY5R3oAxj3ZMn9j+HX+r3qiWBo=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210210122944-38e126ef1a20 h1:cKyGWuu+FB6Nfudu3fUxPliC9jx6haa1CyPINzOK2io=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210210122944-38e126ef1a20/go.mod h1:G5ygnZ86P6T2iRh4gUY5R3oAxj3ZMn9j+HX+r3qiWBo=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=

--- a/main.go
+++ b/main.go
@@ -229,8 +229,8 @@ func main() {
 		}
 	}
 	// Loads image enhancement library
-	err=c_util.LoadImageUpscaleLibrary()
-	if err != nil{
+	err = c_util.LoadImageUpscaleLibrary()
+	if err != nil {
 		log.Error(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Config variables should be kept in alphabetical order for clarity (easier to find them in the dump on startup, etc.). Also ran go mod tidy because there was some clutter in there.