### PR TITLE
Ingest Existing D3M Dataset

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -80,8 +80,7 @@ type Config struct {
 	RankingRowLimit                    int     `env:"RANKING_ROW_LIMIT" envDefault:"1000"`
 	RemoteSensingGPUBatchSize          int     `env:"REMOTE_SENSING_GPU_BATCH_SIZE" envDefault:"32"`
 	RemoteSensingNumJobs               int     `env:"REMOTE_SENSING_NUM_JOBS" envDefault:"-1"` // -1 sets num jobs = num cpus
-	SchemaPath                         string  `env:"SCHEMA_PATH" envDefault:"datasetDoc.json"`
-	ShouldScaleImages                  bool    `env:"SHOULD_SCALE_IMAGES" envDefault:"false"` // enables and disables image scaling
+	ShouldScaleImages                  bool    `env:"SHOULD_SCALE_IMAGES" envDefault:"false"`  // enables and disables image scaling
 	SkipIngest                         bool    `env:"SKIP_INGEST" envDefault:"false"`
 	SkipPreprocessing                  bool    `env:"SKIP_PREPROCESSING" envDefault:"false"`
 	SolutionComputeEndpoint            string  `env:"SOLUTION_COMPUTE_ENDPOINT" envDefault:"localhost:50051"`

--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -221,14 +221,6 @@ type datasetCreationResult struct {
 }
 
 func createDataset(datasetPath string, datasetName string, config *env.Config) (*datasetCreationResult, error) {
-	// check if already a dataset
-	if util.IsDatasetDir(datasetPath) {
-		return &datasetCreationResult{
-			name: datasetName,
-			path: datasetPath,
-		}, nil
-	}
-
 	// create the raw dataset
 	log.Infof("Creating raw dataset '%s' from '%s'", datasetName, datasetPath)
 	ds, groups, indexFields, err := createRawDataset(datasetPath, datasetName)

--- a/main.go
+++ b/main.go
@@ -221,8 +221,15 @@ func main() {
 			log.Errorf("%+v", err)
 			os.Exit(1)
 		}
-		_, err = task.IngestDataset(metadata.Contrib, pgDataStorageCtor, esMetadataStorageCtor,
-			"initial", nil, model.DatasetTypeModelling, ingestConfig, &task.IngestSteps{ClassificationOverwrite: true})
+		ingestParams := &task.IngestParams{
+			Source:   metadata.Contrib,
+			DataCtor: pgDataStorageCtor,
+			MetaCtor: esMetadataStorageCtor,
+			ID:       "initial",
+			Origins:  nil,
+			Type:     model.DatasetTypeModelling,
+		}
+		_, err = task.IngestDataset(ingestParams, ingestConfig, &task.IngestSteps{ClassificationOverwrite: true})
 		if err != nil {
 			log.Errorf("%+v", err)
 			os.Exit(1)


### PR DESCRIPTION
Fixed the import of a folder that is already in a D3M dataset format. It now handles cases where the folder name does not match the dataset id in the metadata file. If the metadata has all the variables, and they are typed properly, then it will use that as definitive types and will not run Simon.

A few cleanup changes were also made. The `SchemaPath` environment variable was removed since it should not be used given that D3M requires the file be named `datasetDoc.json`. Ingest was changed to have most of the parameters passed in through a struct for clarity.

There needs to be follow-on work so that we can use the types we do have in a schema doc as definitive types for those variables post ingest. Right now, if at least one variable is missing from the metadata (or has a type indicating it isn't definitive), Simon is run as usual and all variables are typed with that output. Ideally, we would run Simon but also use the types we do have in the metadata.