### PR TITLE
Timestamp Extrema Crash

### DIFF
--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -535,7 +535,7 @@ func (f *DateTimeField) getFromClause(alias bool) string {
 
 func (f *DateTimeField) fetchExtremaStorage() (*api.Extrema, error) {
 	// add min / max aggregation
-	aggQuery := f.Storage.getMinMaxAggsQuery(f.Key, f.Type)
+	aggQuery := f.getMinMaxAggsQuery()
 
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s;", aggQuery, f.GetDatasetStorageName())

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -37,6 +37,7 @@ type Field interface {
 	GetLabel() string
 	GetType() string
 	fetchExtremaStorage() (*api.Extrema, error)
+	fetchExtremaByURI(resultURI string) (*api.Extrema, error)
 }
 
 // TimelineField defines the behaviour of a field which can be used as a timeline.
@@ -88,6 +89,10 @@ func (b *BasicField) GetType() string {
 }
 
 func (b *BasicField) fetchExtremaStorage() (*api.Extrema, error) {
+	return &api.Extrema{}, nil
+}
+
+func (b *BasicField) fetchExtremaByURI(resultURI string) (*api.Extrema, error) {
 	return &api.Extrema{}, nil
 }
 

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -680,7 +680,7 @@ func (f *NumericalField) getNaNFilter() string {
 }
 
 func (f *NumericalField) fetchExtremaStorage() (*api.Extrema, error) {
-	aggQuery := f.Storage.getMinMaxAggsQuery(f.Key, f.Type)
+	aggQuery := f.getMinMaxAggsQuery(f.Key)
 
 	// numerical columns need to filter NaN out
 	filter := fmt.Sprintf("WHERE \"%s\" != 'NaN'", f.Key)

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -254,7 +254,7 @@ func (f *NumericalField) fetchHistogramByResult(resultURI string, filterParams *
 func (f *NumericalField) fetchExtrema() (*api.Extrema, error) {
 	fromClause := f.getFromClause(true)
 	// add min / max aggregation
-	aggQuery := f.getMinMaxAggsQuery(f.Key)
+	aggQuery := f.getMinMaxAggsQuery()
 
 	// create a query that does min and max aggregations for each variable
 	// need to ignore the NaN values
@@ -386,14 +386,14 @@ func (f *NumericalField) parseExtrema(rows pgx.Rows) (*api.Extrema, error) {
 	}, nil
 }
 
-func (f *NumericalField) getMinMaxAggsQuery(key string) string {
+func (f *NumericalField) getMinMaxAggsQuery() string {
 	// get min / max agg names
-	minAggName := api.MinAggPrefix + key
-	maxAggName := api.MaxAggPrefix + key
+	minAggName := api.MinAggPrefix + f.Key
+	maxAggName := api.MaxAggPrefix + f.Key
 
 	// create aggregations
 	queryPart := fmt.Sprintf("MIN(\"%s\") AS \"%s\", MAX(\"%s\") AS \"%s\"",
-		key, minAggName, key, maxAggName)
+		f.Key, minAggName, f.Key, maxAggName)
 	// add aggregations
 	return queryPart
 }
@@ -402,7 +402,7 @@ func (f *NumericalField) fetchExtremaByURI(resultURI string) (*api.Extrema, erro
 	fromClause := f.getFromClause(false)
 
 	// add min / max aggregation
-	aggQuery := f.getMinMaxAggsQuery(f.Key)
+	aggQuery := f.getMinMaxAggsQuery()
 
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s INNER JOIN %s result ON %s.\"%s\" = result.index WHERE result.result_id = $1 AND %s;",
@@ -680,7 +680,7 @@ func (f *NumericalField) getNaNFilter() string {
 }
 
 func (f *NumericalField) fetchExtremaStorage() (*api.Extrema, error) {
-	aggQuery := f.getMinMaxAggsQuery(f.Key)
+	aggQuery := f.getMinMaxAggsQuery()
 
 	// numerical columns need to filter NaN out
 	filter := fmt.Sprintf("WHERE \"%s\" != 'NaN'", f.Key)


### PR DESCRIPTION
Fixes #2268

Timestamp extremas were failing because the query was converting to integer for this specific route whereas the parsing code had been updated in the past to expect a timestamp (all other extrema queries for timestamps work as expected). In fixing this, some no longer useful (and downright bad) code has been removed.