### PR TITLE
2201 remote sensing

### DIFF
--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"path"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/araddon/dateparse"
@@ -147,9 +148,27 @@ func (s *Satellite) CreateDataset(rootDataPath string, datasetName string, confi
 	if err != nil {
 		return nil, err
 	}
-
+	labelHeader := "label"
+	expectedHeaders := []string{model.D3MIndexFieldName, "image_file", "group_id", "band", "timestamp", "coordinates", labelHeader, "geo_coordinates"}
+	headerNames := expectedHeaders
+	if len(imageFolders) == 0 {
+		// search just in case the above order is changed at some point
+		labelIdx := sort.Search(len(headerNames), func(i int) bool {
+			return labelHeader == headerNames[i]
+		})
+		// remove "label" header due to 0 folders
+		if labelIdx == len(headerNames)-1 {
+			// if label is at the end can't use the method below it will index out of range
+			headerNames = headerNames[:labelIdx]
+		} else {
+			// this maintains order of the slice
+			headerNames = append(headerNames[:labelIdx], headerNames[labelIdx+1:]...)
+		}
+		// add the parent folder as the imageFolder
+		imageFolders = append(imageFolders, s.ExtractedFilePath)
+	}
 	csvData := make([][]string, 0)
-	csvData = append(csvData, []string{model.D3MIndexFieldName, "image_file", "group_id", "band", "timestamp", "coordinates", "label", "geo_coordinates"})
+	csvData = append(csvData, headerNames)
 	mediaFolder := util.GetUniqueFolder(path.Join(outputDatasetPath, "media"))
 
 	// need to keep track of d3m Index values since they are shared for a whole group
@@ -216,8 +235,10 @@ func (s *Satellite) CreateDataset(rootDataPath string, datasetName string, confi
 					d3mIDRunning = d3mIDRunning + 1
 					d3mIDs[groupID] = d3mID
 				}
+				// remove values that are not needed based on the headerNames (expects values, expectedHeaders and headerNames to be IN ORDER)
+				csvLine := removeMissingValues(expectedHeaders, headerNames, []string{fmt.Sprintf("%d", d3mID), path.Base(targetImageFilename), groupID, band, timestamp, coordinates.String(), label, coordinates.ToGeometryString()})
 
-				csvData = append(csvData, []string{fmt.Sprintf("%d", d3mID), path.Base(targetImageFilename), groupID, band, timestamp, coordinates.String(), label, coordinates.ToGeometryString()})
+				csvData = append(csvData, csvLine)
 			}
 		}
 	}
@@ -228,37 +249,47 @@ func (s *Satellite) CreateDataset(rootDataPath string, datasetName string, confi
 	meta := model.NewMetadata(datasetName, datasetName, "", datasetID)
 	dr := model.NewDataResource(compute.DefaultResourceID, model.ResTypeTable, map[string][]string{compute.D3MResourceFormat: {"csv"}})
 	dr.ResPath = dataFilePath
+	varCounter := 0
 	dr.Variables = append(dr.Variables,
-		model.NewVariable(0, model.D3MIndexFieldName, model.D3MIndexFieldName, model.D3MIndexFieldName,
+		model.NewVariable(varCounter, model.D3MIndexFieldName, model.D3MIndexFieldName, model.D3MIndexFieldName,
 			model.D3MIndexFieldName, model.IntegerType, model.IntegerType, "D3M index",
 			[]string{model.RoleMultiIndex}, model.VarDistilRoleIndex, nil, dr.Variables, false),
 	)
+	varCounter++
 	dr.Variables = append(dr.Variables,
-		model.NewVariable(1, "image_file", "image_file", "image_file", "image_file", model.MultiBandImageType,
+		model.NewVariable(varCounter, "image_file", "image_file", "image_file", "image_file", model.MultiBandImageType,
 			model.StringType, "Reference to image file", []string{"attribute"},
 			model.VarDistilRoleData, map[string]interface{}{"resID": "0", "resObject": "item"}, dr.Variables, false))
+	varCounter++
 	dr.Variables = append(dr.Variables,
-		model.NewVariable(2, "group_id", "group_id", "group_id", "group_id", model.StringType,
+		model.NewVariable(varCounter, "group_id", "group_id", "group_id", "group_id", model.StringType,
 			model.StringType, "ID linking all bands of a particular image set together", []string{"attribute", "suggestedGroupingKey"},
 			model.VarDistilRoleGrouping, nil, dr.Variables, false))
+	varCounter++
 	dr.Variables = append(dr.Variables,
-		model.NewVariable(3, "band", "band", "band", "band", model.StringType,
+		model.NewVariable(varCounter, "band", "band", "band", "band", model.StringType,
 			model.StringType, "Image band", []string{"attribute"},
 			model.VarDistilRoleData, nil, dr.Variables, false))
+	varCounter++
 	dr.Variables = append(dr.Variables,
-		model.NewVariable(4, "timestamp", "timestamp", "timestamp", "timestamp", timestampType,
+		model.NewVariable(varCounter, "timestamp", "timestamp", "timestamp", "timestamp", timestampType,
 			model.StringType, "Image timestamp", []string{"attribute"},
 			model.VarDistilRoleData, nil, dr.Variables, false))
+	varCounter++
 	dr.Variables = append(dr.Variables,
-		model.NewVariable(5, "coordinates", "coordinates", "coordinates", "coordinates", model.RealVectorType,
+		model.NewVariable(varCounter, "coordinates", "coordinates", "coordinates", "coordinates", model.RealVectorType,
 			model.RealVectorType, "Coordinates of the image defined by a bounding box", []string{"attribute"},
 			model.VarDistilRoleData, nil, dr.Variables, false))
+	varCounter++
+	if len(expectedHeaders) == len(headerNames) {
+		dr.Variables = append(dr.Variables,
+			model.NewVariable(varCounter, "label", "label", "label", "label", model.CategoricalType,
+				model.StringType, "Label of the image", []string{"suggestedTarget"},
+				model.VarDistilRoleData, nil, dr.Variables, false))
+		varCounter++
+	}
 	dr.Variables = append(dr.Variables,
-		model.NewVariable(6, "label", "label", "label", "label", model.CategoricalType,
-			model.StringType, "Label of the image", []string{"suggestedTarget"},
-			model.VarDistilRoleData, nil, dr.Variables, false))
-	dr.Variables = append(dr.Variables,
-		model.NewVariable(7, "__geo_coordinates", "coordinates", "geo_coordinates", "__geo_coordinates", model.GeoBoundsType,
+		model.NewVariable(varCounter, "__geo_coordinates", "coordinates", "geo_coordinates", "__geo_coordinates", model.GeoBoundsType,
 			model.GeoBoundsType, "postgis structure for the bounding box coordinates of the tile", []string{},
 			model.VarDistilRoleMetadata, nil, dr.Variables, false))
 
@@ -279,6 +310,20 @@ func (s *Satellite) CreateDataset(rootDataPath string, datasetName string, confi
 	}, nil
 }
 
+// removeValues removes values not needed based on supplied headernames
+func removeMissingValues(expectedHeaders []string, headerNames []string, values []string) []string {
+	headerMap := map[string]string{}
+	// build map of the expected header for remote sensing ds
+	for i, header := range expectedHeaders {
+		headerMap[header] = values[i]
+	}
+	result := []string{}
+	// build the value string based on the actual headers that exist
+	for _, header := range headerNames {
+		result = append(result, headerMap[header])
+	}
+	return result
+}
 func verifySatelliteImage(filename string, defaultType string) bool {
 	typ := path.Ext(filename)
 	if len(typ) > 0 {

--- a/api/model/storage/postgres/bounds.go
+++ b/api/model/storage/postgres/bounds.go
@@ -352,10 +352,10 @@ func (f *BoundsField) parseHistogram(rows pgx.Rows, xExtrema *api.Extrema, yExtr
 
 	// initialize empty histogram structure
 	i := 0
-	for xVal := xRounded.Min; xVal < xRounded.Max; xVal += xInterval {
+	for xVal := xRounded.Min; i < int(xBucketCount); xVal += xInterval {
 		yBuckets := make([]*api.Bucket, yBucketCount)
 		j := 0
-		for yVal := yRounded.Min; yVal < yRounded.Max; yVal += yInterval {
+		for yVal := yRounded.Min; j < int(yBucketCount); yVal += yInterval {
 			yBuckets[j] = &api.Bucket{
 				Key:     fmt.Sprintf("%f", yVal),
 				Count:   0,

--- a/api/routes/config.go
+++ b/api/routes/config.go
@@ -42,7 +42,7 @@ func ConfigHandler(config env.Config, version string, timestamp string, problemP
 			"ta2version":               ta2Version,
 			"trainTestSplit":           config.TrainTestSplit,
 			"trainTestSplitTimeSeries": config.TrainTestSplitTimeSeries,
-			"shouldScaleImages":		config.ShouldScaleImages,
+			"shouldScaleImages":        config.ShouldScaleImages,
 		})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal version into JSON and write response"))

--- a/api/routes/config.go
+++ b/api/routes/config.go
@@ -42,6 +42,7 @@ func ConfigHandler(config env.Config, version string, timestamp string, problemP
 			"ta2version":               ta2Version,
 			"trainTestSplit":           config.TrainTestSplit,
 			"trainTestSplitTimeSeries": config.TrainTestSplitTimeSeries,
+			"shouldScaleImages":		config.ShouldScaleImages,
 		})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal version into JSON and write response"))

--- a/main.go
+++ b/main.go
@@ -229,10 +229,12 @@ func main() {
 		}
 	}
 	// Loads image enhancement library
-	err = c_util.LoadImageUpscaleLibrary()
-	if err != nil {
-		log.Error(err)
-		os.Exit(1)
+	if config.ShouldScaleImages {
+		err = c_util.LoadImageUpscaleLibrary()
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
 	}
 	// register routes
 	mux := goji.NewMux()

--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -64,7 +64,11 @@
             <i class="fa fa-adjust fa-rotate-180" aria-hidden="true" />
             {{ brightnessValue }}
           </label>
-          <b-button @click="upscaleFetch" :disabled="disableUpscale">
+          <b-button
+            v-if="shouldImagesScale"
+            @click="upscaleFetch"
+            :disabled="disableUpscale"
+          >
             <b-spinner v-if="fetchingUpscale" small />
             Upscale Image
           </b-button>
@@ -82,6 +86,7 @@ import {
   actions as datasetActions,
   mutations as datasetMutations,
 } from "../store/dataset/module";
+import { getters as appGetters } from "../store/app/module";
 import { getters as routeGetters } from "../store/route/module";
 import { Dictionary } from "../util/dict";
 import { IMAGE_TYPE, MULTIBAND_IMAGE_TYPE } from "../util/types";
@@ -139,6 +144,9 @@ export default Vue.extend({
   },
 
   computed: {
+    shouldImagesScale(): boolean {
+      return appGetters.getShouldScaleImages(this.$store);
+    },
     bandName(): string {
       return datasetGetters
         .getMultiBandCombinations(this.$store)

--- a/public/store/app/actions.ts
+++ b/public/store/app/actions.ts
@@ -99,6 +99,7 @@ export const actions = {
         context,
         response.data.trainTestSplitTimeSeries
       );
+      mutations.setShouldScaleImages(context, response.data.shouldScaleImages);
     } catch (err) {
       console.warn(err);
     }

--- a/public/store/app/getters.ts
+++ b/public/store/app/getters.ts
@@ -51,4 +51,7 @@ export const getters = {
   getTrainTestSplitTimeSeries(state: AppState): number {
     return state.trainTestSplitTimeSeries;
   },
+  getShouldScaleImages(state: AppState): boolean {
+    return state.shouldScaleImages;
+  },
 };

--- a/public/store/app/index.ts
+++ b/public/store/app/index.ts
@@ -12,6 +12,7 @@ export interface AppState {
   prototype: boolean;
   trainTestSplit: number;
   trainTestSplitTimeSeries: number;
+  shouldScaleImages: boolean;
 }
 
 export interface StatusPanelState {
@@ -35,6 +36,7 @@ export const state: AppState = {
   prototype: false,
   trainTestSplit: null,
   trainTestSplitTimeSeries: null,
+  shouldScaleImages: false,
 };
 
 export type StatusPanelContentType = DatasetPendingRequestType;

--- a/public/store/app/module.ts
+++ b/public/store/app/module.ts
@@ -31,6 +31,7 @@ export const getters = {
   isPrototype: read(moduleGetters.isPrototype),
   getTrainTestSplit: read(moduleGetters.getTrainTestSplit),
   getTrainTestSplitTimeSeries: read(moduleGetters.getTrainTestSplitTimeSeries),
+  getShouldScaleImages: read(moduleGetters.getShouldScaleImages),
 };
 
 // typed actions
@@ -64,4 +65,5 @@ export const mutations = {
   setTrainTestSplitTimeSeries: commit(
     moduleMutations.setTrainTestSplitTimeSeries
   ),
+  setShouldScaleImages: commit(moduleMutations.setShouldScaleImages),
 };

--- a/public/store/app/mutations.ts
+++ b/public/store/app/mutations.ts
@@ -36,7 +36,9 @@ export const mutations = {
   setTA2VersionNumber(state: AppState, ta2Version: string) {
     state.ta2Version = ta2Version;
   },
-
+  setShouldScaleImages(state: AppState, shouldScale: boolean) {
+    state.shouldScaleImages = shouldScale;
+  },
   setTrainTestSplit(state: AppState, trainTestSplit: string) {
     state.trainTestSplit = parseFloat(trainTestSplit);
   },


### PR DESCRIPTION
- Added support for remote sensing datasets without sub folders
- Changed the way geobounds facet buckets are calculated to avoid IOOR
- Added check to not load the upscale models if shouldScaleImages is false
- Added shouldScaleImages to frontend to disable the button
- 
![image](https://user-images.githubusercontent.com/25306965/107785621-ce246100-6d1a-11eb-8a2a-0761cc3d440e.png)

- Note: possible issue with selectTarget view. Currently there is no way to check if there is an available target (and if so we should probably route to the labeling view instead of target). The provided image shows that time stamp can be selected as the target; however, upon selecting timestamp the server errors with unable to find intended model. 
closes #2201