### PR TITLE
#2252 search fix

### DIFF
--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -361,7 +361,7 @@ export default Vue.extend({
       }
     },
     search(newTerm, oldTerm) {
-      if (!newTerm || newTerm === oldTerm) return;
+      if (newTerm === undefined || newTerm === oldTerm) return;
 
       const entry = overlayRouteEntry(this.$route, {
         [this.routeSearchKey()]: this.search,


### PR DESCRIPTION
Closes #2252 - empty string was failing to trigger the watch on search, so the change wasn't emitting, so the route didn't update. Longer term, this is why avoiding individual queries in the route is worse pursuing (consisent update conditions) but for now, I just made it such that undefined doesn't trigger an update, but the empty string case does.