### PR TITLE
Join Reintroduction

### DIFF
--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -73,11 +73,6 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 					return
 				}
 
-				if params["joinedDataset"] == nil {
-					missingParamErr(w, "joinedDataset")
-					return
-				}
-
 				// set the origin information
 				originalDataset, okOriginal := params["originalDataset"].(map[string]interface{})
 				joinedDataset, okJoined := params["joinedDataset"].(map[string]interface{})

--- a/api/routes/join.go
+++ b/api/routes/join.go
@@ -56,15 +56,9 @@ func JoinHandler(metaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *ht
 			return
 		}
 
-		if params["searchResultIndex"] == nil {
-			missingParamErr(w, "searchResultIndex")
-			return
-		}
-
 		// fetch vars from params
 		datasetLeft := params["datasetLeft"].(map[string]interface{})
 		datasetRight := params["datasetRight"].(map[string]interface{})
-		searchResultIndex := int(params["searchResultIndex"].(float64))
 
 		leftJoin := &task.JoinSpec{
 			DatasetID:     datasetLeft["id"].(string),
@@ -102,35 +96,8 @@ func JoinHandler(metaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *ht
 		}
 		leftVariables = append(leftVariables, d3mIndexVar)
 
-		// need to find the right join suggestion since a single dataset
-		// can have multiple join suggestions
-		if datasetRight["joinSuggestion"] == nil {
-			handleError(w, errors.Wrap(err, "Join Suggestion undefined"))
-			return
-		}
-
-		joinSuggestions := datasetRight["joinSuggestion"].([]interface{})
-		targetJoin := joinSuggestions[searchResultIndex].(map[string]interface{})
-		if targetJoin == nil {
-			handleError(w, errors.Wrap(err, "Unable to find join suggestion at search result index"))
-			return
-		}
-
-		targetJoinOrigin := targetJoin["datasetOrigin"].(map[string]interface{})
-		if targetJoinOrigin == nil {
-			handleError(w, errors.Wrap(err, "Unable to find join origin"))
-			return
-		}
-
-		targetOriginModel := model.DatasetOrigin{}
-		err = json.MapToStruct(&targetOriginModel, targetJoinOrigin)
-		if err != nil {
-			handleError(w, errors.Wrap(err, "Unable to parse join origin from JSON"))
-			return
-		}
-
 		// run joining pipeline
-		data, err := task.Join(leftJoin, rightJoin, leftVariables, rightVariables, &targetOriginModel)
+		data, err := join(leftJoin, rightJoin, leftVariables, rightVariables, datasetRight, params)
 		if err != nil {
 			handleError(w, err)
 			return
@@ -179,4 +146,72 @@ func parseVariables(variablesRaw []interface{}) ([]*model.Variable, error) {
 	}
 
 	return variables, nil
+}
+
+func join(joinLeft *task.JoinSpec, joinRight *task.JoinSpec, varsLeft []*model.Variable,
+	varsRight []*model.Variable, datasetRight map[string]interface{}, params map[string]interface{}) (*api.FilteredData, error) {
+	// determine if distil or datamart
+	if params["searchResultIndex"] == nil {
+		return joinDistil(joinLeft, joinRight, varsLeft, varsRight, datasetRight, params)
+	}
+
+	return joinDatamart(joinLeft, joinRight, varsLeft, varsRight, datasetRight, params)
+}
+
+func joinDistil(joinLeft *task.JoinSpec, joinRight *task.JoinSpec, varsLeft []*model.Variable,
+	varsRight []*model.Variable, datasetRight map[string]interface{}, params map[string]interface{}) (*api.FilteredData, error) {
+	if params["datasetAColumn"] == nil {
+		return nil, errors.Errorf("missing parameter 'datasetAColumn'")
+	}
+	leftCol := params["datasetAColumn"].(string)
+	if params["datasetBColumn"] == nil {
+		return nil, errors.Errorf("missing parameter 'datasetBColumn'")
+	}
+	rightCol := params["datasetBColumn"].(string)
+
+	data, err := task.JoinDistil(joinLeft, joinRight, varsLeft, varsRight, leftCol, rightCol)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func joinDatamart(joinLeft *task.JoinSpec, joinRight *task.JoinSpec, varsLeft []*model.Variable,
+	varsRight []*model.Variable, datasetRight map[string]interface{}, params map[string]interface{}) (*api.FilteredData, error) {
+	if params["searchResultIndex"] == nil {
+		return nil, errors.Errorf("missing parameter 'searchResultIndex'")
+	}
+	searchResultIndex := int(params["searchResultIndex"].(float64))
+
+	// need to find the right join suggestion since a single dataset
+	// can have multiple join suggestions
+	if datasetRight["joinSuggestion"] == nil {
+		return nil, errors.Errorf("Join Suggestion undefined")
+	}
+
+	joinSuggestions := datasetRight["joinSuggestion"].([]interface{})
+	targetJoin := joinSuggestions[searchResultIndex].(map[string]interface{})
+	if targetJoin == nil {
+		return nil, errors.Errorf("Unable to find join suggestion at search result index")
+	}
+
+	targetJoinOrigin := targetJoin["datasetOrigin"].(map[string]interface{})
+	if targetJoinOrigin == nil {
+		return nil, errors.Errorf("Unable to find join origin")
+	}
+
+	targetOriginModel := model.DatasetOrigin{}
+	err := json.MapToStruct(&targetOriginModel, targetJoinOrigin)
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to parse join origin from JSON")
+	}
+
+	// run joining pipeline
+	data, err := task.JoinDatamart(joinLeft, joinRight, varsLeft, varsRight, &targetOriginModel)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -104,7 +104,10 @@ func TestJoin(t *testing.T) {
 		Provenance:   "NYU",
 	}
 
-	result, err := join(leftJoin, rightJoin, varsLeft, varsRight, rightOrigin, testSubmitter{}, &cfg)
+	pipelineDesc, err := description.CreateDatamartAugmentPipeline("Join Preview",
+		"Join to be reviewed by user", rightOrigin.SearchResult, rightOrigin.Provenance)
+	assert.NoError(t, err)
+	result, err := join(leftJoin, rightJoin, varsLeft, varsRight, pipelineDesc, testSubmitter{}, &cfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -107,7 +107,8 @@ func TestJoin(t *testing.T) {
 	pipelineDesc, err := description.CreateDatamartAugmentPipeline("Join Preview",
 		"Join to be reviewed by user", rightOrigin.SearchResult, rightOrigin.Provenance)
 	assert.NoError(t, err)
-	result, err := join(leftJoin, rightJoin, varsLeft, varsRight, pipelineDesc, testSubmitter{}, &cfg)
+	datasetLeftURI := env.ResolvePath(leftJoin.DatasetSource, leftJoin.DatasetFolder)
+	_, result, err := join(leftJoin, rightJoin, varsLeft, varsRight, pipelineDesc, []string{datasetLeftURI}, testSubmitter{}, &cfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,7 @@ go 1.13
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/caarlos0/env v3.5.0+incompatible
-	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/fatih/color v1.10.0 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.4.2
 	github.com/golangci/golangci-lint v1.33.0 // indirect
@@ -28,7 +26,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/uncharted-distil/distil-compute v0.0.0-20210208222927-a7ae5d433614
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210210122944-38e126ef1a20

--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -12,6 +12,7 @@
         :dataset-a="datasetA"
         :dataset-b="datasetB"
         :joined-column="joinedColumn"
+        :path="joinedPath"
         @success="onJoinCommitSuccess"
         @failure="onJoinCommitFailure"
         @close="showJoinSuccess = !showJoinSuccess"
@@ -107,6 +108,7 @@ export default Vue.extend({
       showJoinFailure: false,
       joinErrorMessage: null,
       previewTableData: null,
+      joinedPath: "",
     };
   },
 
@@ -198,14 +200,16 @@ export default Vue.extend({
         .then((tableData) => {
           this.pending = false;
           this.showJoinSuccess = true;
+          this.joinedPath = tableData.path;
           // sealing the return to prevent slow, unnecessary deep reactivity.
-          this.previewTableData = Object.seal(tableData);
+          this.previewTableData = Object.seal(tableData.data);
         })
         .catch((err) => {
           // display error modal
           this.pending = false;
           this.showJoinFailure = true;
           this.previewTableData = null;
+          this.joinedPath = "";
         });
     },
     onJoinCommitSuccess(datasetID: string) {

--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -93,8 +93,8 @@ export default Vue.extend({
   },
 
   props: {
-    datasetA: String as () => string,
-    datasetB: String as () => string,
+    datasetIdA: String as () => string,
+    datasetIdB: String as () => string,
     datasetAColumn: Object as () => TableColumn,
     datasetBColumn: Object as () => TableColumn,
     joinAccuracy: Number as () => number,
@@ -109,6 +109,8 @@ export default Vue.extend({
       joinErrorMessage: null,
       previewTableData: null,
       joinedPath: "",
+      datasetA: null,
+      datasetB: null,
     };
   },
 
@@ -181,12 +183,14 @@ export default Vue.extend({
       this.pending = true;
 
       const a = _.find(this.datasets, (d) => {
-        return d.id === this.datasetA;
+        return d.id === this.datasetIdA;
       });
 
       const b = _.find(this.datasets, (d) => {
-        return d.id === this.datasetB;
+        return d.id === this.datasetIdB;
       });
+      this.datasetA = a;
+      this.datasetB = b;
 
       // dispatch action that triggers request send to server
       datasetActions

--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -3,7 +3,6 @@
     <b-modal
       v-model="showJoinSuccess"
       modal-class="join-preview-modal"
-      @shown="onSuccessModalShwon"
       cancel-disabled
       hide-header
       hide-footer
@@ -193,7 +192,8 @@ export default Vue.extend({
           datasetA: a,
           datasetB: b,
           joinAccuracy: this.joinAccuracy,
-          joinSuggestionIndex: 0,
+          datasetAColumn: this.datasetAColumn.key,
+          datasetBColumn: this.datasetBColumn.key,
         })
         .then((tableData) => {
           this.pending = false;

--- a/public/components/JoinDatasetsPreview.vue
+++ b/public/components/JoinDatasetsPreview.vue
@@ -83,6 +83,7 @@ export default Vue.extend({
     joinedColumn: String as () => string,
     previewTableData: Object as () => TableData,
     searchResultIndex: Number as () => number,
+    path: String as () => string,
   },
 
   data() {
@@ -149,7 +150,7 @@ export default Vue.extend({
         originalDataset: this.datasetA,
         joinedDataset: this.datasetB,
         searchResultIndex: this.searchResultIndex,
-        path: "",
+        path: this.path,
       };
       datasetActions
         .importDataset(this.$store, importDatasetArgs)

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -447,7 +447,7 @@ export default Vue.extend({
         .joinDatasetsPreview(this.$store, datasetJoinInfo)
         .then((tableData) => {
           // sealing the return to prevent slow, unnecessary deep reactivity.
-          this.previewTableData = Object.seal(tableData);
+          this.previewTableData = Object.seal(tableData.data);
 
           // display join preview modal
           this.isAttemptingJoin = false;

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -662,7 +662,7 @@ export const actions = {
       datasetAColumn?: string;
       datasetBColumn?: string;
     }
-  ): Promise<void> {
+  ): Promise<any> {
     if (!validateArgs(args, ["datasetA", "datasetB", "joinAccuracy"])) {
       return null;
     }

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -67,7 +67,7 @@ async function getVariables(dataset: string): Promise<Variable[]> {
 
 // Return the best variable name of a dataset for outlier detection
 function getOutlierVariableName(variables: Variable[]) {
-  /* 
+  /*
     Find a grouping variable, specially a remote-sensing one.
     This is needed in case the remote-sensing images have not
     been prefiturized.
@@ -658,7 +658,9 @@ export const actions = {
       datasetA: Dataset;
       datasetB: Dataset;
       joinAccuracy: number;
-      joinSuggestionIndex: number;
+      joinSuggestionIndex?: number;
+      datasetAColumn?: string;
+      datasetBColumn?: string;
     }
   ): Promise<void> {
     if (!validateArgs(args, ["datasetA", "datasetB", "joinAccuracy"])) {
@@ -677,6 +679,8 @@ export const actions = {
       accuracy: args.joinAccuracy,
       datasetLeft: args.datasetA,
       datasetRight: datasetBrevised,
+      datasetAColumn: args.datasetAColumn,
+      datasetBColumn: args.datasetBColumn,
       searchResultIndex: args.joinSuggestionIndex,
     });
     return response.data;
@@ -1342,7 +1346,7 @@ export const actions = {
       highlight: Highlight;
     }
   ) {
-    if (!validateArgs(args, ["dataset", "filterParams"])) {
+    if (!validateArgs(args, ["datasets", "filterParams"])) {
       return null;
     }
     return Promise.all(

--- a/public/views/JoinDatasets.vue
+++ b/public/views/JoinDatasets.vue
@@ -72,8 +72,8 @@
           <div class="col-12">
             <join-datasets-form
               class="select-create-solutions"
-              :dataset-a="topDataset"
-              :dataset-b="bottomDataset"
+              :dataset-id-a="topDataset"
+              :dataset-id-b="bottomDataset"
               :dataset-a-column="topColumn"
               :dataset-b-column="bottomColumn"
               :join-accuracy="joinAccuracy"


### PR DESCRIPTION
Initial work to reintroduce join to the system to allow for joining of two datasets outside of a datamart. Note that currently the workflow isn't fixed properly, but navigating manually to `/#/join&joinDatasets=dsA,dsB&baseColumnSuggestions=ColA&joinColumnSuggestions=ColB&joinColumnA=ColA&joinColumnB=ColB` can initiate a join.