### PR TITLE
Single Timestamp Remote Sensing Querying

### DIFF
--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -150,7 +150,7 @@ func (s *Satellite) CreateDataset(rootDataPath string, datasetName string, confi
 	}
 	labelHeader := "label"
 	expectedHeaders := []string{model.D3MIndexFieldName, "image_file", "group_id", "band", "timestamp", "coordinates", labelHeader, "geo_coordinates"}
-	headerNames := append([]string(nil),expectedHeaders...)
+	headerNames := append([]string(nil), expectedHeaders...)
 	if len(imageFolders) == 0 {
 		// search just in case the above order is changed at some point
 		labelIdx := sort.Search(len(headerNames), func(i int) bool {
@@ -320,7 +320,7 @@ func removeMissingValues(indices []int, values []string) []string {
 	}
 	return result
 }
-func getIndicesToKeep(expectedHeaders []string, headers []string) []int{
+func getIndicesToKeep(expectedHeaders []string, headers []string) []int {
 	result := []int{}
 	headerMap := map[string]int{}
 	// build map
@@ -329,7 +329,7 @@ func getIndicesToKeep(expectedHeaders []string, headers []string) []int{
 	}
 	// check what is missing and append indices
 	for i, header := range expectedHeaders {
-		if _, ok := headerMap[header]; ok{
+		if _, ok := headerMap[header]; ok {
 			result = append(result, i)
 		}
 	}

--- a/api/model/storage/postgres/bounds.go
+++ b/api/model/storage/postgres/bounds.go
@@ -150,7 +150,7 @@ func (f *BoundsField) fetchHistogram(filterParams *api.FilterParams, invert bool
 	//	ST_INTERSECTS WILL OVERCOUNT THOSE THAT CROSS BOUNDARIES
 	query := fmt.Sprintf(`
 		SELECT b.xbuckets, b.xcoord, b.ybuckets, b.ycoord, COUNT(%s)
-		FROM %s AS d inner join %s AS b ON ST_WITHIN(d."%s", b.coordinates) %s
+		FROM %s AS d inner join %s AS b ON ST_INTERSECTS(d."%s", b.coordinates) %s
 		GROUP BY b.xbuckets, b.xcoord, b.ybuckets, b.ycoord
 		ORDER BY b.xbuckets, b.ybuckets;`, f.Count, queryTableName, tmpTableName, f.PolygonCol, where)
 	res, err := tx.Query(context.Background(), query, params...)
@@ -308,7 +308,7 @@ func (f *BoundsField) fetchHistogramByResult(resultURI string, filterParams *api
 	queryTableName := getBaseTableName(f.DatasetStorageName)
 	query := fmt.Sprintf(`
 		SELECT b.xbuckets, b.xcoord, b.ybuckets, b.ycoord, COUNT(%s)
-		FROM %s AS data inner join %s AS b ON ST_WITHIN(data."%s", b.coordinates)
+		FROM %s AS data inner join %s AS b ON ST_INTERSECTS(data."%s", b.coordinates)
 		INNER JOIN %s result ON cast(data."%s" as double precision) = result.index
 		WHERE result.result_id = $%d %s
 		GROUP BY b.xbuckets, b.xcoord, b.ybuckets, b.ycoord

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -250,7 +250,8 @@ func (f *DateTimeField) getHistogramAggQuery(extrema *api.Extrema, numBuckets in
 	// if only a single value, then return a simple count.
 	if extrema.Max == extrema.Min {
 		// want to return the count under bucket 0.
-		bucketQueryString = fmt.Sprintf("(%s\"%s\" - %s\"%s\")", alias, extrema.Key, alias, extrema.Key)
+		// specify a cast because the group by clause sees 0 as not a number
+		bucketQueryString = "cast(0 as integer)"
 	} else {
 		bucketQueryString = fmt.Sprintf("width_bucket(cast(extract(epoch from %s\"%s\") as integer), %d, %d, %d) - 1",
 			alias, extrema.Key, int(extrema.Min), int(extrema.Max), extrema.GetBucketCount(numBuckets))
@@ -494,7 +495,8 @@ func (f *DateTimeField) getResultHistogramAggQuery(extrema *api.Extrema, resultV
 	// if only a single value, then return a simple count.
 	if rounded.Max == rounded.Min {
 		// want to return the count under bucket 0.
-		bucketQueryString = fmt.Sprintf("(\"%s\" - \"%s\")", fieldTyped, fieldTyped)
+		// specify a cast because the group by clause sees 0 as not a number
+		bucketQueryString = "cast(0 as integer)"
 	} else {
 		bucketQueryString = fmt.Sprintf("width_bucket(%s, %d, %d, %d) - 1",
 			fieldTyped, int(rounded.Min), int(rounded.Max), extrema.GetBucketCount(numBuckets))

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -199,7 +199,7 @@ func (s *Storage) buildIncludeFilter(dataset string, wheres []string, params []i
 
 	case model.GeoBoundsFilter:
 		// geo bounds
-		where := fmt.Sprintf("ST_WITHIN(%s, $%d)", name, len(params)+1)
+		where := fmt.Sprintf("ST_INTERSECTS(%s, $%d)", name, len(params)+1)
 		params = append(params, buildBoundsGeometryString(filter.Bounds))
 		wheres = append(wheres, where)
 
@@ -326,7 +326,7 @@ func (s *Storage) buildExcludeFilter(dataset string, wheres []string, params []i
 
 	case model.GeoBoundsFilter:
 		// geo bounds
-		where := fmt.Sprintf("ST_WITHIN(%s, $%d)=false", name, len(params)+1)
+		where := fmt.Sprintf("ST_INTERSECTS(%s, $%d)=false", name, len(params)+1)
 		params = append(params, buildBoundsGeometryString(filter.Bounds))
 		wheres = append(wheres, where)
 


### PR DESCRIPTION
Fixed a couple of minor issues with remote sensing / date time querying. If only a single timestamp existed, then the generated query was invalid. Also switched to use an intersects function rather than within function. This will overcount tiles that cross bucket boundaries rather than undercount them. This avoids having the map not show anything at all in cases where data could be sparse or if zoomed in a lot.