### PR TITLE
Join Dataset Grouping

### DIFF
--- a/api/dataset/media.go
+++ b/api/dataset/media.go
@@ -272,5 +272,10 @@ func getLabelFolders(folderPath string) ([]string, error) {
 		}
 	}
 
+	// add the parent directory since all media must be in it and not subfolders.
+	if len(labelFolders) == 0 {
+		labelFolders = append(labelFolders, folderPath)
+	}
+
 	return labelFolders, nil
 }

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -134,7 +134,7 @@ func FetchDataset(dataset string, includeIndex bool, includeMeta bool, filterPar
 		return nil, err
 	}
 
-	data, err := storageData.FetchData(dataset, metadata.StorageName, filterParams, false, nil)
+	data, err := storageData.FetchData(dataset, metadata.StorageName, filterParams, false, false, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to fetch data")
 	}

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -80,7 +80,7 @@ type DataStorageCtor func() (DataStorage, error)
 // DataStorage defines the functions available to query the underlying data storage.
 type DataStorage interface {
 	FetchNumRows(storageName string, variables []*model.Variable) (int, error)
-	FetchData(dataset string, storageName string, filterParams *FilterParams, invert bool, orderByVar *model.Variable) (*FilteredData, error)
+	FetchData(dataset string, storageName string, filterParams *FilterParams, invert bool, includeGroupingCol bool, orderByVar *model.Variable) (*FilteredData, error)
 	FetchDataset(dataset string, storageName string, includeMetadata bool, invert bool, filterParams *FilterParams) ([][]string, error)
 	FetchResultDataset(dataset string, storageName string, predictionName string, features []string, resultURI string) ([][]string, error)
 	FetchSummary(dataset string, storageName string, varName string, filterParams *FilterParams, invert bool, mode SummaryMode) (*VariableSummary, error)

--- a/api/routes/data.go
+++ b/api/routes/data.go
@@ -49,6 +49,8 @@ func DataHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataStorageCt
 		dataset := pat.Param(r, "dataset")
 		invert := pat.Param(r, "invert")
 		invertBool := parseBoolParam(invert)
+		includeGroupingCol := pat.Param(r, "include-grouping-col")
+		includeGroupingColBool := parseBoolParam(includeGroupingCol)
 		var orderByVar *model.Variable = nil
 		// get filter client
 		storage, err := storageCtor()
@@ -90,7 +92,7 @@ func DataHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataStorageCt
 		}
 
 		// fetch filtered data based on the supplied search parameters
-		data, err := storage.FetchData(dataset, storageName, expandedFilterParams, invertBool, orderByVar)
+		data, err := storage.FetchData(dataset, storageName, expandedFilterParams, invertBool, includeGroupingColBool, orderByVar)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable fetch filtered data"))
 			return

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -44,7 +44,7 @@ func getOptions(requestURI string) string {
 }
 
 // MultiBandImageHandler fetches individual band images and combines them into a single RGB image using the supplied mapping.
-func MultiBandImageHandler(ctor api.MetadataStorageCtor, config env.Config) func(http.ResponseWriter, *http.Request) {
+func MultiBandImageHandler(ctor api.MetadataStorageCtor, dataCtor api.DataStorageCtor, config env.Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		dataset := pat.Param(r, "dataset")
 		imageID := pat.Param(r, "image-id")
@@ -62,6 +62,12 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, config env.Config) func
 			handleError(w, err)
 			return
 		}
+		dataStorage, err := dataCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
 		res, err := storage.FetchDataset(dataset, false, false, false)
 		if err != nil {
 			handleError(w, err)
@@ -94,7 +100,15 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, config env.Config) func
 			// if thumbnail scale should be 0
 			options.Scale = 0
 		}
-		img, err := util.ImageFromCombination(sourcePath, imageID, bandCombo, imageScale, options)
+
+		// need to get the band -> filename from the data
+		bandMapping, err := getBandMapping(res, imageID, dataStorage)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		img, err := util.ImageFromCombination(sourcePath, bandMapping, bandCombo, imageScale, options)
 		if err != nil {
 			handleError(w, err)
 			return
@@ -120,4 +134,69 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, config env.Config) func
 			return
 		}
 	}
+}
+
+func getBandMapping(ds *api.Dataset, groupKey string, dataStorage api.DataStorage) (map[string]string, error) {
+	// build a filter to only include rows matching a group id
+	var groupingCol *model.Variable
+	var bandCol *model.Variable
+	var fileCol *model.Variable
+	for _, v := range ds.Variables {
+		if v.DistilRole == model.VarDistilRoleGrouping {
+			groupingCol = v
+		} else if v.Key == "band" {
+			bandCol = v
+		} else if v.RefersTo != nil {
+			fileCol = v
+		}
+	}
+	if groupingCol == nil {
+		return nil, errors.Errorf("no grouping col found in dataset")
+	}
+	if fileCol == nil {
+		return nil, errors.Errorf("no file col found in dataset")
+	}
+	if bandCol == nil {
+		return nil, errors.Errorf("no band col found in dataset")
+	}
+
+	filter := &api.FilterParams{}
+	filter.Filters = []*model.Filter{
+		{
+			Key:        groupingCol.Key,
+			Type:       model.CategoricalFilter,
+			Categories: []string{groupKey},
+			Mode:       model.IncludeFilter,
+		},
+	}
+
+	// pull back all rows for a group id
+	data, err := dataStorage.FetchData(ds.ID, ds.StorageName, filter, false, false, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// cycle through results to build the band mapping
+	fileColumn := -1
+	bandColumn := -1
+	for i, c := range data.Columns {
+		if c.Key == fileCol.Key {
+			fileColumn = i
+		} else if c.Key == bandCol.Key {
+			bandColumn = i
+		}
+	}
+	if fileColumn == -1 {
+		return nil, errors.Errorf("no file column found in stored data")
+	}
+	if bandColumn == -1 {
+		return nil, errors.Errorf("no band column found in stored data")
+	}
+
+	mapping := map[string]string{}
+	for _, r := range data.Values {
+		mapping[r[bandColumn].Value.(string)] = r[fileColumn].Value.(string)
+	}
+
+	return mapping, nil
 }

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -551,7 +551,7 @@ func CreateComposedVariable(metaStorage api.MetadataStorage, dataStorage api.Dat
 			Variables: []string{model.D3MIndexName},
 		}
 	}
-	rawData, err := dataStorage.FetchData(dataset, storageName, filter, false, nil)
+	rawData, err := dataStorage.FetchData(dataset, storageName, filter, false, false, nil)
 	if err != nil {
 		return err
 	}

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -28,7 +28,6 @@ import (
 	"path"
 	"strings"
 
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/nfnt/resize"
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/gdal"
@@ -124,19 +123,9 @@ func NormalizingTransform(bandValues ...uint16) float64 {
 var (
 	// SentinelBandCombinations defines a list of recommended band combinations for sentinel 2 satellite missions
 	SentinelBandCombinations = map[string]*BandCombination{}
-
-	// Cache to hold directory file type search results
-	folderTypeCache *lru.Cache
 )
 
 func init() {
-	// create an LRU cache to hold the results of time consuming directory content analysis
-	var err error
-	folderTypeCache, err = lru.New(100)
-	if err != nil {
-		log.Error(errors.Wrap(err, "failed to init directory type cache"))
-	}
-
 	// initialize the band combination structures - needs to be done in init so that referenced color ramps are built
 	SentinelBandCombinations = map[string]*BandCombination{
 		NaturalColors:          {NaturalColors, "Natural Colors", []string{"b04", "b03", "b02"}, nil, nil},
@@ -521,13 +510,6 @@ func SplitMultiBandImage(dataset gdal.Dataset, outputFolder string, bandMapping 
 	}
 
 	return files, nil
-}
-
-// getFilePath takes a top level dataset directory, a file ID and a band label and composes them
-// into a coherent path for a BigEarthNet file.
-func getFilePath(datasetDir string, fileID string, bandLabel string, fileType string) string {
-	fileName := fmt.Sprintf("%s_%s.%s", fileID, strings.ToUpper(bandLabel), fileType)
-	return path.Join(datasetDir, fileName)
 }
 
 func lerp(v0 float64, v1 float64, t float64) float64 {

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -158,30 +158,19 @@ func init() {
 
 // ImageFromCombination takes a base datsaet directory, fileID and a band combination label and
 // returns a composed image.  NOTE: Currently a bit hardcoded for sentinel-2 data.
-func ImageFromCombination(datasetDir string, fileID string, bandCombo string, imageScale ImageScale, options ...Options) (*image.RGBA, error) {
+func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, bandCombo string, imageScale ImageScale, options ...Options) (*image.RGBA, error) {
 	// attempt to get the folder file type for the supplied dataset dir from the cache, if
 	// not do the look up
 	bandCombination := BandCombinationID(bandCombo)
-	var fileType string
-	cacheValue, ok := folderTypeCache.Get(datasetDir)
-	if !ok {
-		var err error
-		fileType, err = GetFolderFileType(datasetDir)
-		if err != nil {
-			return nil, err
-		}
-		folderTypeCache.Add(datasetDir, fileType)
-	} else {
-		fileType = cacheValue.(string)
-	}
 
 	// map the band files to the inputs
 	filePaths := []string{}
 	if bandCombo, ok := SentinelBandCombinations[strings.ToLower(string(bandCombination))]; ok {
 		for _, bandLabel := range bandCombo.Mapping {
-			filePath := getFilePath(datasetDir, fileID, bandLabel, fileType)
-			filePaths = append(filePaths, filePath)
+			log.Infof("BAND LABEL: %v", bandLabel)
+			filePaths = append(filePaths, path.Join(datasetDir, bandFileMapping[bandLabel]))
 		}
+		log.Infof("FILE PATHS: %v", filePaths)
 		return ImageFromBands(filePaths, bandCombo.Ramp, bandCombo.Transform, imageScale, options...)
 	}
 

--- a/api/util/imagery_test.go
+++ b/api/util/imagery_test.go
@@ -16,14 +16,29 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
-	log "github.com/unchartedsoftware/plog"
 	"image"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	log "github.com/unchartedsoftware/plog"
 )
 
 func TestImageFromCombination(t *testing.T) {
-	composedImage, err := ImageFromCombination("test/bigearthnet", "S2A_MSIL2A_20171121T112351_79_21", NaturalColors, ImageScale{})
+	bandMap := map[string]string{
+		"b01": "S2A_MSIL2A_20171121T112351_79_21_B01.tif",
+		"b02": "S2A_MSIL2A_20171121T112351_79_21_B02.tif",
+		"b03": "S2A_MSIL2A_20171121T112351_79_21_B03.tif",
+		"b04": "S2A_MSIL2A_20171121T112351_79_21_B04.tif",
+		"b05": "S2A_MSIL2A_20171121T112351_79_21_B05.tif",
+		"b06": "S2A_MSIL2A_20171121T112351_79_21_B06.tif",
+		"b07": "S2A_MSIL2A_20171121T112351_79_21_B07.tif",
+		"b08": "S2A_MSIL2A_20171121T112351_79_21_B08.tif",
+		"b8A": "S2A_MSIL2A_20171121T112351_79_21_B8A.tif",
+		"b09": "S2A_MSIL2A_20171121T112351_79_21_B09.tif",
+		"b11": "S2A_MSIL2A_20171121T112351_79_21_B11.tif",
+		"b12": "S2A_MSIL2A_20171121T112351_79_21_B12.tif",
+	}
+	composedImage, err := ImageFromCombination("test/bigearthnet", bandMap, NaturalColors, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,7 @@ go 1.13
 require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/caarlos0/env v3.5.0+incompatible
-	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1
-	github.com/fatih/color v1.10.0 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.4.2
 	github.com/golangci/golangci-lint v1.33.0 // indirect
@@ -32,8 +30,6 @@ require (
 	github.com/uncharted-distil/distil-compute v0.0.0-20210208222927-a7ae5d433614
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210210122944-38e126ef1a20
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
-	github.com/unchartedsoftware/witch v0.0.0-20200617171400-4f405404126f // indirect
-	github.com/urfave/cli v1.22.5 // indirect
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5
 	github.com/unchartedsoftware/witch v0.0.0-20200617171400-4f405404126f // indirect
 	github.com/urfave/cli v1.22.5 // indirect

--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ func main() {
 	registerRoute(mux, "/distil/export/:solution-id", routes.ExportHandler(solutionClient, config.D3MOutputDir, discoveryLogger))
 	registerRoute(mux, "/distil/config", routes.ConfigHandler(config, version, timestamp, problemPath, datasetDocPath, ta2Version))
 	registerRoute(mux, "/distil/task/:dataset/:target/:variables", routes.TaskHandler(pgDataStorageCtor, esMetadataStorageCtor))
-	registerRoute(mux, "/distil/multiband-image/:dataset/:image-id/:band-combination/:is-thumbnail/*", routes.MultiBandImageHandler(esMetadataStorageCtor, config))
+	registerRoute(mux, "/distil/multiband-image/:dataset/:image-id/:band-combination/:is-thumbnail/*", routes.MultiBandImageHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoute(mux, "/distil/multiband-combinations/:dataset", routes.MultiBandCombinationsHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/distil/load/:solution-id/:fitted", routes.LoadHandler(esExportedModelStorageCtor, pgSolutionStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/distil/solution-variable-rankings/:solution-id", routes.SolutionVariableRankingHandler(esMetadataStorageCtor, pgSolutionStorageCtor))

--- a/main.go
+++ b/main.go
@@ -283,7 +283,7 @@ func main() {
 	registerRoutePost(mux, "/distil/grouping/:dataset", routes.GroupingHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/remove-grouping/:dataset/:variable", routes.RemoveGroupingHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/variables/:dataset", routes.VariableTypeHandler(pgDataStorageCtor, esMetadataStorageCtor))
-	registerRoutePost(mux, "/distil/data/:dataset/:invert", routes.DataHandler(pgDataStorageCtor, esMetadataStorageCtor))
+	registerRoutePost(mux, "/distil/data/:dataset/:invert/:include-grouping-col", routes.DataHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/import/:datasetID/:source/:provenance", routes.ImportHandler(pgDataStorageCtor, datamartCtors, fileMetadataStorageCtor, esMetadataStorageCtor, &config))
 	registerRoutePost(mux, "/distil/delete/:dataset/:variable", routes.DeleteHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/results/:dataset/:solution-id", routes.ResultsHandler(pgSolutionStorageCtor, pgDataStorageCtor, esMetadataStorageCtor))

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1362,7 +1362,7 @@ export const actions = {
 
         try {
           const response = await axios.post(
-            `distil/data/${dataset}/false`,
+            `distil/data/${dataset}/false/true`,
             filterParams
           );
           mutations.setJoinDatasetsTableData(context, {
@@ -1505,7 +1505,7 @@ export const actions = {
 
     try {
       const response = await axios.post(
-        `distil/data/${args.dataset}/${!args.include}`,
+        `distil/data/${args.dataset}/${!args.include}/false`,
         { ...filterParams, orderBy: args.orderBy }
       );
       return response.data;


### PR DESCRIPTION
Fixes to allow for joins to be done on the group id of a remote sensing dataset. This includes updating how the group id is built to exclude the timestamp if only a single timestamp exists in the dataset. Also fixed the multiband creation to lookup the files in the stored data rather than assume a filename structure which could be incorrect.