### PR TITLE
images are performing much better

### DIFF
--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-observe-visibility="visibilityChanged"
+    v-observe-visibility="{ callback: visibilityChanged }"
     :class="{ 'is-hidden': !isVisible && !preventHiding }"
     :style="{
       width: `${width}px`, // + 2 for boarder
@@ -111,7 +111,7 @@ export default Vue.extend({
       if (newUrl === null) {
         return;
       }
-      if (newUrl !== oldUrl) {
+      if (newUrl !== oldUrl && this.isVisible) {
         this.cleanUp();
         this.hasRendered = false;
         this.hasRequested = false;


### PR DESCRIPTION
![Peek 2021-02-18 15-07](https://user-images.githubusercontent.com/25306965/108415153-25cf3a80-71fb-11eb-8306-61aeea90f052.gif)
The v-observe-visibility was only calling the callback when the element was visible. 
When paging, all the items that had previously been once visible would try to fetch images. 
Potentially 100 request on page. This was the cause of the sluggishness.

closes #2283 