### PR TITLE
fixed geoplot not loading images. Fixed timestamp facet.

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -599,7 +599,6 @@ export default Vue.extend({
 
     // Return name of column used as grouping column for the table data
     multibandImageGroupColumn(): string {
-      console.log(datasetGetters.getVariables(this.$store));
       const groupColumns = datasetGetters
         .getVariables(this.$store)
         .find((v) => v.colType === MULTIBAND_IMAGE_TYPE);

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -557,15 +557,12 @@ export default Vue.extend({
     highlight(): Highlight {
       return routeGetters.getDecodedHighlight(this.$store);
     },
-
     mapCenter(): number[] {
       return routeGetters.getGeoCenter(this.$store);
     },
-
     mapZoom(): number {
       return routeGetters.getGeoZoom(this.$store);
     },
-
     rowSelection(): RowSelection {
       return routeGetters.getDecodedRowSelection(this.$store);
     },
@@ -602,14 +599,11 @@ export default Vue.extend({
 
     // Return name of column used as grouping column for the table data
     multibandImageGroupColumn(): string {
+      console.log(datasetGetters.getVariables(this.$store));
       const groupColumns = datasetGetters
         .getVariables(this.$store)
-        .filter((v) => v.colType === MULTIBAND_IMAGE_TYPE)
-        .map((v) => (v.grouping as MultiBandImageGrouping).idCol);
-      if (groupColumns.length > 1) {
-        console.error("only 1 grouping column is expected");
-      }
-      return groupColumns[0];
+        .find((v) => v.colType === MULTIBAND_IMAGE_TYPE);
+      return groupColumns.key;
     },
 
     band(): string {
@@ -1106,7 +1100,7 @@ export default Vue.extend({
     tableDataToAreas(tableData: any[]): Area[] {
       const areas = tableData.map((item, i) => {
         const imageUrl = this.isMultiBandImage
-          ? item[this.multibandImageGroupColumn]
+          ? item[this.multibandImageGroupColumn].value
           : null;
         const fullCoordinates = item[this.coordinateColumn].value.Elements;
         if (fullCoordinates.some((x) => x === undefined)) return;

--- a/public/util/facets.ts
+++ b/public/util/facets.ts
@@ -420,7 +420,12 @@ export function getRowSelectionLabels(summary: VariableSummary): string[] {
       }
     })
   );
-
+  // if date time parse into numeric value
+  if (summary.varType === DATE_TIME_TYPE) {
+    rowKeys = rowKeys.map((key) => {
+      return (Date.parse(key) / 1000).toString(); // convert to seconds
+    });
+  }
   if (summary.type === NUMERICAL_SUMMARY) {
     const bucketFloors = summary.baseline.buckets.map((b) => _.toNumber(b.key));
     rowKeys = rowKeys.map((rk) => _.toNumber(rk));


### PR DESCRIPTION
closes #2264
![image](https://user-images.githubusercontent.com/25306965/108532281-ad718380-72a5-11eb-8baf-ffef1bd3b1d5.png)

- After tracking down the source of the issue:
- https://github.com/uncharted-distil/distil/blob/main/api/model/storage/elastic/variable.go#L429
- The d3mIndex variable had a distilRole of Data causing it to be filtered out. The d3mIndex is required for rowSelection. Upon reingesting the baseball ds shown above. The d3mIndex is given the proper distilRole. In order to fix this we just need to do a reingest of all the datasets.
- Fixed map not loading images
- Fixed timestamp not showing rowSelection (there was a key mismatch)