### PR TITLE
The v-observe has issues where it does not register quick scrolls.

### DIFF
--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -111,7 +111,7 @@ export default Vue.extend({
       if (newUrl === null) {
         return;
       }
-      if (newUrl !== oldUrl && this.isVisible) {
+      if (newUrl !== oldUrl) {
         this.cleanUp();
         this.hasRendered = false;
         this.hasRequested = false;


### PR DESCRIPTION
closes #2287
- v-observe-visibility has issues where it wont register quick scrolls. Causing the image preview not to fetch images because it thinks it is not in the viewport.(this unfortunately causes performance issues with a max of 100 fetches on page)