### PR TITLE
Join Metadata Creation

### DIFF
--- a/api/dataset/d3m.go
+++ b/api/dataset/d3m.go
@@ -105,7 +105,7 @@ func (d *D3M) isFullySpecified(ds *api.RawDataset) bool {
 	// check the variable list against the header in the data
 	for i, h := range ds.Data[0] {
 		if varMapIndex[i] == nil || varMapIndex[i].HeaderName != h {
-			log.Infof("header in data file does not match metadata variable list")
+			log.Infof("header in data file does not match metadata variable list (%s differs from %s at position %d)", h, varMapIndex[i].HeaderName, i)
 			return false
 		}
 	}

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -374,10 +374,18 @@ func CreateDatasetFromResult(newDatasetName string, predictionDataset string, so
 	}
 
 	// store new dataset metadata
+	steps := &IngestSteps{
+		VerifyMetadata:       false,
+		FallbackMerged:       false,
+		CreateMetadataTables: false,
+	}
+	params := &IngestParams{
+		Source: metadata.Augmented,
+		Type:   api.DatasetTypeModelling,
+	}
 	ingestConfig := NewConfig(config)
 	cloneSchemaPath := path.Join(outputPath, compute.D3MDataSchema)
-	_, err = IngestMetadata(cloneSchemaPath, cloneSchemaPath, nil, metaStorage,
-		metadata.Augmented, nil, api.DatasetTypeModelling, ingestConfig, false, false)
+	_, err = IngestMetadata(cloneSchemaPath, cloneSchemaPath, nil, metaStorage, params, ingestConfig, steps)
 	if err != nil {
 		return "", err
 	}
@@ -397,7 +405,7 @@ func CreateDatasetFromResult(newDatasetName string, predictionDataset string, so
 	}
 
 	// ingest to postgres from disk
-	err = IngestPostgres(cloneSchemaPath, cloneSchemaPath, metadata.Augmented, nil, ingestConfig, false, false, false)
+	err = IngestPostgres(cloneSchemaPath, cloneSchemaPath, params, ingestConfig, steps)
 	if err != nil {
 		return "", err
 	}

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -73,8 +73,10 @@ type IngestTaskConfig struct {
 // IngestSteps is a collection of parameters that specify ingest behaviour.
 type IngestSteps struct {
 	ClassificationOverwrite bool
-	RawGroupings            []map[string]interface{}
-	IndexFields             []string
+	VerifyMetadata          bool
+	FallbackMerged          bool
+	CreateMetadataTables    bool
+	CheckMatch              bool
 }
 
 // NewDefaultClient creates a new client to use when submitting pipelines.
@@ -132,13 +134,16 @@ type IngestResult struct {
 
 // IngestParams contains the parameters needed to ingest a dataset
 type IngestParams struct {
-	Source   metadata.DatasetSource
-	DataCtor api.DataStorageCtor
-	MetaCtor api.MetadataStorageCtor
-	ID       string
-	Origins  []*model.DatasetOrigin
-	Type     api.DatasetType
-	Path     string
+	Source          metadata.DatasetSource
+	DataCtor        api.DataStorageCtor
+	MetaCtor        api.MetadataStorageCtor
+	ID              string
+	Origins         []*model.DatasetOrigin
+	Type            api.DatasetType
+	Path            string
+	RawGroupings    []map[string]interface{}
+	IndexFields     []string
+	DefinitiveTypes map[string]*model.Variable
 }
 
 func (i *IngestParams) getSchemaDocPath() string {
@@ -192,7 +197,6 @@ func IngestDataset(params *IngestParams, config *IngestTaskConfig, steps *Ingest
 	latestSchemaOutput = output
 	log.Infof("finished cleaning the dataset")
 
-	definitiveClassification := false
 	if config.ClassificationEnabled {
 		if steps.ClassificationOverwrite || !classificationExists(latestSchemaOutput, config) {
 			_, err = Classify(latestSchemaOutput, params.ID, config)
@@ -204,7 +208,6 @@ func IngestDataset(params *IngestParams, config *IngestTaskConfig, steps *Ingest
 			}
 			log.Infof("finished classifying the dataset")
 		} else {
-			definitiveClassification = true
 			log.Infof("skipping classification because it already exists")
 		}
 	} else {
@@ -251,17 +254,16 @@ func IngestDataset(params *IngestParams, config *IngestTaskConfig, steps *Ingest
 		log.Infof("finished sampling dataset")
 	}
 
-	datasetID, err := Ingest(originalSchemaFile, latestSchemaOutput, dataStorage, metaStorage, params.ID,
-		params.Source, params.Origins, params.Type, steps.IndexFields, config, true, !definitiveClassification, true)
+	datasetID, err := Ingest(originalSchemaFile, latestSchemaOutput, dataStorage, metaStorage, params, config, steps)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to ingest ranked data")
 	}
 	log.Infof("finished ingesting the dataset")
 
 	// set the known grouping information
-	if steps.RawGroupings != nil {
+	if params.RawGroupings != nil {
 		log.Infof("creating groupings in metadata")
-		err = SetGroups(datasetID, steps.RawGroupings, metaStorage, config)
+		err = SetGroups(datasetID, params.RawGroupings, metaStorage, config)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to set grouping")
 		}
@@ -324,10 +326,10 @@ func Featurize(originalSchemaFile string, schemaFile string, data api.DataStorag
 }
 
 // Ingest the metadata to ES and the data to Postgres.
-func Ingest(originalSchemaFile string, schemaFile string, data api.DataStorage, storage api.MetadataStorage, dataset string, source metadata.DatasetSource,
-	origins []*model.DatasetOrigin, datasetType api.DatasetType, indexFields []string, config *IngestTaskConfig, checkMatch bool, verifyMetadata bool, fallbackMerged bool) (string, error) {
+func Ingest(originalSchemaFile string, schemaFile string, data api.DataStorage,
+	storage api.MetadataStorage, params *IngestParams, config *IngestTaskConfig, steps *IngestSteps) (string, error) {
 	// TODO: A LOT OF THIS CODE SHOULD BE IN THE STORAGE PACKAGES!!!
-	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, source, nil, config, verifyMetadata, fallbackMerged)
+	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, params.Source, nil, config, steps.VerifyMetadata, steps.FallbackMerged)
 	if err != nil {
 		return "", err
 	}
@@ -341,7 +343,7 @@ func Ingest(originalSchemaFile string, schemaFile string, data api.DataStorage, 
 		}
 
 		if uniqueName != meta.Name {
-			extendedOutput := source == metadata.Augmented
+			extendedOutput := params.Source == metadata.Augmented
 			log.Infof("storing (extended: %v) metadata with new name to %s (new: '%s', old: '%s')", extendedOutput, originalSchemaFile, uniqueName, meta.Name)
 			meta.Name = uniqueName
 			meta.ID = model.NormalizeDatasetID(uniqueName)
@@ -370,7 +372,7 @@ func Ingest(originalSchemaFile string, schemaFile string, data api.DataStorage, 
 	}
 
 	// Check for existing dataset
-	if checkMatch && config.IngestOverwrite {
+	if steps.CheckMatch && config.IngestOverwrite {
 		match, err := matchDataset(storage, meta)
 		// Ignore the error for now as if this fails we still want ingest to succeed.
 		if err != nil {
@@ -387,24 +389,24 @@ func Ingest(originalSchemaFile string, schemaFile string, data api.DataStorage, 
 	}
 
 	// ingest the metadata
-	_, err = IngestMetadata(originalSchemaFile, schemaFile, data, storage, source, origins, datasetType, config, verifyMetadata, fallbackMerged)
+	updatedDatasetID, err := IngestMetadata(originalSchemaFile, schemaFile, data, storage, params, config, steps)
 	if err != nil {
 		return "", err
 	}
 
 	// ingest the data
-	err = IngestPostgres(originalSchemaFile, schemaFile, source, indexFields, config, verifyMetadata, false, fallbackMerged)
+	err = IngestPostgres(originalSchemaFile, schemaFile, params, config, steps)
 	if err != nil {
 		return "", err
 	}
 
 	// expand the suggested types to be the exhaustive list of types it can be
-	err = VerifySuggestedTypes(dataset, data, storage)
+	err = VerifySuggestedTypes(updatedDatasetID, data, storage)
 	if err != nil {
 		return "", err
 	}
 
-	return meta.ID, nil
+	return updatedDatasetID, nil
 }
 
 // VerifySuggestedTypes checks expands the suggested types to include all valid
@@ -424,13 +426,13 @@ func VerifySuggestedTypes(dataset string, dataStorage api.DataStorage, metaStora
 }
 
 // IngestMetadata ingests the data to ES.
-func IngestMetadata(originalSchemaFile string, schemaFile string, data api.DataStorage, storage api.MetadataStorage, source metadata.DatasetSource,
-	origins []*model.DatasetOrigin, datasetType api.DatasetType, config *IngestTaskConfig, verifyMetadata bool, fallbackMerged bool) (string, error) {
-	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, source, origins, config, verifyMetadata, fallbackMerged)
+func IngestMetadata(originalSchemaFile string, schemaFile string, data api.DataStorage,
+	storage api.MetadataStorage, params *IngestParams, config *IngestTaskConfig, steps *IngestSteps) (string, error) {
+	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, params.Source, params.Origins, config, steps.VerifyMetadata, steps.FallbackMerged)
 	if err != nil {
 		return "", err
 	}
-	meta.Type = string(datasetType)
+	meta.Type = string(params.Type)
 
 	if data != nil {
 		storageName, err := data.GetStorageName(meta.ID)
@@ -449,7 +451,7 @@ func IngestMetadata(originalSchemaFile string, schemaFile string, data api.DataS
 	}
 	meta.Immutable = true
 	// Ingest the dataset info into the metadata storage
-	err = storage.IngestDataset(source, meta)
+	err = storage.IngestDataset(params.Source, meta)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to ingest metadata")
 	}
@@ -460,9 +462,8 @@ func IngestMetadata(originalSchemaFile string, schemaFile string, data api.DataS
 }
 
 // IngestPostgres ingests a dataset to PG storage.
-func IngestPostgres(originalSchemaFile string, schemaFile string, source metadata.DatasetSource, indexFields []string,
-	config *IngestTaskConfig, verifyMetadata bool, createMetadataTables bool, fallbackMerged bool) error {
-	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, source, nil, config, verifyMetadata, fallbackMerged)
+func IngestPostgres(originalSchemaFile string, schemaFile string, params *IngestParams, config *IngestTaskConfig, steps *IngestSteps) error {
+	_, meta, err := loadMetadataForIngest(originalSchemaFile, schemaFile, params.Source, nil, config, steps.VerifyMetadata, steps.FallbackMerged)
 	if err != nil {
 		return err
 	}
@@ -485,7 +486,7 @@ func IngestPostgres(originalSchemaFile string, schemaFile string, source metadat
 	}
 
 	dbTable := meta.StorageName
-	if createMetadataTables {
+	if steps.CreateMetadataTables {
 		err = pg.CreateSolutionMetadataTables()
 		if err != nil {
 			return err
@@ -554,7 +555,7 @@ func IngestPostgres(originalSchemaFile string, schemaFile string, source metadat
 	}
 
 	log.Infof("checking if indices are necessary")
-	err = createIndices(pg, meta.ID, indexFields, meta, config)
+	err = createIndices(pg, meta.ID, params.IndexFields, meta, config)
 	if err != nil {
 		return err
 	}

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -130,6 +130,7 @@ func createDatasetFromCSV(config *env.Config, csvFile string, datasetName string
 
 	mergedVariables, referencedResources := joinMetadataVariables(inputData[0], joinLeft.Variables, joinLeft.ExistingMetadata, joinRight.Variables, joinRight.ExistingMetadata)
 	dataResource.Variables = mergedVariables
+	inputData[0] = dataResource.GenerateHeader()
 
 	metadata.DataResources = append(referencedResources, dataResource)
 

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -39,18 +39,21 @@ func TestJoin(t *testing.T) {
 	varsLeft := []*model.Variable{
 		{
 			Key:         "d3mIndex",
+			HeaderName:  "D3M Index",
 			DisplayName: "D3M Index",
 			Type:        model.IntegerType,
 			DistilRole:  "data",
 		},
 		{
 			Key:         "alpha",
+			HeaderName:  "Alpha",
 			DisplayName: "Alpha",
 			Type:        model.RealType,
 			DistilRole:  "data",
 		},
 		{
 			Key:         "bravo",
+			HeaderName:  "Bravo",
 			DisplayName: "Bravo",
 			Type:        model.IntegerType,
 			DistilRole:  "data",
@@ -60,19 +63,21 @@ func TestJoin(t *testing.T) {
 	varsRight := []*model.Variable{
 		{
 			Key:         "d3mIndex",
+			HeaderName:  "D3M Index",
 			DisplayName: "D3M Index",
 			Type:        model.IntegerType,
 			DistilRole:  "data",
 		},
 		{
-			Key:          "charlie",
-			DisplayName:  "Charlie",
-			Type:         model.CountryType,
-			OriginalType: model.CategoricalFilter,
-			DistilRole:   "data",
+			Key:         "charlie",
+			HeaderName:  "Charlie",
+			DisplayName: "Charlie",
+			Type:        model.CategoricalType,
+			DistilRole:  "data",
 		},
 		{
 			Key:         "delta",
+			HeaderName:  "Delta",
 			DisplayName: "Delta",
 			Type:        model.IntegerType,
 			DistilRole:  "data",
@@ -91,12 +96,14 @@ func TestJoin(t *testing.T) {
 		DatasetID:     "test_1",
 		DatasetFolder: "test_1_TRAIN",
 		DatasetSource: "contrib",
+		Variables:     varsLeft,
 	}
 
 	rightJoin := &JoinSpec{
 		DatasetID:     "test_2",
 		DatasetFolder: "test_2_TRAIN",
 		DatasetSource: "contrib",
+		Variables:     varsRight,
 	}
 
 	rightOrigin := &model.DatasetOrigin{
@@ -108,7 +115,7 @@ func TestJoin(t *testing.T) {
 		"Join to be reviewed by user", rightOrigin.SearchResult, rightOrigin.Provenance)
 	assert.NoError(t, err)
 	datasetLeftURI := env.ResolvePath(leftJoin.DatasetSource, leftJoin.DatasetFolder)
-	_, result, err := join(leftJoin, rightJoin, varsLeft, varsRight, pipelineDesc, []string{datasetLeftURI}, testSubmitter{}, &cfg)
+	_, result, err := join(leftJoin, rightJoin, pipelineDesc, []string{datasetLeftURI}, testSubmitter{}, &cfg)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -148,7 +155,7 @@ func TestJoin(t *testing.T) {
 		},
 		{
 			Label:  "Charlie",
-			Key:    "Charlie",
+			Key:    "charlie",
 			Type:   model.CategoricalType,
 			Weight: float64(0),
 		},
@@ -165,7 +172,7 @@ func TestJoin(t *testing.T) {
 	assert.Equal(t, result.NumRows, 4)
 	for i := 0; i < len(expectedTyped); i++ {
 		for j := 0; j < len(expectedTyped[i]); j++ {
-			assert.Equal(t, result.Values[i][j].Value, expectedTyped[i][j])
+			assert.Equal(t, expectedTyped[i][j], result.Values[i][j].Value)
 		}
 	}
 }

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -716,12 +716,12 @@ func copyFeatureGroups(fittedSolutionID string, datasetName string, solutionStor
 	if err != nil {
 		return err
 	}
-	variableMap := createVarMap(variables, false, false)
+	variableMap := comp.MapVariables(variables, func(variable *model.Variable) string { return variable.Key })
 	variablesPrediction, err := metaStorage.FetchVariables(datasetName, false, true, false)
 	if err != nil {
 		return err
 	}
-	variablePredictionMap := createVarMap(variablesPrediction, false, false)
+	variablePredictionMap := comp.MapVariables(variablesPrediction, func(variable *model.Variable) string { return variable.Key })
 
 	// copy over the groups that are found and dont already exist in the prediction dataset
 	for _, feature := range solutionRequest.Features {

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -241,7 +241,15 @@ func ImportPredictionDataset(params *PredictParams) (string, string, error) {
 func IngestPredictionDataset(params *PredictParams) error {
 	schemaPath := params.SchemaPath
 	// ingest the dataset but without running simon, duke, etc.
-	err := IngestPostgres(schemaPath, schemaPath, metadata.Augmented, nil, params.IngestConfig, true, false, false)
+	steps := &IngestSteps{
+		VerifyMetadata:       true,
+		FallbackMerged:       false,
+		CreateMetadataTables: false,
+	}
+	ingestParams := &IngestParams{
+		Source: metadata.Augmented,
+	}
+	err := IngestPostgres(schemaPath, schemaPath, ingestParams, params.IngestConfig, steps)
 	if err != nil {
 		return errors.Wrap(err, "unable to ingest prediction data")
 	}

--- a/main.go
+++ b/main.go
@@ -229,7 +229,12 @@ func main() {
 			Origins:  nil,
 			Type:     model.DatasetTypeModelling,
 		}
-		_, err = task.IngestDataset(ingestParams, ingestConfig, &task.IngestSteps{ClassificationOverwrite: true})
+		steps := &task.IngestSteps{
+			ClassificationOverwrite: true,
+			VerifyMetadata:          true,
+			FallbackMerged:          true,
+		}
+		_, err = task.IngestDataset(ingestParams, ingestConfig, steps)
 		if err != nil {
 			log.Errorf("%+v", err)
 			os.Exit(1)

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -541,15 +541,17 @@ export const actions = {
     }
 
     let postParams = {};
-    if (args.originalDataset !== null) {
-      postParams = {
-        originalDataset: args.originalDataset,
-        joinedDataset: args.joinedDataset,
-      };
-    } else if (args.path !== "") {
+    if (args.path !== "") {
       postParams = {
         path: args.path,
         nosample: args.nosample,
+        originalDataset: args.originalDataset,
+        joinedDataset: args.joinedDataset,
+      };
+    } else if (args.originalDataset !== null) {
+      postParams = {
+        originalDataset: args.originalDataset,
+        joinedDataset: args.joinedDataset,
       };
     }
     const response = await axios.post(


### PR DESCRIPTION
Updated the join code to allow for specifying of metadata from the two source datasets. This update was also made for the import, where the client can specify source datasets which should be used to capture types properly.

The join code was also cleaned up to use code that has been added in the last year to simplify a few different pieces of it. The ingest code was refactored slightly to use structs to pass in parameters rather than keep growing the parameter list. It also now accepts definitive type information on a per variable basis.