### PR TITLE
Dataset Reading And Labelling Crash Fixes

### DIFF
--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -18,6 +18,7 @@ package serialization
 import (
 	"path"
 
+	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
 )
@@ -71,8 +72,7 @@ func GetParquetStorage() Storage {
 
 // ReadDataset reads the metadata to find the main data reference, then reads that.
 func ReadDataset(schemaPath string) (*api.RawDataset, error) {
-	// metadata can be read by CSV storage
-	meta, err := csvStorage.ReadMetadata(schemaPath)
+	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaPath, false)
 	if err != nil {
 		return nil, err
 	}

--- a/public/components/ModelPreview.vue
+++ b/public/components/ModelPreview.vue
@@ -103,7 +103,7 @@ export default Vue.extend({
     onResult() {
       openModelSolution(this.$router, {
         datasetId: this.model.datasetId,
-        targetFeature: this.model.target.displayName,
+        targetFeature: this.model.target.key,
         fittedSolutionId: this.model.fittedSolutionId,
         variableFeatures: this.model.variables,
       });


### PR DESCRIPTION
Dataset reading was using the default csv behaviour to determine if a dataset was stored as parquet or csv, which led to a chance of crashing if the parquet file could not be read properly by a csv reader. It has been changed to read the metadata only, then reading the full dataset properly.

The model preview was using the display name rather than the key to determine the task, thereby erroring if the two names did not match.