### PR TITLE
Apply Predictions Existing Dataset

### DIFF
--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -507,7 +507,7 @@ func getPredictionDataset(requestTask *api.Task, request *api.PredictRequest, pr
 			return "", "", err
 		}
 
-		return ds.ID, env.ResolvePath(ds.Source, ds.Folder), nil
+		return ds.ID, path.Join(env.ResolvePath(ds.Source, ds.Folder), compute.D3MDataSchema), nil
 	}
 
 	// ingest the data as a new prediction dataset

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -616,6 +616,7 @@ export const actions = {
         targetType: request.targetType,
         intervalCount: request.intervalCount ?? null,
         intervalLength: request.intervalLength ?? null,
+        existingDataset: request.existingDataset,
       });
     });
   },


### PR DESCRIPTION
Addition of a simple dropdown to select an existing dataset to use when predicting. This is a very quick and dirty solution to let us progress in preparing demos. It needs to be made cleaned up, and we need to explore what happens to the underlying data stored when making such predictions. Should we clone the dataset and then predict on the clone? Should we show the predictions on the main dataset?