### PR TITLE
Image query cache

### DIFF
--- a/api/routes/delete_dataset.go
+++ b/api/routes/delete_dataset.go
@@ -18,6 +18,7 @@ package routes
 import (
 	"net/http"
 
+	"github.com/uncharted-distil/distil/api/task"
 	"github.com/uncharted-distil/distil/api/util"
 
 	"github.com/pkg/errors"
@@ -72,6 +73,10 @@ func DeletingDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataS
 			handleError(w, err)
 			return
 		}
+
+		// delete the query cache associated wit this dataset if it exists
+		task.DeleteQueryCache(dataset)
+
 		// send json
 		err = handleJSON(w, map[string]interface{}{"success": true})
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210208222927-a7ae5d433614
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210211160256-b9cb91e1a5c9
+	github.com/uncharted-distil/distil-compute v0.0.0-20210222122537-5b7d569fcaef
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5
 	github.com/unchartedsoftware/witch v0.0.0-20200617171400-4f405404126f // indirect
@@ -42,5 +42,3 @@ require (
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
 	google.golang.org/grpc v1.25.1
 )
-
-replace github.com/uncharted-distil/distil-compute => ../distil-compute

--- a/go.mod
+++ b/go.mod
@@ -42,3 +42,5 @@ require (
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
 	google.golang.org/grpc v1.25.1
 )
+
+replace github.com/uncharted-distil/distil-compute => ../distil-compute

--- a/go.sum
+++ b/go.sum
@@ -550,6 +550,8 @@ github.com/ultraware/whitespace v0.0.4 h1:If7Va4cM03mpgrNH9k49/VOicWpGoG70XPBFFO
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/uncharted-distil/distil-compute v0.0.0-20210208222927-a7ae5d433614 h1:GUHDkf0VWeRcNe91fIWHINGD3MEJyY+AP3p6b19POZo=
 github.com/uncharted-distil/distil-compute v0.0.0-20210208222927-a7ae5d433614/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210222122537-5b7d569fcaef h1:hQ58Bi5DpeYpgjkwHy4ah8jNMFXdEBoM1MQNf3SzDnk=
+github.com/uncharted-distil/distil-compute v0.0.0-20210222122537-5b7d569fcaef/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210210122944-38e126ef1a20 h1:cKyGWuu+FB6Nfudu3fUxPliC9jx6haa1CyPINzOK2io=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210210122944-38e126ef1a20/go.mod h1:G5ygnZ86P6T2iRh4gUY5R3oAxj3ZMn9j+HX+r3qiWBo=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210211160256-b9cb91e1a5c9 h1:FZXa8V3DNuym+TVnHF7rxxyKr74tpm8vjmO7vUQwD/w=


### PR DESCRIPTION
fixes #2297 

The image retrieval primitive has the ability to cache dot product computation to a caller supplied location.  This cache needs to be given a name that is unique to a particular query session, which in our case corresponds to the temporary query dataset.  Since we can delete query datasets and then end up creating a new one with the same name, we need to make sure we delete the cache when the query dataset is deleted.

