### PR TITLE
fixes for intersect vs within

### DIFF
--- a/public/components/DrillDown.vue
+++ b/public/components/DrillDown.vue
@@ -183,6 +183,15 @@ export default Vue.extend({
           t.coordinates as LatLngBoundsLiteral
         ).getCenter();
         const indices = this.getIndex(center.lng, center.lat);
+        if (
+          indices.x < 0 ||
+          indices.y < 0 ||
+          indices.x >= this.cols ||
+          indices.y >= this.rows
+        ) {
+          // tile outside defined area
+          return;
+        }
         const invertY = this.rows - 1 - indices.y;
         result[invertY][indices.x].selected = t;
         result[invertY][indices.x].overlapped.push(t);


### PR DESCRIPTION
closes #2294

Recently the geo bounds query has changed from ST_WITHIN to ST_INTERSECTS.
This change dealt with buckets not filling correctly.
The issue with the map is it still assumed ST_WITHIN
- Changed the drilldown to just drop any tiles supplied that are not within the supplied bounds (more future proof depending on if the underlying query changes)