### PR TITLE
Predict Existing Dataset Prefeaturized

### DIFF
--- a/api/compute/filter.go
+++ b/api/compute/filter.go
@@ -173,7 +173,8 @@ func preparePrefilteringDataset(outputFolder string, sourceDataset *api.Dataset,
 
 	// if learning dataset, then update that
 	if sourceDataset.LearningDataset != "" {
-		return UpdatePrefeaturizedDataset(outputFolder, sourceDataset.LearningDataset, sourceDataset, data)
+		// TODO: Figure out if it matters if that last param is true. Currently set to false due to deadline.
+		return UpdatePrefeaturizedDataset(outputFolder, sourceDataset.LearningDataset, sourceDataset, data, false)
 	}
 
 	// read the metadata from disk to keep the reference data resources
@@ -227,7 +228,7 @@ func preparePrefilteringDataset(outputFolder string, sourceDataset *api.Dataset,
 
 // UpdatePrefeaturizedDataset updates a featurized dataset that already exists
 // on disk to have new variables included
-func UpdatePrefeaturizedDataset(outputFolder string, prefeaturizedPath string, sourceDataset *api.Dataset, storedData [][]string) ([]*model.Variable, error) {
+func UpdatePrefeaturizedDataset(outputFolder string, prefeaturizedPath string, sourceDataset *api.Dataset, storedData [][]string, updateMetadata bool) ([]*model.Variable, error) {
 	// copy the prefeaturized dataset to the output folder
 	err := util.Copy(prefeaturizedPath, outputFolder)
 	if err != nil {
@@ -287,6 +288,13 @@ func UpdatePrefeaturizedDataset(outputFolder string, prefeaturizedPath string, s
 			rowComplete := append(row, newDataMap[d3mIndexPre]...)
 			preFeaturizedOutput = append(preFeaturizedOutput, rowComplete)
 		}
+	}
+
+	// make sure the ids and names match
+	if updateMetadata {
+		dsDisk.Metadata.ID = sourceDataset.ID
+		dsDisk.Metadata.Name = sourceDataset.Name
+		dsDisk.Metadata.StorageName = sourceDataset.StorageName
 	}
 
 	// output the new pre featurized data

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -255,7 +255,7 @@ func (d *Parquet) WriteMetadata(uri string, meta *model.Metadata, extended bool,
 
 	// make sure the resource format and path match expected parquet types
 	mainDR := meta.GetMainDataResource()
-	if mainDR.ResFormat[compute.DistilParquetLearningData] == nil {
+	if mainDR.ResFormat[compute.DistilParquetResourceFormat] == nil {
 		if !update {
 			return errors.Errorf("main data resource not set to parquet format")
 		}

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -195,7 +195,7 @@ func updateLearningDataset(newDataset *api.RawDataset, metaDataset *api.Dataset,
 	}
 
 	// copy the learning dataset
-	learningFolder := fmt.Sprintf("%s-featurized", newDataset.Metadata.ID)
+	learningFolder := createFeaturizedDatasetID(newDataset.Metadata.ID)
 	learningFolder = path.Join(path.Dir(parentDS.LearningDataset), learningFolder)
 	err := util.Copy(parentDS.LearningDataset, learningFolder)
 	if err != nil {

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -142,6 +142,7 @@ func ExportDataset(dataset string, metaStorage api.MetadataStorage, dataStorage 
 
 	// need to write the prefeaturized version of the dataset if it exists
 	if metaDataset.ParentDataset != "" {
+		log.Infof("exporting dataset %s that has parent dataset %s", dataset, metaDataset.ParentDataset)
 		parentDS, err := metaStorage.FetchDataset(metaDataset.ParentDataset, false, false, false)
 		if err != nil {
 			return "", "", err
@@ -154,15 +155,24 @@ func ExportDataset(dataset string, metaStorage api.MetadataStorage, dataStorage 
 
 		// read metadata of the parent from disk to get the non main data resources
 		parentDatasetDoc := path.Join(env.ResolvePath(parentDS.Source, parentDS.Folder), compute.D3MDataSchema)
-		metaDisk, err := serialization.ReadMetadata(parentDatasetDoc)
+		parentMetaDisk, err := serialization.ReadMetadata(parentDatasetDoc)
 		if err != nil {
 			return "", "", err
 		}
-		metaDiskMainDR := metaDisk.GetMainDataResource()
-		for _, dr := range metaDisk.DataResources {
-			if dr != metaDiskMainDR {
+		parentMetaDiskMainDR := parentMetaDisk.GetMainDataResource()
+		for _, dr := range parentMetaDisk.DataResources {
+			if dr != parentMetaDiskMainDR {
 				dr.ResPath = model.GetResourcePath(parentDatasetDoc, dr)
 				meta.DataResources = append(meta.DataResources, dr)
+			}
+		}
+
+		// main data resources need to be checked for any resource references
+		parentVariablesMap := apicompute.MapVariables(parentMetaDiskMainDR.Variables, func(variable *model.Variable) string { return variable.Key })
+		for _, v := range dataRaw.Metadata.GetMainDataResource().Variables {
+			parentVar := parentVariablesMap[v.Key]
+			if parentVar != nil && parentVar.RefersTo != nil {
+				v.RefersTo = parentVar.RefersTo
 			}
 		}
 	}
@@ -282,6 +292,7 @@ func CreateDatasetFromResult(newDatasetName string, predictionDataset string, so
 	}
 
 	// need to expand feature set to handle groups
+	varsExpanded := map[string]bool{}
 	varsSource := map[string]*model.Variable{}
 	groups := []*model.Variable{}
 	for _, v := range sourceDS.Variables {
@@ -292,7 +303,14 @@ func CreateDatasetFromResult(newDatasetName string, predictionDataset string, so
 	}
 	featuresExpanded := []string{}
 	for _, f := range features {
-		featuresExpanded = append(featuresExpanded, getComponentVariables(varsSource[f])...)
+		expandedFeature := getComponentVariables(varsSource[f])
+		// make sure each feature is only included once
+		for _, ef := range expandedFeature {
+			if !varsExpanded[ef] {
+				featuresExpanded = append(featuresExpanded, ef)
+				varsExpanded[ef] = true
+			}
+		}
 	}
 
 	// extract the data from the database (result + base)
@@ -350,6 +368,9 @@ func CreateDatasetFromResult(newDatasetName string, predictionDataset string, so
 		return "", err
 	}
 
+	// update the header of the data since the data from the database uses keys as header
+	data[0] = metaDisk.GetMainDataResource().GenerateHeader()
+
 	metaDisk.ID = newDatasetID
 	metaDisk.Name = newDatasetName
 	metaDisk.StorageName = newStorageName
@@ -399,6 +420,17 @@ func CreateDatasetFromResult(newDatasetName string, predictionDataset string, so
 		v.Index = len(newDS.Variables)
 		newDS.Variables = append(newDS.Variables, v)
 	}
+
+	// update prefeaturized dataset based on the source dataset since the target already exists but is blank!
+	if sourceDS.LearningDataset != "" {
+		targetFolder := env.ResolvePath(newDS.Source, createFeaturizedDatasetID(newDatasetID))
+		_, err = apicompute.UpdatePrefeaturizedDataset(targetFolder, sourceDS.GetLearningFolder(), newDS, rawDS.Data, true)
+		if err != nil {
+			return "", err
+		}
+		newDS.LearningDataset = targetFolder
+	}
+
 	err = metaStorage.UpdateDataset(newDS)
 	if err != nil {
 		return "", err

--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -38,6 +38,10 @@ func submitForBatch(pip *description.FullySpecifiedPipeline) func(string) (strin
 	}
 }
 
+func createFeaturizedDatasetID(datasetID string) string {
+	return fmt.Sprintf("%s-featurized", datasetID)
+}
+
 // FeaturizeDataset creates a featurized output of the data that can be used
 // in simplified pipelines.
 func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset string, metaStorage api.MetadataStorage, config *IngestTaskConfig) (string, string, error) {
@@ -71,7 +75,7 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 	}
 
 	// create the dataset folder
-	featurizedDatasetID := fmt.Sprintf("%s-featurized", dataset)
+	featurizedDatasetID := createFeaturizedDatasetID(dataset)
 	featurizedDatasetID, err = GetUniqueOutputFolder(featurizedDatasetID, env.GetAugmentedPath())
 	if err != nil {
 		return "", "", err

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -179,6 +179,164 @@ type PredictParams struct {
 	Config             *env.Config
 }
 
+func createPredictionDatasetID(existingDatasetID string, fittedSolutionID string) string {
+	return model.NormalizeDatasetID(fmt.Sprintf("%s-%s", existingDatasetID, fittedSolutionID))
+}
+
+func cloneDiskDataset(existingFolder string, cloneFolder string, cloneDatasetID string) error {
+	err := util.Copy(existingFolder, cloneFolder)
+	if err != nil {
+		return err
+	}
+	schemaPath := path.Join(cloneFolder, compute.D3MDataSchema)
+	meta, err := metadata.LoadMetadataFromOriginalSchema(schemaPath, false)
+	if err != nil {
+		return err
+	}
+	meta.ID = cloneDatasetID
+	meta.GetMainDataResource().ResPath = path.Join(cloneFolder, compute.D3MDataFolder, compute.D3MLearningData)
+	writer := serialization.GetStorage(meta.GetMainDataResource().ResPath)
+	err = writer.WriteMetadata(schemaPath, meta, false, false)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func cloneDataset(sourceDatasetID string, cloneDatasetID string, cloneFolder string,
+	cloneLearningDataset bool, metaStorage api.MetadataStorage, dataStorage api.DataStorage) error {
+
+	ds, err := metaStorage.FetchDataset(sourceDatasetID, false, false, false)
+	if err != nil {
+		return err
+	}
+
+	folderExisting := env.ResolvePath(ds.Source, ds.Folder)
+	folderClone := env.ResolvePath(metadata.Augmented, cloneDatasetID)
+	storageNameClone, err := dataStorage.GetStorageName(cloneDatasetID)
+	if err != nil {
+		return err
+	}
+
+	err = metaStorage.CloneDataset(sourceDatasetID, cloneDatasetID, storageNameClone, cloneFolder)
+	if err != nil {
+		return err
+	}
+
+	err = dataStorage.CloneDataset(sourceDatasetID, ds.StorageName, cloneDatasetID, storageNameClone)
+	if err != nil {
+		return err
+	}
+
+	// if there is a learning dataset, need to copy it as well and update the metadata
+	if cloneLearningDataset && ds.LearningDataset != "" {
+		cloneLearningFolder := createFeaturizedDatasetID(folderClone)
+		err = cloneDiskDataset(ds.GetLearningFolder(), cloneLearningFolder, cloneDatasetID)
+		if err != nil {
+			return err
+		}
+
+		dsCloned, err := metaStorage.FetchDataset(cloneDatasetID, true, true, true)
+		if err != nil {
+			return err
+		}
+		dsCloned.LearningDataset = cloneLearningFolder
+		err = metaStorage.UpdateDataset(dsCloned)
+		if err != nil {
+			return err
+		}
+	}
+	err = cloneDiskDataset(folderExisting, folderClone, cloneDatasetID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// PrepExistingPredictionDataset sets up an existing dataset to be usable for predictions.
+func PrepExistingPredictionDataset(params *PredictParams) (string, string, error) {
+	// we need to clone the base dataset and use the clone for predictions
+	// otherwise we would be updating the base dataset with new data
+	cloneDatasetID := createPredictionDatasetID(params.Dataset, params.FittedSolutionID)
+	dsCloned, err := params.MetaStorage.FetchDataset(cloneDatasetID, true, true, true)
+	if err != nil {
+		return "", "", err
+	}
+	if dsCloned != nil {
+		// already cloned so assume everything is good to go
+		return cloneDatasetID, dsCloned.GetLearningFolder(), nil
+	}
+
+	dsSource, err := params.MetaStorage.FetchDataset(params.Dataset, true, true, true)
+	if err != nil {
+		return "", "", err
+	}
+	targetFolder := fmt.Sprintf("%s-%s", dsSource.Folder, params.FittedSolutionID)
+	schemaPath := path.Join(targetFolder, compute.D3MDataSchema)
+
+	// clone the base dataset, then add the necessary fields
+	err = cloneDataset(params.Dataset, cloneDatasetID, targetFolder, false, params.MetaStorage, params.DataStorage)
+	if err != nil {
+		return "", "", err
+	}
+
+	// pull the cloned dataset for updates
+	dsCloned, err = params.MetaStorage.FetchDataset(cloneDatasetID, true, true, true)
+	if err != nil {
+		return "", "", err
+	}
+
+	// make sure the dataset on disk has the target variable!
+	// (if performance here becomes an issue, only need data if adding target)
+	dsDisk, err := serialization.ReadDataset(schemaPath)
+	if err != nil {
+		return "", "", err
+	}
+	mainDR := dsDisk.Metadata.GetMainDataResource()
+
+	foundTarget := false
+	for i, v := range mainDR.Variables {
+		if v.Key == params.Target.Key {
+			// not ideal to update the target as a side effect...
+			foundTarget = true
+			params.Target.Index = i
+			break
+		}
+	}
+	if !foundTarget {
+		// not ideal to update the target as a side effect...
+		params.Target.Index = len(mainDR.Variables)
+		mainDR.Variables = append(mainDR.Variables, params.Target)
+
+		// need to append the target to the underlying data
+		for i, row := range dsDisk.Data {
+			dsDisk.Data[i] = append(row, "")
+		}
+		dsCloned.Variables = append(dsCloned.Variables, params.Target)
+		err = serialization.WriteDataset(targetFolder, dsDisk)
+		if err != nil {
+			return "", "", err
+		}
+		err = params.MetaStorage.UpdateDataset(dsCloned)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	// update the learning dataset
+	if dsSource.LearningDataset != "" {
+		targetFolder = createFeaturizedDatasetID(targetFolder)
+		_, err = comp.UpdatePrefeaturizedDataset(targetFolder, dsSource.GetLearningFolder(), dsCloned, dsDisk.Data)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	return cloneDatasetID, targetFolder, nil
+}
+
 // ImportPredictionDataset imports a dataset to be used for predictions.
 func ImportPredictionDataset(params *PredictParams) (string, string, error) {
 	meta := params.Meta
@@ -330,8 +488,7 @@ func IngestPredictionDataset(params *PredictParams) error {
 
 // Predict processes input data to generate predictions.
 func Predict(params *PredictParams) (string, error) {
-	log.Infof("generating predictions for fitted solution ID %s", params.FittedSolutionID)
-	datasetPath := path.Join(params.OutputPath, params.Dataset)
+	log.Infof("generating predictions for fitted solution ID %s found at '%s'", params.FittedSolutionID, params.SchemaPath)
 	schemaPath := params.SchemaPath
 	datasetName := params.Dataset
 
@@ -342,7 +499,7 @@ func Predict(params *PredictParams) (string, error) {
 		return "", errors.Wrap(err, "unable to read latest dataset doc")
 	}
 	meta.ID = params.SourceDatasetID
-	datasetStorage := serialization.GetStorage(schemaPath)
+	datasetStorage := serialization.GetStorage(meta.GetMainDataResource().ResPath)
 	err = datasetStorage.WriteMetadata(schemaPath, meta, true, false)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to update dataset doc")
@@ -368,8 +525,8 @@ func Predict(params *PredictParams) (string, error) {
 	}
 
 	// submit the new dataset for predictions
-	log.Infof("generating predictions using data found at '%s'", datasetPath)
-	predictionResult, err := comp.GeneratePredictions(datasetPath, solution.SolutionID, params.FittedSolutionID, client)
+	log.Infof("generating predictions using data found at '%s'", params.SchemaPath)
+	predictionResult, err := comp.GeneratePredictions(params.SchemaPath, solution.SolutionID, params.FittedSolutionID, client)
 	if err != nil {
 		return "", err
 	}
@@ -607,6 +764,7 @@ func createComposedFields(data []*api.FilteredDataValue, fields []string, mapped
 	}
 	return strings.Join(dataToJoin, separator)
 }
+
 func createClassification(params *PredictParams, datasetPath string, variables []*model.Variable) error {
 	outputPath := path.Join(datasetPath, params.Config.ClassificationOutputPath)
 	log.Info("writing predicted dataset type classification to file")
@@ -618,6 +776,7 @@ func createClassification(params *PredictParams, datasetPath string, variables [
 	}
 	return nil
 }
+
 func updateMetaDataTypes(solutionStorage api.SolutionStorage, metaStorage api.MetadataStorage,
 	dataStorage api.DataStorage, meta *model.Metadata, fittedSolutionID string, dataset string, storageName string) []*model.Variable {
 	variables := meta.GetMainDataResource().Variables

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -311,7 +311,8 @@ func PrepExistingPredictionDataset(params *PredictParams) (string, string, error
 		mainDR.Variables = append(mainDR.Variables, params.Target)
 
 		// need to append the target to the underlying data
-		for i, row := range dsDisk.Data {
+		dsDisk.Data[0] = append(dsDisk.Data[0], params.Target.HeaderName)
+		for i, row := range dsDisk.Data[1:] {
 			dsDisk.Data[i] = append(row, "")
 		}
 		dsCloned.Variables = append(dsCloned.Variables, params.Target)

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -156,10 +156,8 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 	filePaths := []string{}
 	if bandCombo, ok := SentinelBandCombinations[strings.ToLower(string(bandCombination))]; ok {
 		for _, bandLabel := range bandCombo.Mapping {
-			log.Infof("BAND LABEL: %v", bandLabel)
 			filePaths = append(filePaths, path.Join(datasetDir, bandFileMapping[bandLabel]))
 		}
-		log.Infof("FILE PATHS: %v", filePaths)
 		return ImageFromBands(filePaths, bandCombo.Ramp, bandCombo.Transform, imageScale, options...)
 	}
 

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -501,13 +501,12 @@ func createPredictionDataset(requestTask *api.Task, request *api.PredictRequest,
 func getPredictionDataset(requestTask *api.Task, request *api.PredictRequest, predictParams *task.PredictParams) (string, string, error) {
 	// check if the dataset already exists
 	if request.ExistingDataset {
-		// read path from metadata storage
-		ds, err := predictParams.MetaStorage.FetchDataset(request.DatasetID, true, true, true)
+		clonedID, clonedPath, err := task.PrepExistingPredictionDataset(predictParams)
 		if err != nil {
 			return "", "", err
 		}
 
-		return ds.ID, path.Join(env.ResolvePath(ds.Source, ds.Folder), compute.D3MDataSchema), nil
+		return clonedID, path.Join(clonedPath, compute.D3MDataSchema), nil
 	}
 
 	// ingest the data as a new prediction dataset


### PR DESCRIPTION
Running predictions on an existing dataset requires cloning (including of any prefeaturization) as well as adding of the target variable if it does not already exist. There is a lot of duplication of code between this and other areas in part due to having very slight differences in needed behaviour and not wanting to risk causing other parts of the system to come crashing down.

In doing these changes, the result extraction was also updated to handle geometry fields properly and fix was done when handling parquet datasets.