### PR TITLE
temporarily disable outlier detection

### DIFF
--- a/api/routes/outlier_detecting.go
+++ b/api/routes/outlier_detecting.go
@@ -42,44 +42,44 @@ type OutlierResult struct {
 // Return the name of the variable if the detection has run successfully.
 func OutlierDetectionHandler(metaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		dataset := pat.Param(r, "dataset")
-		variable := pat.Param(r, "variable")
+		// dataset := pat.Param(r, "dataset")
+		// variable := pat.Param(r, "variable")
 
-		// get storage clients
-		metaStorage, err := metaCtor()
-		if err != nil {
-			handleError(w, err)
-			return
-		}
+		// // get storage clients
+		// metaStorage, err := metaCtor()
+		// if err != nil {
+		// 	handleError(w, err)
+		// 	return
+		// }
 
-		// get the metadata
-		datasetMeta, err := metaStorage.FetchDataset(dataset, false, false, false)
-		if err != nil {
-			handleError(w, err)
-			return
-		}
+		// // get the metadata
+		// datasetMeta, err := metaStorage.FetchDataset(dataset, false, false, false)
+		// if err != nil {
+		// 	handleError(w, err)
+		// 	return
+		// }
 
-		// find the outliers in the dataset
-		outlierData, err := task.OutlierDetection(datasetMeta, variable)
-		if err != nil {
-			handleError(w, err)
-			return
-		}
+		// // find the outliers in the dataset
+		// outlierData, err := task.OutlierDetection(datasetMeta, variable)
+		// if err != nil {
+		// 	handleError(w, err)
+		// 	return
+		// }
 
 		// create a result
 		result := OutlierResult{
 			OutlierSuccess: false,
 		}
 
-		if outlierData != nil {
-			result = OutlierResult{
-				OutlierSuccess: true,
-				OutlierField:   outlierVarName,
-			}
-		}
+		// if outlierData != nil {
+		// 	result = OutlierResult{
+		// 		OutlierSuccess: true,
+		// 		OutlierField:   outlierVarName,
+		// 	}
+		// }
 
 		// marshal output into JSON
-		err = handleJSON(w, result)
+		err := handleJSON(w, result)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal outlier variable name into JSON"))
 			return


### PR DESCRIPTION
Disabling outlier detection temporarily due to perf concerns during demo