### PR TITLE
updated icon and label view divider lines

### DIFF
--- a/public/components/labelingComponents/LabelAnnotation.vue
+++ b/public/components/labelingComponents/LabelAnnotation.vue
@@ -1,5 +1,8 @@
 <template>
-  <i :class="getLabel" aria-hidden="true"></i>
+  <span class="stacked-icons">
+    <i v-if="shouldRender" class="fa fa-circle fa-stack-1x p-1" />
+    <i :class="getLabel" />
+  </span>
 </template>
 
 <script lang="ts">
@@ -14,15 +17,18 @@ export default Vue.extend({
     getLabel(): string {
       switch (this.item[LOW_SHOT_LABEL_COLUMN_NAME].value) {
         case LowShotLabels.positive:
-          return "fa fa-check text-success p-1";
+          return "fa fa-plus-circle text-success p-1 fa-stack-1x";
           break;
         case LowShotLabels.negative:
-          return "fa fa-times red p-1";
+          return "fa fa-minus-circle red p-1 fa-stack-1x";
           break;
         default:
           return "d-none";
           break;
       }
+    },
+    shouldRender(): boolean {
+      return this.getLabel !== "d-none";
     },
   },
 });
@@ -31,5 +37,13 @@ export default Vue.extend({
 <style scoped>
 .red {
   color: var(--red);
+}
+.stacked-icons {
+  position: relative;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  line-height: 1em;
+  vertical-align: middle;
 }
 </style>

--- a/public/components/labelingComponents/LabelHeaderButtons.vue
+++ b/public/components/labelingComponents/LabelHeaderButtons.vue
@@ -7,14 +7,20 @@
       title="Annotate selected items to positive"
       @click="onButtonClick(positive)"
     >
-      <i class="fa fa-check text-success" aria-hidden="true"></i>
+      <span class="stacked-icons">
+        <i class="fa fa-circle fa-stack-1x" />
+        <i class="fa fa-plus-circle text-success fa-stack-1x" />
+      </span>
       Positive
     </b-button>
     <b-button
       title="Annotate selected items to negative"
       @click="onButtonClick(negative)"
     >
-      <i class="fa fa-times red" aria-hidden="true"></i>
+      <span class="stacked-icons">
+        <i class="fa fa-circle fa-stack-1x" />
+        <i class="fa fa-minus-circle red fa-stack-1x" />
+      </span>
       Negative</b-button
     >
     <b-button
@@ -64,5 +70,13 @@ export default Vue.extend({
 <style scoped>
 .red {
   color: var(--red);
+}
+.stacked-icons {
+  position: relative;
+  display: inline-block;
+  width: 2em;
+  height: 1em;
+  line-height: 1em;
+  vertical-align: middle;
 }
 </style>

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -4,7 +4,7 @@
     <div
       class="col-12 col-md-3 d-flex h-100 flex-column border-right border-color"
     >
-      <h5 class="header-title">Labels</h5>
+      <h5 class="header-title border-bottom border-color">Labels</h5>
       <variable-facets
         enable-highlighting
         enable-type-filtering
@@ -12,7 +12,7 @@
         :instance-name="instance"
         class="h-18"
       />
-      <h5 class="header-title">Features</h5>
+      <h5 class="header-title border-bottom border-color">Features</h5>
       <variable-facets
         enable-highlighting
         enable-type-filtering
@@ -45,7 +45,7 @@
     <div
       class="col-12 col-md-3 d-flex h-100 flex-column border-left border-color"
     >
-      <h5 class="header-title">Scores</h5>
+      <h5 class="header-title border-bottom border-color">Scores</h5>
       <variable-facets
         enable-highlighting
         enable-type-filtering
@@ -509,6 +509,6 @@ export default Vue.extend({
   height: 18% !important;
 }
 .border-color {
-  border-color: var(--gray-500) !important;
+  border-color: #e0e0e0 !important;
 }
 </style>


### PR DESCRIPTION
divider lines are now the same as the result view

![Screenshot from 2021-02-24 16-22-55](https://user-images.githubusercontent.com/25306965/109067642-c79fcd00-76bc-11eb-9635-973fa3c982c3.png)
