### PR TITLE
Dataset Prediction Cloning Naming

### DIFF
--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -210,7 +210,9 @@ func (d *RawDataset) AddField(variable *model.Variable) error {
 	if d.FieldExists(variable) {
 		return errors.Errorf("field '%s' already exists in the raw dataset", variable.Key)
 	}
-	d.Metadata.GetMainDataResource().Variables = append(d.Metadata.GetMainDataResource().Variables, variable)
+	clone := variable.Clone()
+	clone.Index = len(d.Metadata.GetMainDataResource().Variables)
+	d.Metadata.GetMainDataResource().Variables = append(d.Metadata.GetMainDataResource().Variables, clone)
 
 	// the first row is the header row
 	d.Data[0] = append(d.Data[0], variable.HeaderName)

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -197,6 +197,68 @@ func (d *Dataset) GetLearningFolder() string {
 	return env.ResolvePath(d.Source, d.Folder)
 }
 
+// SyncMetadata updates the key metadata properties to match a given metadata.
+// This is often use to update the metadata for prediction or prefeaturization purposes.
+func (d *RawDataset) SyncMetadata(metaToSync *model.Metadata) {
+	d.Metadata.ID = metaToSync.ID
+	d.Metadata.Name = metaToSync.Name
+	d.Metadata.StorageName = metaToSync.StorageName
+}
+
+// AddField adds a field to the dataset, updating both the data and the metadata.
+func (d *RawDataset) AddField(variable *model.Variable) error {
+	if d.FieldExists(variable) {
+		return errors.Errorf("field '%s' already exists in the raw dataset", variable.Key)
+	}
+	d.Metadata.GetMainDataResource().Variables = append(d.Metadata.GetMainDataResource().Variables, variable)
+
+	// the first row is the header row
+	d.Data[0] = append(d.Data[0], variable.HeaderName)
+	for i, row := range d.Data[1:] {
+		d.Data[i+1] = append(row, "")
+	}
+
+	return nil
+}
+
+// FieldExists returns true if a field is already part of the metadata.
+func (d *RawDataset) FieldExists(variable *model.Variable) bool {
+	for _, v := range d.Metadata.GetMainDataResource().Variables {
+		if v.Key == variable.Key {
+			return true
+		}
+	}
+
+	return false
+}
+
+// GetVariableIndex returns the index of the variable as found in the header
+// or -1 if not found in the header.
+func (d *RawDataset) GetVariableIndex(variableHeaderName string) int {
+	for i, f := range d.Data[0] {
+		if f == variableHeaderName {
+			return i
+		}
+	}
+
+	return -1
+}
+
+// GetVariableIndices returns the mapping of variable header name to header index.
+// It will error if a field is not found in the header.
+func (d *RawDataset) GetVariableIndices(variableHeaderNames []string) (map[string]int, error) {
+	indices := map[string]int{}
+	for _, v := range variableHeaderNames {
+		varIndex := d.GetVariableIndex(v)
+		if varIndex == -1 {
+			return nil, errors.Errorf("variable '%s' does not exist in header", v)
+		}
+		indices[v] = varIndex
+	}
+
+	return indices, nil
+}
+
 // UpdateExtremas updates the variable extremas based on the data stored.
 func UpdateExtremas(dataset string, varName string, storageMeta MetadataStorage, storageData DataStorage) error {
 	// get the metadata and then query the data storage for the latest values

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -149,7 +149,7 @@ func FetchDataset(dataset string, includeIndex bool, includeMeta bool, filterPar
 // GetD3MIndexVariable returns the D3M index variable.
 func (d *Dataset) GetD3MIndexVariable() *model.Variable {
 	for _, v := range d.Variables {
-		if v.Key == model.D3MIndexName {
+		if v.Key == model.D3MIndexFieldName {
 			return v
 		}
 	}

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -732,14 +732,14 @@ func (s *Storage) UpdateVariableBatch(storageName string, varName string, update
 	// loop through the updates, building batches to minimize overhead
 	tableNameTmp := fmt.Sprintf("%s_utmp", storageName)
 	dataSQL := fmt.Sprintf("CREATE TEMP TABLE \"%s\" (\"%s\" TEXT NOT NULL, \"%s\" TEXT) ON COMMIT DROP;",
-		tableNameTmp, model.D3MIndexName, varName)
+		tableNameTmp, model.D3MIndexFieldName, varName)
 	_, err = tx.Exec(context.Background(), dataSQL)
 	if err != nil {
 		_ = tx.Rollback(context.Background())
 		return errors.Wrap(err, "unable to create temp table")
 	}
 
-	err = s.insertBulkCopyTransaction(tx, tableNameTmp, []string{model.D3MIndexName, varName}, params)
+	err = s.insertBulkCopyTransaction(tx, tableNameTmp, []string{model.D3MIndexFieldName, varName}, params)
 	if err != nil {
 		_ = tx.Rollback(context.Background())
 		return errors.Wrap(err, "unable to insert into temp table")
@@ -747,7 +747,7 @@ func (s *Storage) UpdateVariableBatch(storageName string, varName string, update
 
 	// run the update
 	updateSQL := fmt.Sprintf("UPDATE %s.%s.\"%s_base\" AS b SET \"%s\" = t.\"%s\" FROM \"%s\" AS t WHERE t.\"%s\" = b.\"%s\";",
-		"distil", "public", storageName, varName, varName, tableNameTmp, model.D3MIndexName, model.D3MIndexName)
+		"distil", "public", storageName, varName, varName, tableNameTmp, model.D3MIndexFieldName, model.D3MIndexFieldName)
 	_, err = tx.Exec(context.Background(), updateSQL)
 	if err != nil {
 		_ = tx.Rollback(context.Background())
@@ -780,21 +780,21 @@ func (s *Storage) UpdateData(dataset string, storageName string, varName string,
 
 	tableNameTmp := fmt.Sprintf("%s_utmp", storageName)
 	dataSQL := fmt.Sprintf("CREATE TEMP TABLE \"%s\" (\"%s\" TEXT NOT NULL, \"%s\" TEXT) ON COMMIT DROP;",
-		tableNameTmp, model.D3MIndexName, varName)
+		tableNameTmp, model.D3MIndexFieldName, varName)
 	_, err = tx.Exec(context.Background(), dataSQL)
 	if err != nil {
 		_ = tx.Rollback(context.Background())
 		return errors.Wrap(err, "unable to create temp table")
 	}
 
-	err = s.insertBulkCopyTransaction(tx, tableNameTmp, []string{model.D3MIndexName, varName}, params)
+	err = s.insertBulkCopyTransaction(tx, tableNameTmp, []string{model.D3MIndexFieldName, varName}, params)
 	if err != nil {
 		_ = tx.Rollback(context.Background())
 		return errors.Wrap(err, "unable to insert into temp table")
 	}
 
 	// build the filter structure
-	wheres := []string{fmt.Sprintf("t.\"%s\" = b.\"%s\"::text", model.D3MIndexName, model.D3MIndexName)}
+	wheres := []string{fmt.Sprintf("t.\"%s\" = b.\"%s\"::text", model.D3MIndexFieldName, model.D3MIndexFieldName)}
 	paramsFilter := make([]interface{}, 0)
 	wheres, paramsFilter = s.buildFilteredQueryWhere(dataset, wheres, paramsFilter, "b", filterParams, false)
 

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -167,7 +167,7 @@ func (s *Storage) PersistExplainedResult(dataset string, storageName string, res
 
 	tableNameTmp := fmt.Sprintf("%s_utmp", storageName)
 	dataSQL := fmt.Sprintf("CREATE TEMP TABLE \"%s\" (\"%s\" TEXT NOT NULL, \"%s\" JSONB) ON COMMIT DROP;",
-		tableNameTmp, model.D3MIndexName, fieldName)
+		tableNameTmp, model.D3MIndexFieldName, fieldName)
 	_, err = tx.Exec(context.Background(), dataSQL)
 	if err != nil {
 		if rbErr := tx.Rollback(context.Background()); rbErr != nil {
@@ -176,7 +176,7 @@ func (s *Storage) PersistExplainedResult(dataset string, storageName string, res
 		return errors.Wrap(err, "unable to create temp table")
 	}
 
-	err = s.insertBulkCopyTransaction(tx, tableNameTmp, []string{model.D3MIndexName, fieldName}, params)
+	err = s.insertBulkCopyTransaction(tx, tableNameTmp, []string{model.D3MIndexFieldName, fieldName}, params)
 	if err != nil {
 		if rbErr := tx.Rollback(context.Background()); rbErr != nil {
 			log.Error("rollback failed")
@@ -186,7 +186,7 @@ func (s *Storage) PersistExplainedResult(dataset string, storageName string, res
 
 	// build the filter structure
 	wheres := []string{
-		fmt.Sprintf("t.\"%s\" = b.index::text", model.D3MIndexName),
+		fmt.Sprintf("t.\"%s\" = b.index::text", model.D3MIndexFieldName),
 		"b.\"result_id\" = $1",
 	}
 	paramsFilter := []interface{}{resultURI}

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -187,7 +187,7 @@ func Cluster(dataset *api.Dataset, variable string, useKMeans bool) (bool, []*Cl
 		// cluster label may be returned with target name
 		clusterIndex = getFieldIndex(header, variable)
 	}
-	d3mIndexIndex := getFieldIndex(header, model.D3MIndexName)
+	d3mIndexIndex := getFieldIndex(header, model.D3MIndexFieldName)
 	if clusterIndex == -1 && len(header) == 2 {
 		// default to second column
 		clusterIndex = (d3mIndexIndex + 1) % 2

--- a/api/task/geocoding.go
+++ b/api/task/geocoding.go
@@ -166,7 +166,7 @@ func GeocodeForward(datasetInputDir string, dataset string, variable *model.Vari
 
 	latIndex := getFieldIndex(header, fmt.Sprintf("%s_latitude", variable.HeaderName))
 	lonIndex := getFieldIndex(header, fmt.Sprintf("%s_longitude", variable.HeaderName))
-	d3mIndexIndex := getFieldIndex(header, model.D3MIndexName)
+	d3mIndexIndex := getFieldIndex(header, model.D3MIndexFieldName)
 	for i, v := range res {
 		lat := v[latIndex].(string)
 		lon := v[lonIndex].(string)

--- a/api/task/outlier_detection.go
+++ b/api/task/outlier_detection.go
@@ -113,10 +113,10 @@ func OutlierDetection(dataset *api.Dataset, variable string) ([]*OutlierPoint, e
 
 	outlierLabelIndex := getFieldIndex(header, "outlier_label")
 	if outlierLabelIndex == -1 {
-		// cluster label may be returned with target name
+		// outlier label may be returned with target name
 		outlierLabelIndex = getFieldIndex(header, variable)
 	}
-	d3mIndex := getFieldIndex(header, model.D3MIndexName)
+	d3mIndex := getFieldIndex(header, model.D3MIndexFieldName)
 	if outlierLabelIndex == -1 && len(header) == 2 {
 		// default to second column
 		outlierLabelIndex = (d3mIndex + 1) % 2

--- a/api/task/pipelines.go
+++ b/api/task/pipelines.go
@@ -161,7 +161,7 @@ func getClusterVariables(meta *model.Metadata, prefix string) ([]*FeatureRequest
 func getD3MIndexField(dr *model.DataResource) int {
 	d3mIndexField := -1
 	for _, v := range dr.Variables {
-		if v.Key == model.D3MIndexName {
+		if v.Key == model.D3MIndexFieldName {
 			d3mIndexField = v.Index
 		}
 	}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -645,7 +645,7 @@ func augmentPredictionDataset(csvData [][]string, sourceVariables []*model.Varia
 				log.Warnf("field '%s' not found in source dataset - column will be empty", predictVariable.Key)
 				predictVariablesMap[i] = -1
 			}
-			if predictVariable.Key == model.D3MIndexName {
+			if predictVariable.Key == model.D3MIndexFieldName {
 				addIndex = false
 			}
 		}
@@ -662,7 +662,7 @@ func augmentPredictionDataset(csvData [][]string, sourceVariables []*model.Varia
 
 	// read the d3m field index if present
 	d3mFieldIndex := -1
-	if variable, ok := sourceVariableMap[strings.ToLower(model.D3MIndexName)]; ok {
+	if variable, ok := sourceVariableMap[strings.ToLower(model.D3MIndexFieldName)]; ok {
 		d3mFieldIndex = variable.Index
 	}
 
@@ -723,7 +723,7 @@ func CreateComposedVariable(metaStorage api.MetadataStorage, dataStorage api.Dat
 		// No grouping column - just use the d3mIndex as we'll just stick some placeholder
 		// data in.
 		filter = &api.FilterParams{
-			Variables: []string{model.D3MIndexName},
+			Variables: []string{model.D3MIndexFieldName},
 		}
 	}
 	rawData, err := dataStorage.FetchData(dataset, storageName, filter, false, false, nil)
@@ -736,7 +736,7 @@ func CreateComposedVariable(metaStorage api.MetadataStorage, dataStorage api.Dat
 	d3mIndexFieldindex := -1
 	colNameToIdx := make(map[string]int)
 	for i, c := range rawData.Columns {
-		if c.Label == model.D3MIndexName {
+		if c.Label == model.D3MIndexFieldName {
 			d3mIndexFieldindex = i
 		} else {
 			colNameToIdx[c.Label] = i

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -307,7 +307,7 @@ func PrepExistingPredictionDataset(params *PredictParams) (string, string, error
 		}
 		dsCloned.LearningDataset = learningFolder
 
-		dsLearning, err := serialization.ReadDataset(path.Join(learningFolder, compute.D3MDataSchema))
+		dsLearning, err = serialization.ReadDataset(path.Join(learningFolder, compute.D3MDataSchema))
 		if err != nil {
 			return "", "", err
 		}

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -296,6 +296,24 @@ func PrepExistingPredictionDataset(params *PredictParams) (string, string, error
 	}
 	mainDR := dsDisk.Metadata.GetMainDataResource()
 
+	// update the learning dataset
+	learningFolder := targetFolder
+	var dsLearning *api.RawDataset
+	if dsSource.LearningDataset != "" {
+		learningFolder = createFeaturizedDatasetID(learningFolder)
+		err := util.Copy(dsSource.GetLearningFolder(), learningFolder)
+		if err != nil {
+			return "", "", err
+		}
+		dsCloned.LearningDataset = learningFolder
+
+		dsLearning, err := serialization.ReadDataset(path.Join(learningFolder, compute.D3MDataSchema))
+		if err != nil {
+			return "", "", err
+		}
+		dsLearning.SyncMetadata(dsCloned.ToMetadata())
+	}
+
 	foundTarget := false
 	for i, v := range mainDR.Variables {
 		if v.Key == params.Target.Key {
@@ -308,13 +326,20 @@ func PrepExistingPredictionDataset(params *PredictParams) (string, string, error
 	if !foundTarget {
 		// not ideal to update the target as a side effect...
 		params.Target.Index = len(mainDR.Variables)
-		mainDR.Variables = append(mainDR.Variables, params.Target)
+		err = dsDisk.AddField(params.Target)
+		if err != nil {
+			return "", "", err
+		}
+
+		// add it to the prefeaturized dataset
+		if dsLearning != nil {
+			err = dsLearning.AddField(params.Target)
+			if err != nil {
+				return "", "", err
+			}
+		}
 
 		// need to append the target to the underlying data
-		dsDisk.Data[0] = append(dsDisk.Data[0], params.Target.HeaderName)
-		for i, row := range dsDisk.Data[1:] {
-			dsDisk.Data[i+1] = append(row, "")
-		}
 		dsCloned.Variables = append(dsCloned.Variables, params.Target)
 		err = serialization.WriteDataset(targetFolder, dsDisk)
 		if err != nil {
@@ -327,23 +352,20 @@ func PrepExistingPredictionDataset(params *PredictParams) (string, string, error
 			return "", "", err
 		}
 	}
-
-	// update the learning dataset
-	if dsSource.LearningDataset != "" {
-		targetFolder = createFeaturizedDatasetID(targetFolder)
-		_, err = comp.UpdatePrefeaturizedDataset(targetFolder, dsSource.GetLearningFolder(), dsCloned, dsDisk.Data, true)
-		if err != nil {
-			return "", "", err
-		}
-		dsCloned.LearningDataset = targetFolder
-	}
 	dsCloned.Type = api.DatasetTypeInference
 	err = params.MetaStorage.UpdateDataset(dsCloned)
 	if err != nil {
 		return "", "", err
 	}
 
-	return cloneDatasetID, targetFolder, nil
+	if dsLearning != nil {
+		err = serialization.WriteDataset(learningFolder, dsLearning)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	return cloneDatasetID, learningFolder, nil
 }
 
 // ImportPredictionDataset imports a dataset to be used for predictions.

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210222122537-5b7d569fcaef
+	github.com/uncharted-distil/distil-compute v0.0.0-20210226143458-81bf44f5636b
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210222122537-5b7d569fcaef h1:hQ58Bi5DpeYpgjkwHy4ah8jNMFXdEBoM1MQNf3SzDnk=
-github.com/uncharted-distil/distil-compute v0.0.0-20210222122537-5b7d569fcaef/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210226143458-81bf44f5636b h1:8VojNSO9/OtYCPas7cq1qUkgf//t/pHoWbr5QV2YvzU=
+github.com/uncharted-distil/distil-compute v0.0.0-20210226143458-81bf44f5636b/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=


### PR DESCRIPTION
Start of the cleanup of the code for predicting on an existing dataset. Removed a side effect of updating targets. Also started the process of reorganizing code that handles prefeaturized dataset and adding fields to datasets on disk.

The reference to the removed duplicate d3m index field name was switched for the remaining constant.