### PR TITLE
Timeseries Creation

### DIFF
--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -713,19 +713,13 @@ func CreateComposedVariable(metaStorage api.MetadataStorage, dataStorage api.Dat
 	}
 
 	composedData := map[string]string{}
-	var filter *api.FilterParams
-	if len(sourceVarNames) > 0 {
-		// Fetch data using the source names as the filter
-		filter = &api.FilterParams{
-			Variables: sourceVarNames,
-		}
-	} else {
-		// No grouping column - just use the d3mIndex as we'll just stick some placeholder
-		// data in.
-		filter = &api.FilterParams{
-			Variables: []string{model.D3MIndexName},
-		}
+	// No grouping column - just use the d3mIndex as we'll just stick some placeholder
+	// data in.
+	filter := &api.FilterParams{
+		Variables: []string{model.D3MIndexName},
 	}
+	// Fetch data using the source names as the filter
+	filter.Variables = append(filter.Variables, sourceVarNames...)
 	rawData, err := dataStorage.FetchData(dataset, storageName, filter, false, false, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
It looks like at some point the d3m index stopped being returned by default from the data fetch. Or some related change was made. Either way, the d3m index field was added in querying for grouping values when building a timeseries (really any component variable, but currently only called by timeseries).