### PR TITLE
Prediction & Cloning Cleanup

### DIFF
--- a/api/serialization/csv.go
+++ b/api/serialization/csv.go
@@ -74,7 +74,6 @@ func (d *CSV) WriteDataset(uri string, data *api.RawDataset) error {
 		return err
 	}
 
-	data.Metadata.GetMainDataResource().ResPath = dataFilename
 	metaFilename := path.Join(uri, compute.D3MDataSchema)
 	err = d.WriteMetadata(metaFilename, data.Metadata, true, true)
 	if err != nil {
@@ -137,7 +136,11 @@ func (d *CSV) WriteMetadata(uri string, meta *model.Metadata, extended bool, upd
 		mainDR.ResPath = fmt.Sprintf("%s.csv", strings.TrimSuffix(mainDR.ResPath, path.Ext(mainDR.ResPath)))
 	}
 	for _, dr := range meta.DataResources {
-		dataResources = append(dataResources, d.writeDataResource(dr, extended))
+		mapped := d.writeDataResource(dr, extended)
+		if dr == mainDR {
+			mapped["resPath"] = path.Join(path.Dir(uri), compute.D3MDataFolder, compute.D3MLearningData)
+		}
+		dataResources = append(dataResources, mapped)
 	}
 
 	about := map[string]interface{}{

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -77,7 +77,6 @@ func (d *Parquet) WriteDataset(uri string, data *api.RawDataset) error {
 		return err
 	}
 
-	data.Metadata.GetMainDataResource().ResPath = dataFilename
 	metaFilename := path.Join(uri, compute.D3MDataSchema)
 	err = d.WriteMetadata(metaFilename, data.Metadata, true, true)
 	if err != nil {
@@ -263,7 +262,11 @@ func (d *Parquet) WriteMetadata(uri string, meta *model.Metadata, extended bool,
 		mainDR.ResPath = fmt.Sprintf("%s.parquet", strings.TrimSuffix(mainDR.ResPath, path.Ext(mainDR.ResPath)))
 	}
 	for _, dr := range meta.DataResources {
-		dataResources = append(dataResources, d.writeDataResource(dr, extended))
+		mapped := d.writeDataResource(dr, extended)
+		if dr == mainDR {
+			mapped["resPath"] = path.Join(path.Dir(uri), compute.D3MDataFolder, compute.DistilParquetLearningData)
+		}
+		dataResources = append(dataResources, mapped)
 	}
 
 	about := map[string]interface{}{

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -60,6 +60,12 @@ func WriteData(uri string, data [][]string) error {
 	return store.WriteData(uri, data)
 }
 
+// WriteMetadata writes the metadata to disk.
+func WriteMetadata(uri string, metadata *model.Metadata) error {
+	store := GetStorage(metadata.GetMainDataResource().ResPath)
+	return store.WriteMetadata(uri, metadata, true, true)
+}
+
 // GetCSVStorage returns the instantiated csv storage.
 func GetCSVStorage() Storage {
 	return csvStorage

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -34,9 +34,108 @@ import (
 	"github.com/uncharted-distil/distil/api/util"
 )
 
+// DiskDataset represents a dataset stored on disk.
+type DiskDataset struct {
+	Dataset           *api.RawDataset
+	FeaturizedDataset *DiskDataset
+	schemaPath        string
+}
+
 // DatasetConstructor is used to build a dataset.
 type DatasetConstructor interface {
 	CreateDataset(rootDataPath string, datasetName string, config *env.Config) (*api.RawDataset, error)
+}
+
+func loadDiskDataset(ds *api.Dataset) (*DiskDataset, error) {
+	folder := env.ResolvePath(ds.Source, ds.Folder)
+	output, err := loadDiskDatasetFromFolder(folder)
+	if err != nil {
+		return nil, err
+	}
+
+	if ds.LearningDataset != "" {
+		pre, err := loadDiskDatasetFromFolder(ds.LearningDataset)
+		if err != nil {
+			return nil, err
+		}
+		output.FeaturizedDataset = pre
+	}
+
+	return output, nil
+}
+
+func loadDiskDatasetFromFolder(folder string) (*DiskDataset, error) {
+	schemaPath := path.Join(folder, compute.D3MDataSchema)
+	dsDisk, err := serialization.ReadDataset(schemaPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DiskDataset{
+		Dataset:    dsDisk,
+		schemaPath: schemaPath,
+	}, nil
+}
+
+func (d *DiskDataset) addField(variable *model.Variable) error {
+	err := d.Dataset.AddField(variable)
+	if err != nil {
+		return err
+	}
+
+	if d.FeaturizedDataset != nil {
+		err = d.FeaturizedDataset.addField(variable)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *DiskDataset) clone(targetFolder string, cloneDatasetID string, cloneStorageName string) (*DiskDataset, error) {
+	// easiest clone is to write the dataset to the new location then read it
+	err := serialization.WriteDataset(targetFolder, d.Dataset)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaPath := path.Join(targetFolder, compute.D3MDataSchema)
+	cloned, err := serialization.ReadDataset(schemaPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// update the metadata
+	cloned.Metadata.ID = cloneDatasetID
+	cloned.Metadata.StorageName = cloneStorageName
+	err = serialization.WriteMetadata(schemaPath, cloned.Metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &DiskDataset{
+		Dataset:    cloned,
+		schemaPath: schemaPath,
+	}
+
+	if d.FeaturizedDataset != nil {
+		clonedPrefeaturized, err := d.FeaturizedDataset.clone(fmt.Sprintf("%s-featurized", targetFolder), cloneDatasetID, cloneStorageName)
+		if err != nil {
+			return nil, err
+		}
+		output.FeaturizedDataset = clonedPrefeaturized
+	}
+
+	return output, nil
+}
+
+func (d *DiskDataset) getLearningFolder() string {
+	if d.FeaturizedDataset != nil {
+		return d.FeaturizedDataset.getLearningFolder()
+	}
+
+	return path.Dir(d.schemaPath)
 }
 
 // CreateDataset structures a raw csv file into a valid D3M dataset.

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -77,6 +77,22 @@ func loadDiskDatasetFromFolder(folder string) (*DiskDataset, error) {
 	}, nil
 }
 
+func (d *DiskDataset) saveDataset() error {
+	err := serialization.WriteDataset(path.Dir(d.schemaPath), d.Dataset)
+	if err != nil {
+		return err
+	}
+
+	if d.FeaturizedDataset != nil {
+		err = d.FeaturizedDataset.saveDataset()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (d *DiskDataset) addField(variable *model.Variable) error {
 	err := d.Dataset.AddField(variable)
 	if err != nil {

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -183,7 +183,8 @@ func createPredictionDatasetID(existingDatasetID string, fittedSolutionID string
 	return fmt.Sprintf("%s-%s", existingDatasetID, fittedSolutionID)
 }
 
-func cloneDataset(sourceDatasetID string, cloneDatasetID string, cloneFolder string,
+// CloneDataset clones a dataset in metadata storage, data storage and on disk.
+func CloneDataset(sourceDatasetID string, cloneDatasetID string, cloneFolder string,
 	cloneLearningDataset bool, metaStorage api.MetadataStorage, dataStorage api.DataStorage) error {
 
 	ds, err := metaStorage.FetchDataset(sourceDatasetID, false, false, false)
@@ -253,7 +254,7 @@ func PrepExistingPredictionDataset(params *PredictParams) (string, string, error
 
 	// clone the base dataset, then add the necessary fields
 	log.Infof("cloning '%s' for predictions using '%s' as new id stored on disk at '%s'", params.Dataset, cloneDatasetID, targetFolder)
-	err = cloneDataset(params.Dataset, cloneDatasetID, targetFolder, false, params.MetaStorage, params.DataStorage)
+	err = CloneDataset(params.Dataset, cloneDatasetID, targetFolder, false, params.MetaStorage, params.DataStorage)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
Fixes #2318 

Cloning datasets on disk now only clones the main data resource and the metadata, thereby not copying the media files (which were never referenced). The prediction prep code and the dataset cloning route now share the same code, making things easier to track and maintain. A side effect of having the respath updated when saving a dataset has been removed. The path is saved properly, but the metadata used in the save is not modified.

Future work needs to fold in the rest of the prefeaturized dataset syncing and update code currently found in both the task and compute packages. It shouldn't be too hard, and once complete we would at least have a decent way to handle prefeaturized datasets without having to worry about updating multiple functions.