### PR TITLE
Colour ramp reversal

### DIFF
--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -289,7 +289,7 @@ export default Vue.extend({
   methods: {
     colorTile(d) {
       if (d.rank !== undefined) {
-        return d.rank.value / this.rankSummary.baseline.extrema.max;
+        return 1.0 - d.rank.value / this.rankSummary.baseline.extrema.max;
       }
       if (d.confidence !== undefined) {
         return d.confidence.value;

--- a/public/components/labelingComponents/LabelGeoplot.vue
+++ b/public/components/labelingComponents/LabelGeoplot.vue
@@ -118,7 +118,7 @@ export default Vue.extend({
       }
       // comes back order by confidence so the rank is already engrained in the array
       if (item[LOW_SHOT_SCORE_COLUMN_NAME]) {
-        return idx / this.dataItems.length;
+        return 1.0 - idx / this.dataItems.length;
       }
       return undefined;
     },


### PR DESCRIPTION
During demo testing it was found that the colour ramps for the result and annotation screens were reversed. 