### PR TITLE
fixed image labels

### DIFF
--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -57,15 +57,20 @@ export default Vue.extend({
       type: Boolean as () => boolean,
       default: false,
     },
+    isResult: { type: Boolean as () => boolean, default: false },
   },
 
   computed: {
     fields(): Dictionary<TableColumn> {
+      if (this.isResult) {
+        return this.includedActive
+          ? resultGetters.getIncludedResultTableDataFields(this.$store)
+          : resultGetters.getExcludedResultTableDataFields(this.$store);
+      }
       return this.includedActive
         ? datasetGetters.getIncludedTableDataFields(this.$store)
         : datasetGetters.getExcludedTableDataFields(this.$store);
     },
-
     labels(): Label[] {
       const labels: Label[] = [];
       let status: string;

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -27,6 +27,7 @@
               shortenLabels
               alignHorizontal
               :item="item"
+              :is-result="isResult"
             />
           </div>
         </template>
@@ -79,6 +80,7 @@ export default Vue.extend({
     instanceName: String as () => string,
     dataItems: Array as () => any[],
     dataFields: Object as () => Dictionary<TableColumn>,
+    isResult: { type: Boolean as () => boolean, default: false },
   },
 
   data() {

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -28,6 +28,7 @@
         :summaries="trainingSummaries"
         :area-of-interest-items="{ inner: inner, outer: outer }"
         :confidence-access-func="colorTile"
+        :is-result="true"
         @tileClicked="onTileClick"
       />
     </div>


### PR DESCRIPTION
closes #2326 
- Fixed issue with the predicted labels not showing up
- Fixed image labels to pull from result store (I noticed an issue where if one hit refresh the labels would go away due to it pulling from the dataset store)
![Screenshot from 2021-03-04 12-11-05](https://user-images.githubusercontent.com/25306965/110002214-24197280-7ce3-11eb-9153-bd6cd4988df7.png)
