### PR TITLE
Display Timeseries on the Data Explorer

### DIFF
--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -114,7 +114,7 @@
 </template>
 
 <script lang="ts">
-import _ from "lodash";
+import _, { isEmpty } from "lodash";
 import Vue from "vue";
 import IconBase from "./icons/IconBase.vue";
 import IconFork from "./icons/IconFork.vue";
@@ -191,6 +191,7 @@ export default Vue.extend({
       shiftClickInfo: { first: null, second: null },
     };
   },
+
   computed: {
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);
@@ -295,7 +296,10 @@ export default Vue.extend({
     },
 
     isTimeseries(): boolean {
-      return routeGetters.isTimeseries(this.$store);
+      return (
+        routeGetters.isTimeseries(this.$store) ||
+        !isEmpty(this.timeseriesGroupings)
+      );
     },
   },
 


### PR DESCRIPTION
fix #2230 

Simply change the test `isTimeseries` to see if some Timeseries Grouping have been selected by the user as the Data Explorer does not set *Task* until before displaying variables.