### PR TITLE
#2279 join workflow re-enabling

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 //
-//   Copyright © 2021 Uncharted Software Inc.
+//   Copyright © 2019 Uncharted Software Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -293,7 +293,7 @@ func main() {
 	registerRoute(mux, "/distil/datasets/:dataset", routes.DatasetHandler(esMetadataStorageCtor))
 	registerRoute(mux, "/distil/models", routes.ModelsHandler(esExportedModelStorageCtor))
 	registerRoute(mux, "/distil/models/:model", routes.ModelHandler(esExportedModelStorageCtor))
-	registerRoute(mux, "/distil/join-suggestions/:dataset", routes.JoinSuggestionHandler(esMetadataStorageCtor, datamartCtors))
+	registerRoute(mux, "/distil/join-suggestions/:dataset", routes.DatasetsHandler(datamartCtors))
 	registerRoute(mux, "/distil/solution/:solution-id", routes.SolutionHandler(pgSolutionStorageCtor))
 	registerRoute(mux, "/distil/solutions/:dataset/:target", routes.SolutionsHandler(pgSolutionStorageCtor, esMetadataStorageCtor))
 	registerRoute(mux, "/distil/solution-requests/:dataset/:target", routes.SolutionRequestsHandler(pgSolutionStorageCtor))

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 //
-//   Copyright © 2019 Uncharted Software Inc.
+//   Copyright © 2021 Uncharted Software Inc.
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.

--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -133,6 +133,7 @@
 import _ from "lodash";
 import Vue from "vue";
 import ErrorModal from "../components/ErrorModal.vue";
+import { addRecentDataset } from "../util/data";
 import { createRouteEntry } from "../util/routes";
 import { formatBytes } from "../util/bytes";
 import {
@@ -144,7 +145,6 @@ import { getters as routeGetters } from "../store/route/module";
 import { Dataset, Variable } from "../store/dataset/index";
 import { actions as datasetActions } from "../store/dataset/module";
 import { DATA_EXPLORER_ROUTE, SELECT_TARGET_ROUTE } from "../store/route/index";
-import localStorage from "store";
 import {
   actions as appActions,
   getters as appGetters,
@@ -226,7 +226,7 @@ export default Vue.extend({
         dataset: this.dataset.id,
       });
       this.$router.push(entry).catch((err) => console.warn(err));
-      this.addRecentDataset(this.dataset.id);
+      addRecentDataset(this.dataset.id);
       appActions.logUserEvent(this.$store, {
         feature: Feature.SELECT_DATASET,
         activity: Activity.DATA_PREPARATION,
@@ -253,13 +253,6 @@ export default Vue.extend({
       );
     },
 
-    addRecentDataset(dataset: string) {
-      const datasets = localStorage.get("recent-datasets") || [];
-      if (datasets.indexOf(dataset) === -1) {
-        datasets.unshift(dataset);
-        localStorage.set("recent-datasets", datasets);
-      }
-    },
     importDataset() {
       this.importPending = true;
       datasetActions

--- a/public/components/JoinDataTable.vue
+++ b/public/components/JoinDataTable.vue
@@ -123,9 +123,8 @@ export default Vue.extend({
         : this.selectedColumn;
     },
     baseColumnSuggestions(): string[] {
-      const columns = routeGetters
-        .getBaseColumnSuggestions(this.$store)
-        .split(",");
+      const columnRoute = routeGetters.getBaseColumnSuggestions(this.$store);
+      const columns = columnRoute ? columnRoute.split(",") : [];
       return columns;
     },
     selectedSuggestedBaseColumn(): string {
@@ -136,9 +135,8 @@ export default Vue.extend({
       return index >= 0 ? this.selectedBaseColumn.key : undefined;
     },
     joinColumnSuggestions(): string[] {
-      const columns = routeGetters
-        .getJoinColumnSuggestions(this.$store)
-        .split(",");
+      const columnRoute = routeGetters.getJoinColumnSuggestions(this.$store);
+      const columns = columnRoute ? columnRoute.split(",") : [];
       return columns;
     },
     selectedSuggestedJoinColumn(): string {

--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -138,6 +138,9 @@ export default Vue.extend({
     target(): string {
       return routeGetters.getRouteTargetVariable(this.$store);
     },
+    returnPath(): string {
+      return routeGetters.getPriorPath(this.$store);
+    },
     columnsSelected(): boolean {
       return !!this.datasetAColumn && !!this.datasetBColumn;
     },
@@ -234,7 +237,7 @@ export default Vue.extend({
         });
     },
     onJoinCommitSuccess(datasetID: string) {
-      const entry = createRouteEntry(SELECT_TRAINING_ROUTE, {
+      const entry = createRouteEntry(this.returnPath, {
         dataset: datasetID,
         target: this.target,
         task: routeGetters.getRouteTask(this.$store),

--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -33,34 +33,32 @@
         @success="onJoinCommitSuccess"
         @failure="onJoinCommitFailure"
         @close="showJoinSuccess = !showJoinSuccess"
-      >
-      </join-datasets-preview>
+      />
     </b-modal>
 
     <error-modal
       :show="showJoinFailure"
       title="Join Failed"
       @close="showJoinFailure = !showJoinFailure"
-    >
-    </error-modal>
+    />
 
     <div
       v-if="columnTypesDoNotMatch"
       class="row justify-content-center mt-3 mb-3 warning-text"
     >
-      <i class="fa fa-exclamation-triangle warning-icon mr-2"></i>
-      <span v-html="joinWarning"></span>
+      <i class="fa fa-exclamation-triangle warning-icon mr-2" />
+      <span v-html="joinWarning" />
     </div>
 
     <div class="row justify-content-center">
       <b-button
         class="join-button"
+        :disabled="disableJoin"
         :variant="joinVariant"
         @click="previewJoin"
-        :disabled="disableJoin"
       >
         <div class="row justify-content-center">
-          <i class="fa fa-check-circle fa-2x mr-2"></i>
+          <i class="fa fa-check-circle fa-2x mr-2" />
           <b>Join Datasets</b>
         </div>
       </b-button>
@@ -73,7 +71,7 @@
         variant="outline-secondary"
         striped
         :animated="true"
-      ></b-progress>
+      />
     </div>
   </div>
 </template>
@@ -81,28 +79,21 @@
 <script lang="ts">
 import _ from "lodash";
 import Vue from "vue";
-import localStorage from "store";
 import JoinDatasetsPreview from "../components/JoinDatasetsPreview.vue";
 import ErrorModal from "../components/ErrorModal.vue";
-import { createRouteEntry } from "../util/routes";
-import { Dictionary } from "../util/dict";
 import { getters as routeGetters } from "../store/route/module";
-import {
-  Dataset,
-  TableData,
-  TableColumn,
-  TableRow,
-} from "../store/dataset/index";
+import { Dataset, TableColumn, TableRow } from "../store/dataset/index";
 import {
   getters as datasetGetters,
   actions as datasetActions,
 } from "../store/dataset/module";
+import { Dictionary } from "../util/dict";
 import { getTableDataItems, getTableDataFields } from "../util/data";
-import { SELECT_TRAINING_ROUTE } from "../store/route";
 import { isJoinable } from "../util/types";
+import { loadJoinedDataset } from "../util/join";
 
 export default Vue.extend({
-  name: "join-datasets-form",
+  name: "JoinDatasetsForm",
 
   components: {
     JoinDatasetsPreview,
@@ -191,13 +182,6 @@ export default Vue.extend({
   },
 
   methods: {
-    addRecentDataset(dataset: string) {
-      const datasets = localStorage.get("recent-datasets") || [];
-      if (datasets.indexOf(dataset) === -1) {
-        datasets.unshift(dataset);
-        localStorage.set("recent-datasets", datasets);
-      }
-    },
     previewJoin() {
       // flag as pending
       this.pending = true;
@@ -234,25 +218,11 @@ export default Vue.extend({
           this.showJoinFailure = true;
           this.previewTableData = null;
           this.joinedPath = "";
+          console.warn(err);
         });
     },
     onJoinCommitSuccess(datasetID: string) {
-      const datasets = datasetGetters.getDatasets(this.$store);
-
-      const targetDatasetID = datasets.reduce((a, d) => {
-        if (d.id.includes(datasetID) && d.id > a) {
-          a = d.id;
-        }
-        return a;
-      }, "");
-
-      const entry = createRouteEntry(this.returnPath, {
-        dataset: targetDatasetID,
-        target: this.target,
-        task: routeGetters.getRouteTask(this.$store),
-      });
-      this.$router.push(entry).catch((err) => console.warn(err));
-      this.addRecentDataset(datasetID);
+      loadJoinedDataset(this.$router, datasetID, this.target);
     },
     onJoinCommitFailure() {
       this.showJoinFailure = true;

--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -237,8 +237,17 @@ export default Vue.extend({
         });
     },
     onJoinCommitSuccess(datasetID: string) {
+      const datasets = datasetGetters.getDatasets(this.$store);
+
+      const targetDatasetID = datasets.reduce((a, d) => {
+        if (d.id.includes(datasetID) && d.id > a) {
+          a = d.id;
+        }
+        return a;
+      }, "");
+
       const entry = createRouteEntry(this.returnPath, {
-        dataset: datasetID,
+        dataset: targetDatasetID,
         target: this.target,
         task: routeGetters.getRouteTask(this.$store),
       });

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -214,7 +214,7 @@ interface StatusPanelJoinState {
 }
 
 export default Vue.extend({
-  name: "status-panel-join",
+  name: "StatusPanelJoin",
   data(): StatusPanelJoinState {
     return {
       showStatusMessage: true,

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -259,6 +259,9 @@ export default Vue.extend({
     target(): string {
       return routeGetters.getRouteTargetVariable(this.$store);
     },
+    currentPath(): string {
+      return routeGetters.getRoutePath(this.$store);
+    },
     joinSuggestionRequestData(): JoinSuggestionPendingRequest {
       const request = datasetGetters
         .getPendingRequests(this.$store)
@@ -267,7 +270,7 @@ export default Vue.extend({
             request.dataset === this.dataset &&
             request.type === DatasetPendingRequestType.JOIN_SUGGESTION
         );
-      return <JoinSuggestionPendingRequest>request;
+      return request as JoinSuggestionPendingRequest;
     },
     joinSuggestions(): Dataset[] {
       const joinSuggestions = (
@@ -311,7 +314,7 @@ export default Vue.extend({
         )
       );
       return isInSuggestionList
-        ? <JoinDatasetImportPendingRequest>request
+        ? (request as JoinDatasetImportPendingRequest)
         : undefined;
     },
     isImporting(): boolean {
@@ -363,6 +366,12 @@ export default Vue.extend({
     spinnerHTML(): string {
       return circleSpinnerHTML();
     },
+  },
+  created() {
+    this.initSuggestionItems();
+  },
+  beforeDestroy() {
+    this.reviewImportingRequest();
   },
   methods: {
     addRecentDataset(dataset: string) {
@@ -448,6 +457,7 @@ export default Vue.extend({
       } else {
         const entry = createRouteEntry(JOIN_DATASETS_ROUTE, {
           joinDatasets: this.dataset + "," + selected.key,
+          priorRoute: this.currentPath,
         });
         this.$router.push(entry).catch((err) => console.warn(err));
       }
@@ -541,7 +551,7 @@ export default Vue.extend({
       this.showJoinSuccess = false;
     },
     onJoinCommitSuccess(datasetID: string) {
-      const entry = createRouteEntry(SELECT_TRAINING_ROUTE, {
+      const entry = createRouteEntry(this.currentPath, {
         dataset: datasetID,
         target: this.target,
         task: routeGetters.getRouteTask(this.$store),
@@ -549,12 +559,6 @@ export default Vue.extend({
       this.$router.push(entry).catch((err) => console.warn(err));
       this.addRecentDataset(datasetID);
     },
-  },
-  created() {
-    this.initSuggestionItems();
-  },
-  beforeDestroy() {
-    this.reviewImportingRequest();
   },
 });
 </script>

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -551,8 +551,17 @@ export default Vue.extend({
       this.showJoinSuccess = false;
     },
     onJoinCommitSuccess(datasetID: string) {
+      const datasets = datasetGetters.getDatasets(this.$store);
+
+      const targetDatasetID = datasets.reduce((a, d) => {
+        if (d.id.includes(datasetID) && d.id > a) {
+          a = d.id;
+        }
+        return a;
+      }, "");
+
       const entry = createRouteEntry(this.currentPath, {
-        dataset: datasetID,
+        dataset: targetDatasetID,
         target: this.target,
         task: routeGetters.getRouteTask(this.$store),
       });

--- a/public/components/StatusPanelJoin.vue
+++ b/public/components/StatusPanelJoin.vue
@@ -347,7 +347,7 @@ export default Vue.extend({
     },
     selectedSuggestion(): JoinSuggestionItem {
       const dataset = this.suggestionDatasets.find(
-        (item) => !!item.suggestionItems.find((js) => js.selected)
+        (item) => !!item.suggestionItems?.find((js) => js.selected)
       );
       if (dataset) {
         return dataset.suggestionItems.find((js) => js.selected);
@@ -358,12 +358,7 @@ export default Vue.extend({
       return this.selectedItem && this.selectedItem.dataset;
     },
     isJoinReady(): boolean {
-      return (
-        this.selectedSuggestion &&
-        this.selectedItem &&
-        this.selectedItem.isAvailable !== undefined &&
-        !this.isImporting
-      );
+      return !!this.selectedItem;
     },
     spinnerHTML(): string {
       return circleSpinnerHTML();
@@ -390,7 +385,7 @@ export default Vue.extend({
           ? this.isImportRequestResolved
           : !isDatamartProvenance(suggestion.provenance);
         const selected = isImporting && isImportingDataset;
-        const joinSuggestions = suggestion.joinSuggestion.map((js) => {
+        const joinSuggestions = suggestion.joinSuggestion?.map((js) => {
           return {
             joinSuggestion: js,
             selected: false,
@@ -444,11 +439,18 @@ export default Vue.extend({
       const currentDataset = _.find(this.datasets, (d) => {
         return d.id === this.dataset;
       });
-      this.previewJoin(
-        currentDataset,
-        selected.dataset,
-        this.selectedSuggestion.joinSuggestion.index
-      );
+      if (this.selectedSuggestion?.joinSuggestion?.index) {
+        this.previewJoin(
+          currentDataset,
+          selected.dataset,
+          this.selectedSuggestion.joinSuggestion.index
+        );
+      } else {
+        const entry = createRouteEntry(JOIN_DATASETS_ROUTE, {
+          joinDatasets: this.dataset + "," + selected.key,
+        });
+        this.$router.push(entry).catch((err) => console.warn(err));
+      }
     },
     previewJoin(datasetA, datasetB, joinSuggestionIndex) {
       this.isAttemptingJoin = true;

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1372,9 +1372,7 @@ export const actions = {
     return Promise.all(
       args.datasets.map(async (dataset) => {
         const highlights =
-          (args.highlights && args.highlights[0].dataset) === dataset
-            ? args.highlights
-            : null;
+          args.highlights?.[0]?.dataset === dataset ? args.highlights : null;
         const filterParams = addHighlightToFilterParams(
           args.filterParams[dataset],
           highlights

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -83,6 +83,10 @@ export const getters = {
     return true;
   },
 
+  getPriorPath(state: Route): string {
+    return state.query.priorRoute as string;
+  },
+
   getRouteJoinDatasets(state: Route): string[] {
     return state.query.joinDatasets
       ? (state.query.joinDatasets as string).split(",")

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -33,6 +33,7 @@ export const getters = {
   getRouteTerms: read(moduleGetters.getRouteTerms),
   getRouteDataset: read(moduleGetters.getRouteDataset),
   getRouteInclude: read(moduleGetters.getRouteInclude),
+  getPriorPath: read(moduleGetters.getPriorPath),
   getRouteJoinDatasets: read(moduleGetters.getRouteJoinDatasets),
   getJoinDatasetColumnA: read(moduleGetters.getJoinDatasetColumnA),
   getJoinDatasetColumnB: read(moduleGetters.getJoinDatasetColumnB),

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -450,6 +450,9 @@ export const actions = {
     await fetchVariableSummaries(context, { dataset, variables });
     fetchClusters(context, { dataset });
     fetchOutliers(context, { dataset });
+    fetchJoinSuggestions(context, {
+      dataset: dataset,
+    });
   },
 
   updateDataExplorerData(context: ViewContext) {

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -146,6 +146,15 @@ export const COLOR_SCALES: Map<
   [ColorScaleNames.turbo, interpolateTurbo],
 ]);
 
+// update datasets in local storage
+export function addRecentDataset(dataset: string) {
+  const datasets = localStorage.get("recent-datasets") || [];
+  if (datasets.indexOf(dataset) === -1) {
+    datasets.unshift(dataset);
+    localStorage.set("recent-datasets", datasets);
+  }
+}
+
 // include the highlight
 export function getAllDataItems(includedActive: boolean): TableRow[] {
   const tableData = includedActive

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -87,6 +87,8 @@ import {
   interpolatePlasma,
 } from "d3-scale-chromatic";
 import router from "../router/router";
+import localStorage from "store";
+
 // Postfixes for special variable names
 export const PREDICTED_SUFFIX = "_predicted";
 export const ERROR_SUFFIX = "_error";

--- a/public/util/join.ts
+++ b/public/util/join.ts
@@ -1,0 +1,62 @@
+/**
+ *
+ *    Copyright © 2021 Uncharted Software Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import { JOIN_DATASETS_ROUTE } from "../store/route/index";
+import { getters as routeGetters } from "../store/route/module";
+import { getters as datasetGetters } from "../store/dataset/module";
+import { createRouteEntry } from "./routes";
+import { addRecentDataset } from "./data";
+import store from "../store/store";
+import VueRouter from "vue-router";
+
+export function loadJoinedDataset(
+  router: VueRouter,
+  datasetID: string,
+  target: string
+) {
+  const priorPath = routeGetters.getPriorPath(store);
+  const returnPath = priorPath ? priorPath : routeGetters.getRoutePath(store);
+  const datasets = datasetGetters.getDatasets(store);
+  const targetDatasetID = datasets.reduce((a, d) => {
+    if (d.id.includes(datasetID) && d.id > a) {
+      a = d.id;
+    }
+    return a;
+  }, "");
+  const entry = createRouteEntry(returnPath, {
+    dataset: targetDatasetID,
+    target: target,
+    task: routeGetters.getRouteTask(store),
+  });
+  router.push(entry).catch((err) => console.warn(err));
+  addRecentDataset(targetDatasetID);
+}
+
+export function loadJoinView(
+  router: VueRouter,
+  datasetA: string,
+  datasetB: string
+) {
+  const sourceRoute = routeGetters.getRoutePath(store);
+  const target = routeGetters.getRouteTargetVariable(store);
+  const entry = createRouteEntry(JOIN_DATASETS_ROUTE, {
+    joinDatasets: datasetA + "," + datasetB,
+    priorRoute: sourceRoute,
+    target: target,
+  });
+  router.push(entry).catch((err) => console.warn(err));
+}

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -75,6 +75,7 @@ export interface RouteArgs {
   // orderBy contains variable names that will order the dataset
   orderBy?: string;
   outlier?: string;
+  priorRoute?: string;
 }
 
 function validateQueryArgs(args: RouteArgs): RouteArgs {


### PR DESCRIPTION
- modified the main.go route for join suggestions to just dump back the imported dataset list for maximum demoability.
- modified join data table, status panel join components to be more robust about the lack of suggested columns to join on.
- factored out addRecentDataset code that was repeated in 3 components into a single data.ts exported function and imported that into the relevant components instead.
- factored out repetitive join related code to in join datasets form and status panel join into new join.ts util then leverage exported shared functions.
- added prior path route to query string (this vue route getters and setters) to enable variable return back to the prior path after doing a join from the join view to any route that it launches it now (data explorer or create - it's all good.)
- various vue & typescript clean ups. lots of "AS type" replacing "<type>" since these files basically missed those clean ups previously.