### PR TITLE
Map fix

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -385,9 +385,10 @@ func (s *Storage) buildFilteredQueryWhere(dataset string, wheres []string, param
 	if len(highlightWheres) > 0 {
 		where := ""
 		if invert {
-			where = fmt.Sprintf("NOT(%s)", strings.Join(highlightWheres, " OR "))
+			// highlights are always treated as or (adding Not(...or...) makes it and)
+			where = fmt.Sprintf("(%s)", strings.Join(highlightWheres, " OR "))
 		} else {
-			where = strings.Join(highlightWheres, " OR ")
+			where = fmt.Sprintf("(%s)",strings.Join(highlightWheres, " OR "))
 		}
 		wheres = append(wheres, where)
 	}
@@ -410,7 +411,7 @@ func (s *Storage) buildFilteredQueryWhere(dataset string, wheres []string, param
 		}
 		wheres = append(wheres, where)
 	}
-	return wheres, params
+ 	return wheres, params
 }
 func (s *Storage) buildSelectStatement(variables []*model.Variable, filterVariables []string) (string, error) {
 

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -636,6 +636,7 @@ func (s *Storage) buildResultQueryFilters(dataset string, storageName string, re
 
 type filters struct {
 	genericFilters    []*model.Filter
+	genericHighlights []*model.Filter
 	predictedFilter   *model.Filter
 	residualFilter    *model.Filter
 	correctnessFilter *model.Filter
@@ -651,6 +652,7 @@ func splitFilters(filterParams *api.FilterParams) *filters {
 	var confidenceFilter *model.Filter
 	var rankFilter *model.Filter
 	var remaining []*model.Filter
+	var remainingHighlights []*model.Filter
 
 	if filterParams == nil {
 		return &filters{}
@@ -670,7 +672,7 @@ func splitFilters(filterParams *api.FilterParams) *filters {
 		} else if api.IsRankKey(highlight.Key) {
 			rankFilter = highlight
 		} else {
-			remaining = append(remaining, highlight)
+			remainingHighlights = append(remainingHighlights, highlight)
 		}
 	}
 
@@ -694,6 +696,7 @@ func splitFilters(filterParams *api.FilterParams) *filters {
 
 	return &filters{
 		genericFilters:    remaining,
+		genericHighlights: remainingHighlights,
 		predictedFilter:   predictedFilter,
 		residualFilter:    residualFilter,
 		correctnessFilter: correctnessFilter,

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -606,7 +606,7 @@ func (s *Storage) buildResultQueryFilters(dataset string, storageName string, re
 	genericFilterParams := &api.FilterParams{
 		Filters: filters.genericFilters,
 	}
-
+	genericFilterParams.Highlights = filters.genericHighlights
 	// create the filter for the query
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -388,7 +388,7 @@ func (s *Storage) buildFilteredQueryWhere(dataset string, wheres []string, param
 			// highlights are always treated as or (adding Not(...or...) makes it and)
 			where = fmt.Sprintf("(%s)", strings.Join(highlightWheres, " OR "))
 		} else {
-			where = fmt.Sprintf("(%s)",strings.Join(highlightWheres, " OR "))
+			where = fmt.Sprintf("(%s)", strings.Join(highlightWheres, " OR "))
 		}
 		wheres = append(wheres, where)
 	}
@@ -411,7 +411,7 @@ func (s *Storage) buildFilteredQueryWhere(dataset string, wheres []string, param
 		}
 		wheres = append(wheres, where)
 	}
- 	return wheres, params
+	return wheres, params
 }
 func (s *Storage) buildSelectStatement(variables []*model.Variable, filterVariables []string) (string, error) {
 

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -205,7 +205,7 @@ func (f *NumericalField) fetchHistogramByResult(resultURI string, filterParams *
 	// need the extrema to calculate the histogram interval
 	if extrema == nil {
 		extrema, err = f.fetchExtremaByURI(resultURI)
-		if extrema == nil{
+		if extrema == nil {
 			return nil, nil
 		}
 		if err != nil {

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -205,6 +205,9 @@ func (f *NumericalField) fetchHistogramByResult(resultURI string, filterParams *
 	// need the extrema to calculate the histogram interval
 	if extrema == nil {
 		extrema, err = f.fetchExtremaByURI(resultURI)
+		if extrema == nil{
+			return nil, nil
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to fetch variable extrema for summary")
 		}

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -782,6 +782,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 		Filters: filters.genericFilters,
 	}
 	genericFilterParams.DataMode = filterParams.DataMode
+	genericFilterParams.Highlights = filters.genericHighlights
 	// Create the filter portion of the where clause.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -781,7 +781,7 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 	genericFilterParams := &api.FilterParams{
 		Filters: filters.genericFilters,
 	}
-
+	genericFilterParams.DataMode = filterParams.DataMode
 	// Create the filter portion of the where clause.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -712,19 +712,25 @@ export default Vue.extend({
       ) {
         return;
       }
+      const tileMap = new Map<string, Area>();
       const innerArea = this.tableDataToAreas(
         this.areaOfInterestItems.inner
       ) as any[];
       innerArea.forEach((i) => {
         i.gray = 0;
+        tileMap.set(i.imageUrl, i);
       });
       const outerArea = this.tableDataToAreas(
         this.areaOfInterestItems.outer
       ) as any[];
       outerArea.forEach((i) => {
         i.gray = 100;
+        if (!tileMap.has(i.imageUrl)) {
+          tileMap.set(i.imageUrl, i);
+        }
       });
-      this.drillDownState.tiles = innerArea.concat(outerArea);
+      console.log(tileMap);
+      this.drillDownState.tiles = [...tileMap.values()];
       this.isImageDrilldown = true;
     },
   },

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -729,7 +729,6 @@ export default Vue.extend({
           tileMap.set(i.imageUrl, i);
         }
       });
-      console.log(tileMap);
       this.drillDownState.tiles = [...tileMap.values()];
       this.isImageDrilldown = true;
     },

--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -158,7 +158,7 @@
           :key="summary.key"
           enable-highlighting
           :summary="summary"
-          :highlight="highlight"
+          :highlight="highlights"
           :enabled-type-changes="[]"
           :row-selection="rowSelection"
           :instance-name="rankingInstanceName"

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -44,7 +44,7 @@
       class="mb-3"
       :variables="allVariables"
       :filters="routeFilters"
-      :highlight="routeHighlight"
+      :highlights="routeHighlight"
       @lex-query="updateFilterAndHighlightFromLexQuery"
     />
 

--- a/public/components/SelectGeoPlot.vue
+++ b/public/components/SelectGeoPlot.vue
@@ -64,8 +64,8 @@ export default Vue.extend({
 
     items(): TableRow[] {
       const tableData = this.includedActive
-        ? datasetGetters.getHighlightedIncludeTableDataItems(this.$store)
-        : datasetGetters.getHighlightedExcludeTableDataItems(this.$store);
+        ? datasetGetters.getBaselineIncludeTableDataItems(this.$store)
+        : datasetGetters.getBaselineExcludeTableDataItems(this.$store);
       const highlighted = tableData
         ? tableData.map((h) => {
             return { ...h, isExcluded: true };

--- a/public/components/layout/SearchBar.vue
+++ b/public/components/layout/SearchBar.vue
@@ -43,7 +43,7 @@ export default Vue.extend({
   name: "SearchBar",
 
   props: {
-    highlight: { type: String, default: "" },
+    highlights: { type: String, default: "" },
     filters: { type: String, default: "" },
     variables: { type: Array as () => Variable[], default: [] },
   },
@@ -98,10 +98,10 @@ export default Vue.extend({
     },
 
     setQuery(): void {
-      if (!this.lex || !(this.filters || this.highlight)) return;
+      if (!this.lex || !(this.filters || this.highlights)) return;
       const lexQuery = filterParamsToLexQuery(
         this.filters,
-        this.highlight,
+        this.highlights,
         this.variables
       );
       this.lex.setQuery(lexQuery, false);

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1449,9 +1449,6 @@ export const actions = {
       include: boolean;
     }
   ) {
-    if (!args.highlights.length && !args.filterParams.filters.length) {
-      return;
-    }
     const mutator = args.include
       ? mutations.setHighlightedIncludeTableData
       : mutations.setHighlightedExcludeTableData;

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1439,7 +1439,7 @@ export const actions = {
     });
     mutations.setExcludedTableData(context, data);
   },
-  async fetchHighlightedTableData(
+  async fetchBaselineTableData(
     context: DatasetContext,
     args: {
       dataset: string;
@@ -1450,8 +1450,8 @@ export const actions = {
     }
   ) {
     const mutator = args.include
-      ? mutations.setHighlightedIncludeTableData
-      : mutations.setHighlightedExcludeTableData;
+      ? mutations.setBaselineIncludeTableData
+      : mutations.setBaselineExcludeTableData;
     const data = await actions.fetchTableData(context, {
       dataset: args.dataset,
       filterParams: args.filterParams,

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -28,8 +28,15 @@ import {
   DatasetUpdate,
 } from "../../util/data";
 import { Dictionary } from "../../util/dict";
-import { EXCLUDE_FILTER, FilterParams } from "../../util/filters";
-import { addHighlightToFilterParams } from "../../util/highlights";
+import {
+  EXCLUDE_FILTER,
+  FilterParams,
+  INCLUDE_FILTER,
+} from "../../util/filters";
+import {
+  addHighlightToFilterParams,
+  highlightsExist,
+} from "../../util/highlights";
 import { loadImage } from "../../util/image";
 import {
   GEOCODED_LAT_PREFIX,
@@ -1506,6 +1513,7 @@ export const actions = {
       highlights: Highlight[];
       include: boolean;
       dataMode: DataMode;
+      mode?: string;
       orderBy?: string;
     }
   ): Promise<TableData> {
@@ -1514,7 +1522,8 @@ export const actions = {
     }
     const filterParams = addHighlightToFilterParams(
       args.filterParams,
-      args.highlights
+      args.highlights,
+      args.mode
     );
 
     const dataModeDefault = args.dataMode ? args.dataMode : DataMode.Default;

--- a/public/store/dataset/getters.ts
+++ b/public/store/dataset/getters.ts
@@ -148,11 +148,11 @@ export const getters = {
   hasIncludedTableData(state: DatasetState): boolean {
     return !!state.includedSet.tableData;
   },
-  getHighlightedIncludeSet(state: DatasetState): TableData {
-    return state.highlightedIncludeSet;
+  getBaselineIncludeSet(state: DatasetState): TableData {
+    return state.baselineIncludeSet;
   },
-  getHighlightedExcludeSet(state: DatasetState): TableData {
-    return state.highlightedExcludeSet;
+  getBaselineExcludeSet(state: DatasetState): TableData {
+    return state.baselineExcludeSet;
   },
   getIncludedTableData(state: DatasetState): TableData {
     return state.includedSet.tableData;
@@ -184,11 +184,11 @@ export const getters = {
   getAreaOfInterestExcludeOuterItems(state: DatasetState) {
     return getTableDataItems(state.areaOfInterestExcludeOuter);
   },
-  getHighlightedIncludeTableDataItems(state: DatasetState) {
-    return getTableDataItems(state.highlightedIncludeSet);
+  getBaselineIncludeTableDataItems(state: DatasetState) {
+    return getTableDataItems(state.baselineIncludeSet);
   },
-  getHighlightedExcludeTableDataItems(state: DatasetState) {
-    return getTableDataItems(state.highlightedExcludeSet);
+  getBaselineExcludeTableDataItems(state: DatasetState) {
+    return getTableDataItems(state.baselineExcludeSet);
   },
   getIncludedTableDataItems(state: DatasetState, getters: any): TableRow[] {
     return getTableDataItems(state.includedSet.tableData);

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -403,8 +403,8 @@ export interface DatasetState {
   joinTableData: Dictionary<TableData>;
   includedSet: WorkingSet;
   excludedSet: WorkingSet;
-  highlightedIncludeSet: TableData;
-  highlightedExcludeSet: TableData;
+  baselineIncludeSet: TableData;
+  baselineExcludeSet: TableData;
   areaOfInterestIncludeInner: TableData;
   areaOfInterestIncludeOuter: TableData;
   areaOfInterestExcludeInner: TableData;
@@ -469,8 +469,8 @@ export const state: DatasetState = {
     rowSelectionData: [],
   },
   // highlight set
-  highlightedIncludeSet: null,
-  highlightedExcludeSet: null,
+  baselineIncludeSet: null,
+  baselineExcludeSet: null,
   // tiles surrounding tile that was clicked
   // include area of interest
   areaOfInterestIncludeInner: null,

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -70,11 +70,11 @@ export const getters = {
   // join data
   getJoinDatasetsTableData: read(moduleGetters.getJoinDatasetsTableData),
   // highlighted data
-  getHighlightedIncludeTableDataItems: read(
-    moduleGetters.getHighlightedIncludeTableDataItems
+  getBaselineIncludeTableDataItems: read(
+    moduleGetters.getBaselineIncludeTableDataItems
   ),
-  getHighlightedExcludeTableDataItems: read(
-    moduleGetters.getHighlightedExcludeTableDataItems
+  getBaselineExcludeTableDataItems: read(
+    moduleGetters.getBaselineExcludeTableDataItems
   ),
   getNumberOfRecords: read(moduleGetters.getNumberOfRecords),
   // included data
@@ -180,7 +180,7 @@ export const actions = {
   // included / excluded table data
   fetchIncludedTableData: dispatch(moduleActions.fetchIncludedTableData),
   fetchExcludedTableData: dispatch(moduleActions.fetchExcludedTableData),
-  fetchHighlightedTableData: dispatch(moduleActions.fetchHighlightedTableData),
+  fetchBaselineTableData: dispatch(moduleActions.fetchBaselineTableData),
   fetchAreaOfInterestData: dispatch(moduleActions.fetchAreaOfInterestData),
   // task info
   fetchTask: dispatch(moduleActions.fetchTask),
@@ -229,11 +229,11 @@ export const mutations = {
   clearJoinDatasetsTableData: commit(
     moduleMutations.clearJoinDatasetsTableData
   ),
-  setHighlightedIncludeTableData: commit(
-    moduleMutations.setHighlightedIncludeTableData
+  setBaselineIncludeTableData: commit(
+    moduleMutations.setBaselineIncludeTableData
   ),
-  setHighlightedExcludeTableData: commit(
-    moduleMutations.setHighlightedExcludeTableData
+  setBaselineExcludeTableData: commit(
+    moduleMutations.setBaselineExcludeTableData
   ),
   setAreaOfInterestIncludeInner: commit(
     moduleMutations.setAreaOfInterestIncludeInner

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -404,11 +404,11 @@ export const mutations = {
   clearJoinDatasetsTableData(state: DatasetState) {
     state.joinTableData = {};
   },
-  setHighlightedIncludeTableData(state: DatasetState, tableData: TableData) {
-    state.highlightedIncludeSet = Object.freeze(tableData);
+  setBaselineIncludeTableData(state: DatasetState, tableData: TableData) {
+    state.baselineIncludeSet = Object.freeze(tableData);
   },
-  setHighlightedExcludeTableData(state: DatasetState, tableData: TableData) {
-    state.highlightedExcludeSet = Object.freeze(tableData);
+  setBaselineExcludeTableData(state: DatasetState, tableData: TableData) {
+    state.baselineExcludeSet = Object.freeze(tableData);
   },
   updateAreaOfInterestIncludeInner(
     state: DatasetState,

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -574,6 +574,12 @@ export const actions = {
       .getDecodedSolutionRequestFilterParams as FilterParams;
     const dataMode = context.getters.getDataMode;
     filterParams.size = datasetGetters.getNumberOfRecords(store);
+    const baseline = {
+      highlights: [],
+      filters: [],
+      variables: filterParams.variables,
+      size: filterParams.size,
+    } as FilterParams;
     return Promise.all([
       datasetActions.fetchHighlightedTableData(store, {
         dataset: dataset,
@@ -584,10 +590,10 @@ export const actions = {
       }), // include
       datasetActions.fetchHighlightedTableData(store, {
         dataset: dataset,
-        filterParams: filterParams,
-        highlights: highlights,
+        filterParams: baseline,
+        highlights: [],
         dataMode: dataMode,
-        include: false,
+        include: true,
       }), // exclude
     ]);
   },
@@ -613,6 +619,17 @@ export const actions = {
     const invertedHighlights = highlights.map((highlight) => {
       return { ...highlight, include: EXCLUDE_FILTER };
     });
+    const baseline = {
+      highlights: [],
+      filters: [
+        filter,
+        ...clonedFilterParams.filters.filter((f) => {
+          return f.mode === EXCLUDE_FILTER;
+        }),
+      ],
+      size: clonedFilterParams.size,
+      variables: clonedFilterParams.variables,
+    } as FilterParams;
     return Promise.all([
       datasetActions.fetchAreaOfInterestData(store, {
         dataset: dataset,
@@ -625,7 +642,7 @@ export const actions = {
       }), // include inner tiles
       datasetActions.fetchAreaOfInterestData(store, {
         dataset: dataset,
-        filterParams: clonedFilterParams,
+        filterParams: baseline,
         highlights: invertedHighlights,
         dataMode: dataMode,
         include: true,

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -68,6 +68,7 @@ import { getters as routeGetters } from "../route/module";
 import store, { DistilState } from "../store";
 import { ViewState } from "./index";
 import { getters as viewGetters, mutations as viewMutations } from "./module";
+import { setHighlightModes, cloneFilters } from "../../util/highlights";
 
 enum ParamCacheKey {
   VARIABLES = "VARIABLES",
@@ -569,17 +570,28 @@ export const actions = {
   },
   updateHighlight(context: ViewContext) {
     const dataset = context.getters.getRouteDataset;
-    const highlights = context.getters.getDecodedHighlights as Highlight[];
-    const filterParams = context.getters
-      .getDecodedSolutionRequestFilterParams as FilterParams;
+    let filterParams = cloneFilters(
+      context.getters.getDecodedSolutionRequestFilterParams
+    );
     const dataMode = context.getters.getDataMode;
     filterParams.size = datasetGetters.getNumberOfRecords(store);
+    filterParams = setHighlightModes(filterParams, EXCLUDE_FILTER);
     const baseline = {
-      highlights: [],
-      filters: [],
+      highlights: filterParams.highlights,
+      filters: filterParams.filters.filter((f) => {
+        return f.mode === EXCLUDE_FILTER;
+      }),
       variables: filterParams.variables,
       size: Number.MAX_SAFE_INTEGER,
     } as FilterParams;
+    const excludeBaseline = {
+      highlights: filterParams.highlights,
+      filters: filterParams.filters.filter((f) => {
+        return f.mode === EXCLUDE_FILTER;
+      }),
+      variables: filterParams.variables,
+      size: Number.MAX_SAFE_INTEGER,
+    };
     return Promise.all([
       datasetActions.fetchBaselineTableData(store, {
         dataset: dataset,
@@ -590,10 +602,10 @@ export const actions = {
       }), // include
       datasetActions.fetchBaselineTableData(store, {
         dataset: dataset,
-        filterParams: baseline,
+        filterParams: excludeBaseline,
         highlights: [],
         dataMode: dataMode,
-        include: true,
+        include: false,
       }), // exclude
     ]);
   },

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -578,17 +578,17 @@ export const actions = {
       highlights: [],
       filters: [],
       variables: filterParams.variables,
-      size: filterParams.size,
+      size: Number.MAX_SAFE_INTEGER,
     } as FilterParams;
     return Promise.all([
-      datasetActions.fetchHighlightedTableData(store, {
+      datasetActions.fetchBaselineTableData(store, {
         dataset: dataset,
-        filterParams: filterParams,
-        highlights: highlights,
+        filterParams: baseline,
+        highlights: [],
         dataMode: dataMode,
         include: true,
       }), // include
-      datasetActions.fetchHighlightedTableData(store, {
+      datasetActions.fetchBaselineTableData(store, {
         dataset: dataset,
         filterParams: baseline,
         highlights: [],
@@ -627,7 +627,7 @@ export const actions = {
           return f.mode === EXCLUDE_FILTER;
         }),
       ],
-      size: clonedFilterParams.size,
+      size: Number.MAX_SAFE_INTEGER,
       variables: clonedFilterParams.variables,
     } as FilterParams;
     return Promise.all([
@@ -670,8 +670,8 @@ export const actions = {
     ]);
   },
   clearHighlight(context: ViewContext) {
-    datasetMutations.setHighlightedIncludeTableData(store, null);
-    datasetMutations.setHighlightedExcludeTableData(store, null);
+    datasetMutations.setBaselineIncludeTableData(store, null);
+    datasetMutations.setBaselineExcludeTableData(store, null);
   },
   async fetchResultsData(context: ViewContext) {
     // clear previous state

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -149,8 +149,8 @@ export const COLOR_SCALES: Map<
 // include the highlight
 export function getAllDataItems(includedActive: boolean): TableRow[] {
   const tableData = includedActive
-    ? datasetGetters.getHighlightedIncludeTableDataItems(store)
-    : datasetGetters.getHighlightedExcludeTableDataItems(store);
+    ? datasetGetters.getBaselineIncludeTableDataItems(store)
+    : datasetGetters.getBaselineExcludeTableDataItems(store);
   const highlighted = tableData
     ? tableData.map((h) => {
         return { ...h, isExcluded: true }; // adding isExcluded for the geoplot to color it gray

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -20,12 +20,10 @@ import {
   Filter,
   FilterParams,
   CATEGORICAL_FILTER,
-  GEOBOUNDS_FILTER,
   CLUSTER_FILTER,
   VECTOR_FILTER,
   INCLUDE_FILTER,
   TEXT_FILTER,
-  BIVARIATE_FILTER,
 } from "../util/filters";
 import { getters as routeGetters } from "../store/route/module";
 import { getters as datasetGetters } from "../store/dataset/module";
@@ -117,7 +115,7 @@ export function createFiltersFromHighlights(
       return {
         key: key,
         type: CLUSTER_FILTER,
-        mode: mode,
+        mode: highlight.include ?? mode,
         categories: [highlight.value],
         displayName: displayName,
       };
@@ -127,7 +125,7 @@ export function createFiltersFromHighlights(
       return {
         key: key,
         type: TEXT_FILTER,
-        mode: mode,
+        mode: highlight.include ?? mode,
         categories: [highlight.value],
         displayName: displayName,
       };
@@ -137,7 +135,7 @@ export function createFiltersFromHighlights(
       return {
         key: key,
         type: CATEGORICAL_FILTER,
-        mode: mode,
+        mode: highlight.include ?? mode,
         categories: [highlight.value],
         displayName: displayName,
       };
@@ -158,7 +156,7 @@ export function createFiltersFromHighlights(
           key: key,
           type: VECTOR_FILTER,
           nestedType: highlight.value.type,
-          mode: mode,
+          mode: highlight.include ?? mode,
           min: highlight.value.from,
           max: highlight.value.to,
           displayName: displayName,
@@ -168,7 +166,7 @@ export function createFiltersFromHighlights(
       return {
         key: key,
         type: highlight.value.type,
-        mode: mode,
+        mode: highlight.include ?? mode,
         min: highlight.value.from,
         max: highlight.value.to,
         displayName: displayName,
@@ -195,7 +193,27 @@ export function createFiltersFromHighlights(
 
   return filterHighlights;
 }
-
+export function cloneFilters(filterParams: FilterParams): FilterParams {
+  return _.cloneDeep(filterParams);
+}
+export function setHighlightModes(
+  filterParams: FilterParams,
+  mode: string
+): FilterParams {
+  filterParams.highlights.forEach((highlight) => {
+    highlight.mode = mode;
+  });
+  return filterParams;
+}
+export function setFilterModes(
+  filterParams: FilterParams,
+  mode: string
+): FilterParams {
+  filterParams.filters.forEach((filter) => {
+    filter.mode = mode;
+  });
+  return filterParams;
+}
 export function addHighlightToFilterParams(
   filterParams: FilterParams,
   highlights: Highlight[],

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -183,7 +183,7 @@ export function createFiltersFromHighlights(
       return {
         key: key,
         type: variable.colType,
-        mode: mode,
+        mode: highlight.include ?? mode,
         minX: highlight.value.minX,
         maxX: highlight.value.maxX,
         minY: highlight.value.minY,

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -38,7 +38,7 @@
       <search-bar
         :variables="allVariables"
         :filters="filters"
-        :highlight="routeHighlight"
+        :highlights="routeHighlight"
         @lex-query="updateFilterAndHighlightFromLexQuery"
       />
 


### PR DESCRIPTION
- First pass 
- There is a lot of issues surrounding multiple highlights and the way the data was being queried
- This PR fixes issues:
1. With multiple highlight there was no way to remove a geo-coordinate highligh(fix add lex bar to result and prediction view)
2. Fix for lexbar highlight vs highlights
3. The invert does a collective NOT() which converts the sequence of ORs into an and (The desired behaviour is keeping the highlights always as an OR)
4. Fixed the map to support multiple highlights
5. Fixed issue in result screen where the backend always assumes rank is available on the result (causing the route to crash and not provide any other result summary like confidence)
closes #2340
