### PR TITLE
Prefiltering Solution Cleanup

### DIFF
--- a/api/compute/filter.go
+++ b/api/compute/filter.go
@@ -191,8 +191,8 @@ func preparePrefilteringDataset(outputFolder string, sourceDataset *api.Dataset,
 		return nil, err
 	}
 	metadataSourceDR := metadataSource.GetMainDataResource()
-	metaVarMap := MapVariables(metadataSourceDR.Variables, func(variable *model.Variable) string { return variable.Key })
-	sourceVarMap := MapVariables(sourceDataset.Variables, func(variable *model.Variable) string { return variable.Key })
+	metaVarMap := api.MapVariables(metadataSourceDR.Variables, func(variable *model.Variable) string { return variable.Key })
+	sourceVarMap := api.MapVariables(sourceDataset.Variables, func(variable *model.Variable) string { return variable.Key })
 
 	// update the metadata to match the data pulled from the data storage
 	// (mostly matching column index and dropping columns not pulled)
@@ -250,10 +250,10 @@ func UpdatePrefeaturizedDataset(outputFolder string, prefeaturizedPath string, s
 	metaDiskMainDR := dsDisk.Metadata.GetMainDataResource()
 
 	// determine if there are new columns that were not part of the original dataset
-	metaDiskVarMap := MapVariables(metaDiskMainDR.Variables, func(variable *model.Variable) string { return variable.Key })
+	metaDiskVarMap := api.MapVariables(metaDiskMainDR.Variables, func(variable *model.Variable) string { return variable.Key })
 
 	// get the index of the new fields in the extracted data
-	storedVarMap := MapVariables(sourceDataset.Variables, func(variable *model.Variable) string { return variable.Key })
+	storedVarMap := api.MapVariables(sourceDataset.Variables, func(variable *model.Variable) string { return variable.Key })
 	storedDataD3MIndex := -1
 	newVars := []*model.Variable{}
 	for i, v := range storedData[0] {
@@ -311,8 +311,8 @@ func UpdatePrefeaturizedDataset(outputFolder string, prefeaturizedPath string, s
 	}
 
 	// capture the final set of variables to use
-	storedVarMap = MapVariables(sourceDataset.Variables, func(variable *model.Variable) string { return variable.HeaderName })
-	metaDiskVarMap = MapVariables(metaDiskMainDR.Variables, func(variable *model.Variable) string { return variable.HeaderName })
+	storedVarMap = api.MapVariables(sourceDataset.Variables, func(variable *model.Variable) string { return variable.HeaderName })
+	metaDiskVarMap = api.MapVariables(metaDiskMainDR.Variables, func(variable *model.Variable) string { return variable.HeaderName })
 	outputVariables := make([]*model.Variable, len(dsDisk.Data[0]))
 	for i, v := range dsDisk.Data[0] {
 		var variable *model.Variable
@@ -326,16 +326,6 @@ func UpdatePrefeaturizedDataset(outputFolder string, prefeaturizedPath string, s
 	}
 
 	return outputVariables, nil
-}
-
-// MapVariables creates a variable map using the mapper function to create the key.
-func MapVariables(variables []*model.Variable, mapper func(variable *model.Variable) string) map[string]*model.Variable {
-	mapped := map[string]*model.Variable{}
-	for _, d := range variables {
-		mapped[mapper(d)] = d
-	}
-
-	return mapped
 }
 
 // HarmonizeDataMetadata updates a dataset on disk to have the schema info

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -295,7 +295,9 @@ func (d *DiskDataset) Update(updates map[string]map[string]string, filterNotFoun
 				filterMap[key] = true
 			}
 		}
-		d.Dataset.FilterDataset(filterMap)
+		if len(filterMap) < 0 {
+			d.Dataset.FilterDataset(filterMap)
+		}
 	}
 
 	// translate column names to indices

--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
-	apiCompute "github.com/uncharted-distil/distil/api/compute"
 	"github.com/uncharted-distil/distil/api/dataset"
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
@@ -145,9 +144,9 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 						return
 					}
 					definitiveVars := append(getVariablesDefault(originalDataset["id"].(string), metaStore), getVariablesDefault(joinedDataset["id"].(string), metaStore)...)
-					ingestParams.DefinitiveTypes = apiCompute.MapVariables(definitiveVars, func(variable *model.Variable) string { return variable.Key })
+					ingestParams.DefinitiveTypes = api.MapVariables(definitiveVars, func(variable *model.Variable) string { return variable.Key })
 				} else {
-					ingestParams.DefinitiveTypes = apiCompute.MapVariables(creationResult.definitiveVars, func(variable *model.Variable) string { return variable.Key })
+					ingestParams.DefinitiveTypes = api.MapVariables(creationResult.definitiveVars, func(variable *model.Variable) string { return variable.Key })
 				}
 				log.Infof("Created dataset '%s' from local source '%s'", ingestParams.ID, ingestParams.Path)
 			}

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -124,7 +124,7 @@ func ExportDataset(dataset string, metaStorage api.MetadataStorage, dataStorage 
 	// need to update metadata variable order to match extracted data
 	header := data[0]
 	exportedVariables := make([]*model.Variable, len(header))
-	exportVarMap := apicompute.MapVariables(metaDataset.Variables, func(variable *model.Variable) string { return variable.Key })
+	exportVarMap := api.MapVariables(metaDataset.Variables, func(variable *model.Variable) string { return variable.Key })
 	for i, v := range header {
 		variable := exportVarMap[v]
 		variable.Index = i
@@ -149,7 +149,7 @@ func ExportDataset(dataset string, metaStorage api.MetadataStorage, dataStorage 
 			return "", "", err
 		}
 
-		err = updateLearningDataset(metaDataset, data)
+		err = api.UpdateDiskDataset(metaDataset, data)
 		if err != nil {
 			return "", "", err
 		}
@@ -169,7 +169,7 @@ func ExportDataset(dataset string, metaStorage api.MetadataStorage, dataStorage 
 		}
 
 		// main data resources need to be checked for any resource references
-		parentVariablesMap := apicompute.MapVariables(parentMetaDiskMainDR.Variables, func(variable *model.Variable) string { return variable.Key })
+		parentVariablesMap := api.MapVariables(parentMetaDiskMainDR.Variables, func(variable *model.Variable) string { return variable.Key })
 		for _, v := range dataRaw.Metadata.GetMainDataResource().Variables {
 			parentVar := parentVariablesMap[v.Key]
 			if parentVar != nil && parentVar.RefersTo != nil {
@@ -187,59 +187,6 @@ func ExportDataset(dataset string, metaStorage api.MetadataStorage, dataStorage 
 	}
 
 	return dataset, outputFolder, nil
-}
-
-func updateLearningDataset(ds *api.Dataset, data [][]string) error {
-	// read the dataset from disk
-	dsDisk, err := api.LoadDiskDataset(ds)
-	if err != nil {
-		return err
-	}
-	varMap := apicompute.MapVariables(ds.Variables, func(variable *model.Variable) string { return variable.HeaderName })
-
-	// use the header row to determine the variables to update
-	d3mIndexIndex := -1
-	updates := map[string]map[string]string{}
-	headerMap := map[string]int{}
-	for i, c := range data[0] {
-		if c == model.D3MIndexFieldName {
-			d3mIndexIndex = i
-		} else {
-			sourceVar := varMap[c]
-			if sourceVar.Immutable {
-				continue
-			}
-			headerMap[sourceVar.HeaderName] = i
-			updates[sourceVar.HeaderName] = map[string]string{}
-
-			// add missing fields
-			if !dsDisk.FieldExists(sourceVar) {
-				err = dsDisk.AddField(sourceVar)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	// create the update maps (d3m index -> new value)
-	for _, row := range data[1:] {
-		for headerName, colIndex := range headerMap {
-			updates[headerName][row[d3mIndexIndex]] = row[colIndex]
-		}
-	}
-
-	err = dsDisk.UpdateDataset(updates, true)
-	if err != nil {
-		return err
-	}
-
-	err = dsDisk.SaveDataset()
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 // CreateDatasetFromResult creates a new dataset based on a result set & the input

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -27,7 +27,6 @@ import (
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	log "github.com/unchartedsoftware/plog"
 
-	apicompute "github.com/uncharted-distil/distil/api/compute"
 	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/postgres"
@@ -705,7 +704,7 @@ func getUniqueDatasetName(meta *model.Metadata, storage api.MetadataStorage) (st
 
 func createIndices(pg *postgres.Database, datasetID string, fields []string, meta *model.Metadata, config *IngestTaskConfig) error {
 	// build variable lookup
-	mappedVariables := apicompute.MapVariables(meta.GetMainDataResource().Variables, func(variable *model.Variable) string { return variable.Key })
+	mappedVariables := api.MapVariables(meta.GetMainDataResource().Variables, func(variable *model.Variable) string { return variable.Key })
 
 	// create indices for flagged fields
 	for _, fieldName := range fields {

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -24,7 +24,6 @@ import (
 	"github.com/uncharted-distil/distil-compute/model"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
-	apiCompute "github.com/uncharted-distil/distil/api/compute"
 	"github.com/uncharted-distil/distil/api/env"
 	apiModel "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/serialization"
@@ -71,8 +70,8 @@ func JoinDistil(joinLeft *JoinSpec, joinRight *JoinSpec, leftCol string, rightCo
 	if err != nil {
 		return "", nil, err
 	}
-	varsLeftMap := apiCompute.MapVariables(joinLeft.Variables, func(variable *model.Variable) string { return variable.Key })
-	varsRightMap := apiCompute.MapVariables(joinRight.Variables, func(variable *model.Variable) string { return variable.Key })
+	varsLeftMap := apiModel.MapVariables(joinLeft.Variables, func(variable *model.Variable) string { return variable.Key })
+	varsRightMap := apiModel.MapVariables(joinRight.Variables, func(variable *model.Variable) string { return variable.Key })
 	pipelineDesc, err := description.CreateJoinPipeline("Joiner", "Join existing data", varsLeftMap[leftCol], varsRightMap[rightCol], 0.8)
 	if err != nil {
 		return "", nil, err
@@ -244,8 +243,8 @@ func denormVariableName(variable *model.Variable) string {
 func joinMetadataVariables(headerNames []string, leftVariables []*model.Variable, leftMetadata *model.Metadata,
 	rightVariables []*model.Variable, rightMetadata *model.Metadata) ([]*model.Variable, []*model.DataResource) {
 	// map the variables using the header names
-	leftMap := apiCompute.MapVariables(leftVariables, denormVariableName)
-	rightMap := apiCompute.MapVariables(rightVariables, denormVariableName)
+	leftMap := apiModel.MapVariables(leftVariables, denormVariableName)
+	rightMap := apiModel.MapVariables(rightVariables, denormVariableName)
 
 	// left dataset takes priority in case of conflict
 	mergedVariables := make([]*model.Variable, len(headerNames))

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -855,12 +855,12 @@ func copyFeatureGroups(fittedSolutionID string, datasetName string, solutionStor
 	if err != nil {
 		return err
 	}
-	variableMap := comp.MapVariables(variables, func(variable *model.Variable) string { return variable.Key })
+	variableMap := api.MapVariables(variables, func(variable *model.Variable) string { return variable.Key })
 	variablesPrediction, err := metaStorage.FetchVariables(datasetName, false, true, false)
 	if err != nil {
 		return err
 	}
-	variablePredictionMap := comp.MapVariables(variablesPrediction, func(variable *model.Variable) string { return variable.Key })
+	variablePredictionMap := api.MapVariables(variablesPrediction, func(variable *model.Variable) string { return variable.Key })
 
 	// copy over the groups that are found and dont already exist in the prediction dataset
 	for _, feature := range solutionRequest.Features {


### PR DESCRIPTION
Reorganized disk dataset code to have common update code be used in multiple places and simplify code in general. Prefiltering now uses the same update code as the export / cloning code. It also treats prefeaturized and non prefeaturized datasets identically.

The solution request persist and dispatch cleaned up slightly and some redundant parameters have been removed (namely the target index).