### PR TITLE
Map loading fixes

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -272,7 +272,6 @@ export default Vue.extend({
 
   data() {
     return {
-      poiLayer: null,
       map: null,
       tileRenderer: null,
       overlay: null,
@@ -280,7 +279,6 @@ export default Vue.extend({
       markers: null,
       areasMeanLng: 0,
       closeButton: null,
-      startingLatLng: null,
       currentRect: null,
       selectedRect: null,
       isSelectionMode: false,
@@ -317,6 +315,7 @@ export default Vue.extend({
       confidenceIconClass: "confidence-icon",
       isSatelliteView: false,
       tileAreaThreshold: 170, // area in pixels
+      boundsInitialized: false,
     };
   },
 
@@ -1299,6 +1298,12 @@ export default Vue.extend({
         quads,
         this.currentState.drawMode()
       );
+
+      if (!this.boundsInitialized) {
+        const mapBounds = this.getBounds(quads);
+        this.map.fitToBounds(mapBounds);
+        this.boundsInitialized = true;
+      }
     },
   },
 });

--- a/public/components/facets/FacetNumerical.vue
+++ b/public/components/facets/FacetNumerical.vue
@@ -72,8 +72,8 @@ import "@uncharted.software/facets-core";
 import "@uncharted.software/facets-plugins";
 import { FacetBarsData } from "@uncharted.software/facets-core/dist/types/facet-bars/FacetBars";
 
-import TypeChangeMenu from "../TypeChangeMenu";
-import ImportanceBars from "../ImportanceBars";
+import TypeChangeMenu from "../TypeChangeMenu.vue";
+import ImportanceBars from "../ImportanceBars.vue";
 import { Highlight, RowSelection, VariableSummary } from "../../store/dataset";
 import {
   getSubSelectionValues,
@@ -108,7 +108,10 @@ export default Vue.extend({
       Function as () => Function,
     ],
     expandCollapse: Function as () => Function,
-    highlights: Array as () => Highlight[],
+    highlights: {
+      type: Array as () => Highlight[],
+      default: () => [] as Highlight[],
+    },
     enableHighlighting: Boolean as () => boolean,
     instanceName: String as () => string,
     rowSelection: Object as () => RowSelection,

--- a/public/util/lex.ts
+++ b/public/util/lex.ts
@@ -15,12 +15,7 @@
  *    limitations under the License.
  */
 
-import {
-  GeoCoordinateGrouping,
-  Highlight,
-  TimeseriesGrouping,
-  Variable,
-} from "../store/dataset";
+import { Highlight, Variable } from "../store/dataset";
 import {
   isNumericType,
   dateToNum,
@@ -29,8 +24,6 @@ import {
   TIMESERIES_TYPE,
   GEOCOORDINATE_TYPE,
   GEOBOUNDS_TYPE,
-  MULTIBAND_IMAGE_TYPE,
-  NUMERIC_TYPE,
 } from "./types";
 import {
   decodeFilters,
@@ -60,7 +53,7 @@ import { Dictionary } from "./dict";
 
 const HIGHLIGHT = "highlight";
 
-/* 
+/*
   These are the custom relation options for our distil lex grammar that map our
   filter and highlight actions to lex bar style relation options. Should we
   ever want even more complex filter relations, we can extend these options.
@@ -227,7 +220,7 @@ export function filterParamsToLexQuery(
 }
 
 /*
-  This translates a lex query's relation and value states to generate a new 
+  This translates a lex query's relation and value states to generate a new
   highlight and filter state so that it can be used to update the route and so
   update the filter and highlight state of the application.
 */
@@ -319,11 +312,11 @@ function modeToRelation(mode: string): ValueStateValue {
   }
 }
 
-/* 
+/*
   Formats distil variables to Lex Suggestions AKA ValueStateValues so they can
   be used in the Lex Language and in translating filter/highlight state into a
-  lex query. Also ungroups some variables such that we can use them in lex 
-  queries as that reflects the current filter/highlight behavior. 
+  lex query. Also ungroups some variables such that we can use them in lex
+  queries as that reflects the current filter/highlight behavior.
 */
 function variablesToLexSuggestions(variables: Variable[]): ValueStateValue[] {
   if (!variables) return;
@@ -373,8 +366,8 @@ function colTypeToOptionType(colType: string): string {
 }
 
 /*
-  Convert Distil Variable Array To a Dictionary For O(1) look up. Used when 
-  converting a filter/highlight from the distil format to a lex query. 
+  Convert Distil Variable Array To a Dictionary For O(1) look up. Used when
+  converting a filter/highlight from the distil format to a lex query.
 */
 function buildVariableDictionary(variables: Variable[]) {
   return variables.reduce((a, v) => {

--- a/public/util/summaries.ts
+++ b/public/util/summaries.ts
@@ -38,7 +38,9 @@ export function resultSummariesToVariables(solutionID: string): Variable[] {
   ];
   const variables = [];
   summaries.forEach((sum) => {
-    if (sum) {
+    // make sure to exclude pending summaries since they
+    // won't have all of their information available
+    if (sum && !sum.pending) {
       variables.push(summaryToVariable(sum));
     }
   });


### PR DESCRIPTION
fixes #2369

There were a few accumulating issues that ended up contributing to this:

1.  An exception was being thrown by the numerical facet when the highlight was unset due to it being initialized to `null` rather than an empty list.
1. An attempt was made to fetch type info from summaries that were in the pending state.  That information is not available until the summary data is fully resolved.
1. The geoplot map bounds were initialized on mount based on available location data.  With larger datasets, the location data was often not yet fetched, causing the map to initialize its bounds to null island, and there was no subsequent update to the bounds when the data did arrive.  We now do a one-time init of the bounds when the data first arrives.