### PR TITLE
Confidence Query Performance

### DIFF
--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -20,6 +20,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/pkg/errors"
+	log "github.com/unchartedsoftware/plog"
+
 	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
 )
@@ -76,11 +79,17 @@ func (s *Storage) fetchExplainHistogram(dataset string, storageName string, targ
 	// use a numerical sub select
 	field := NewNumericalFieldSubSelect(s, dataset, storageName, explainFieldAlias, explainFieldName, model.RealType, "", s.explainSubSelect(storageName, explainFieldName, explainFieldAlias))
 
-	// use predefined ranged of [0,1] for everything except rank - we'll leave that as nil so that it
-	// will be computed when the histogram is fetched
+	// use predefined ranged of [0,1] for everything except rank
+	// rank extrema should be pulled now to optimize the query
 	var extrema *api.Extrema
-	if explainFieldName != "rank" {
+	var err error
+	if explainFieldName == "rank" {
+		extrema, err = s.fetchExplainExtrema(storageName, explainFieldName, resultURI)
+	} else {
 		extrema, _ = api.NewExtrema(0.0, 1.0)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	// filter for the single result confidences instead of having all result confidences
@@ -107,6 +116,43 @@ func (s *Storage) listExplainFields() []string {
 	}
 
 	return jsonNames
+}
+
+func (s *Storage) fetchExplainExtrema(storageName string, explainFieldName string, resultURI string) (*api.Extrema, error) {
+	selectSQL := fmt.Sprintf(
+		"MIN((explain_values ->> '%s')::double precision) as min_val, MAX((explain_values ->> '%s')::double precision) as max_val",
+		explainFieldName, explainFieldName)
+	sql := fmt.Sprintf("SELECT %s FROM %s WHERE result_id = $1", selectSQL, s.getResultTable(storageName))
+
+	rows, err := s.client.Query(sql, resultURI)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to query explain field extrema")
+	}
+	defer rows.Close()
+
+	var minValue *float64
+	var maxValue *float64
+	if rows.Next() {
+		err := rows.Scan(&minValue, &maxValue)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to parse extrema for explain field")
+		}
+	}
+
+	// check values exist and if none exist, then use a default extrema to avoid slow queries.
+	if minValue == nil || maxValue == nil {
+		log.Warnf("no min / max aggregation values found for explain field so defaulting to [0, 1]")
+		minValue = new(float64)
+		*minValue = 0
+		maxValue = new(float64)
+		*maxValue = 1
+	}
+
+	// assign attributes
+	return &api.Extrema{
+		Min: *minValue,
+		Max: *maxValue,
+	}, nil
 }
 
 func (s *Storage) explainSubSelect(storageName string, fieldName string, aliasName string) func() string {

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -174,7 +174,10 @@ var (
 		"float":   true,
 		"real":    true,
 	}
-	wordRegex = regexp.MustCompile("[^a-zA-Z]")
+	wordRegex     = regexp.MustCompile("[^a-zA-Z]")
+	resultIndices = []string{
+		"result_id",
+	}
 )
 
 // Database is a struct representing a full logical database.
@@ -429,6 +432,15 @@ func (d *Database) CreateResultTable(tableName string) error {
 	_, err = d.Client.Exec(createStatement)
 	if err != nil {
 		return err
+	}
+
+	log.Infof("creating indices on result table %s", resultTableName)
+	for i, index := range resultIndices {
+		indexStatement := fmt.Sprintf("CREATE INDEX idx%d_%s ON %s (%s)", i+1, resultTableName, resultTableName, index)
+		_, err = d.Client.Exec(indexStatement)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Added an index on the result id of the result table to speed up querying when more and more results are stored. Also updated the confidence fetching to pull the extrema for ranks using a specific query rather than relying on the general numeric field query since that one is a bit more complicated.