### PR TITLE
Atmospheric Penetration Layer Mapping

### DIFF
--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -132,7 +132,7 @@ func init() {
 		FalseColorInfrared:     {FalseColorInfrared, "False Color Infrared", []string{"b08", "b04", "b03"}, nil, nil},
 		FalseColorUrban:        {FalseColorUrban, "False Color Urban", []string{"b12", "b11", "b04"}, nil, nil},
 		Agriculture:            {Agriculture, "Agriculture", []string{"b11", "b08", "b02"}, nil, nil},
-		AtmosphericPenetration: {AtmosphericPenetration, "Atmospheric Penetration", []string{"b12", "b11", "b8A"}, nil, nil},
+		AtmosphericPenetration: {AtmosphericPenetration, "Atmospheric Penetration", []string{"b12", "b11", "b8a"}, nil, nil},
 		HealthyVegetation:      {HealthyVegetation, "Healthy Vegetation", []string{"b08", "b11", "b02"}, nil, nil},
 		LandWater:              {LandWater, "Land/Water", []string{"b08", "b11", "b04"}, nil, nil},
 		AtmosphericRemoval:     {AtmosphericRemoval, "Atmospheric Removal", []string{"b12", "b08", "b03"}, nil, nil},


### PR DESCRIPTION
Fixes #2370 

One band was not set to lowercase as expected in the layer mappings.