### PR TITLE
Parquet read memory optimization

### DIFF
--- a/api/compute/split.go
+++ b/api/compute/split.go
@@ -261,6 +261,7 @@ func (s *stratifiedSplitter) splitCategories(colIndex int, data [][]string) map[
 }
 
 func (s *stratifiedSplitter) split(data [][]string) ([][]string, [][]string, error) {
+	log.Infof("performing split based on stratified sampling")
 	// create the output
 	outputTrain := [][]string{}
 	outputTest := [][]string{}
@@ -275,9 +276,11 @@ func (s *stratifiedSplitter) split(data [][]string) ([][]string, [][]string, err
 	// subsets by category, and then sampling the subsets using the supplied train/test ratio.
 
 	// first pass - create subsets by category
+	log.Infof("collecting categories")
 	categoryRowData := s.splitCategories(s.targetCol, inputData)
 
 	// second pass - randomly sample each category to generate train/test split
+	log.Infof("shuffling and splitting based on %d categories", len(categoryRowData))
 	for _, data := range categoryRowData {
 		maxCategoryTrainingRows := int(math.Max(1, float64(len(data))/float64(len(inputData))*float64(numTrainingRows)))
 		maxCategoryTestRows := int(math.Max(1, float64(len(data))/float64(len(inputData))*float64(numTestRows)))

--- a/api/serialization/parquet_test.go
+++ b/api/serialization/parquet_test.go
@@ -1,3 +1,18 @@
+//
+//   Copyright © 2021 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
 package serialization
 
 import (

--- a/api/serialization/parquet_test.go
+++ b/api/serialization/parquet_test.go
@@ -1,0 +1,43 @@
+package serialization
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadWriteParquet(t *testing.T) {
+	p := NewParquet()
+
+	// Generate a parquet file
+	rows := 5
+	cols := 10
+	fileName := "test/test_file.parquet"
+	originalData, err := generateParquet(p, cols, rows, fileName)
+	assert.NoError(t, err)
+
+	// Read it in with a transposition
+	data, err := p.ReadData(fileName)
+	assert.NoError(t, err)
+	assert.Equal(t, len(data), rows)
+	assert.Equal(t, len(data[0]), cols)
+
+	assert.Equal(t, originalData, data)
+}
+
+func generateParquet(p *Parquet, cols int, rows int, fileName string) ([][]string, error) {
+	data := make([][]string, rows)
+	for i := 0; i < rows; i++ {
+		rowData := make([]string, cols)
+		for j := 0; j < cols; j++ {
+			rowData[j] = fmt.Sprintf("row_%d__col_%d", i, j)
+		}
+		data[i] = rowData
+	}
+	err := p.WriteData(fileName, data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}


### PR DESCRIPTION
Testing with unpooled prefeaturized data revealed a case where we were creating 2 copies of a dataset on load.  This normally is not a problem, but the unpooled set was 10K rows x 32K columns, which is much larger than those we have typically dealt with.  This update allocates the memory for the output up front, then incrementally updates it with column data as it is loaded.  Column data *should* be freed as it is no longer referenced the  next pass through the loop.