### PR TITLE
generate explanations for unpooled remote sensing datasets

### DIFF
--- a/api/compute/search.go
+++ b/api/compute/search.go
@@ -81,12 +81,9 @@ func (s *SolutionRequest) dispatchSolutionExplainPipeline(client *compute.Client
 	for _, eo := range explainOutputs {
 		exposedOutputs = append(exposedOutputs, eo.output)
 	}
-
-	exposeType := []string{}
-	if s.useParquet {
-		exposeType = append(exposeType, compute.ParquetURIValueType)
-	}
-	produceSolutionRequest := createProduceSolutionRequest(explainDatasetURI, searchResult.fittedSolutionID, exposedOutputs, exposeType)
+	// create the produce request that will generate the explanations - we force the use of CSV for output since the
+	// go parquet library doesn't handle nested lists well
+	produceSolutionRequest := createProduceSolutionRequest(explainDatasetURI, searchResult.fittedSolutionID, exposedOutputs, []string{compute.CSVURIValueType})
 
 	// generate predictions
 	_, predictionResponses, err := client.GeneratePredictions(context.Background(), produceSolutionRequest)


### PR DESCRIPTION
fixes #2343

1. Allows explanations to be generated when there is a learning dataset AND the system is working with unpooled data.  We should probably be storing whether a dasaset is pooled or unpooled in the metadata, but we currently read the POOL_FEATURES env var.
2. Forces the explanation produce call use CSV for output, as the go parquet lib we use handles nested lists by flattening them, without providing any of the original dimensions.  This makes it impossible to reconstitute the 4x4 attention matrices from the flattened data.