### PR TITLE
Coordinates Group Filter

### DIFF
--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -758,6 +758,9 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 	}
 	datasetPathTest = fmt.Sprintf("file://%s", datasetPathTest)
 
+	// get filters that map filters on groupings to the underlying field
+	s.Filters = mapFilterKeys(s.Dataset, s.Filters, dataset.Variables)
+
 	// generate the pre-processing pipeline to enforce feature selection and semantic type changes
 	var preprocessing *pipeline.PipelineDescription
 	if !client.SkipPreprocessing {

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210316110323-e63d6af46fff
+	github.com/uncharted-distil/distil-compute v0.0.0-20210319155318-38b7539dfad7
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210316110323-e63d6af46fff h1:L+3/CmHHeuF4AHYvipl+8ilKzZGnu7TjTrY8eg7aS0A=
-github.com/uncharted-distil/distil-compute v0.0.0-20210316110323-e63d6af46fff/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210319155318-38b7539dfad7 h1:tsgzpGYUOFCcQnEmuQ++I8cPW9DN5ksHA0jJ6S8P0q0=
+github.com/uncharted-distil/distil-compute v0.0.0-20210319155318-38b7539dfad7/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=


### PR DESCRIPTION
Fixes #2371 

Geobounds group filters had to be mapped to the underlying field for filtering. Note that this wont work until the vector bounds primitive is updated to no longer use nested lists.