### PR TITLE
Select a positive label

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "preact": "8.5.3",
     "sigma": "^1.2.1",
     "store": "^2.0.12",
+    "string-similarity": "^4.0.4",
     "ts-enum-util": "^4.0.1",
     "vue": "^2.6.6",
     "vue-observe-visibility": "^0.4.4",

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -66,6 +66,7 @@ import { getters as routeGetters } from "../store/route/module";
 import { RESULTS_ROUTE } from "../store/route/index";
 import { actions as requestActions } from "../store/requests/module";
 import { Solution } from "../store/requests/index";
+import { SolutionRequestMsg } from "../store/requests/actions";
 import { Variable, DataMode } from "../store/dataset/index";
 import { DATE_TIME_TYPE } from "../util/types";
 import { FilterParams } from "../util/filters";
@@ -161,18 +162,25 @@ export default Vue.extend({
       const routeSplit = routeGetters.getRouteTrainTestSplit(this.$store);
       const defaultSplit = appGetters.getTrainTestSplit(this.$store);
       const timestampSplit = routeGetters.getRouteTimestampSplit(this.$store);
+
+      const solutionRequestMsg = {
+        dataset: this.dataset,
+        filters: this.filterParams,
+        target: routeGetters.getRouteTargetVariable(this.$store),
+        metrics: this.metrics,
+        maxSolutions: routeGetters.getModelLimit(this.$store),
+        maxTime: routeGetters.getModelTimeLimit(this.$store),
+        quality: routeGetters.getModelQuality(this.$store),
+        trainTestSplit: !!routeSplit ? routeSplit : defaultSplit,
+        timestampSplitValue: timestampSplit,
+      } as SolutionRequestMsg;
+
+      // Add optional values to the request
+      const positiveLabel = routeGetters.getPositiveLabel(this.$store);
+      if (positiveLabel) solutionRequestMsg.positiveLabel = positiveLabel;
+
       requestActions
-        .createSolutionRequest(this.$store, {
-          dataset: this.dataset,
-          filters: this.filterParams,
-          target: routeGetters.getRouteTargetVariable(this.$store),
-          metrics: this.metrics,
-          maxSolutions: routeGetters.getModelLimit(this.$store),
-          maxTime: routeGetters.getModelTimeLimit(this.$store),
-          quality: routeGetters.getModelQuality(this.$store),
-          trainTestSplit: !!routeSplit ? routeSplit : defaultSplit,
-          timestampSplitValue: timestampSplit,
-        })
+        .createSolutionRequest(this.$store, solutionRequestMsg)
         .then((res: Solution) => {
           this.pending = false;
           const dataMode = routeGetters.getDataMode(this.$store);

--- a/public/components/TargetVariable.vue
+++ b/public/components/TargetVariable.vue
@@ -26,14 +26,21 @@
       :log-activity="logActivity"
     />
 
-    <form v-if="labels">
-      <label for="positive-label">Positive Label</label>
-      <select id="positive-label">
-        <option v-for="(label, index) in labels" :key="index" :value="label">
-          {{ label }}
-        </option>
-      </select>
-    </form>
+    <!-- Dropdown to select a positive label for Binary Classification task -->
+    <b-form-group
+      v-if="options"
+      label="Positive Label:"
+      label-class="font-weight-bold"
+      label-cols="auto"
+      label-size="sm"
+    >
+      <b-form-select
+        id="positive-label"
+        v-model="positiveLabel"
+        :options="options"
+        size="sm"
+      />
+    </b-form-group>
   </div>
 </template>
 
@@ -42,8 +49,9 @@ import Vue from "vue";
 import VariableFacets from "./facets/VariableFacets.vue";
 import { getters as routeGetters } from "../store/route/module";
 import { TARGET_VAR_INSTANCE } from "../store/route/index";
-import { Bucket, VariableSummary } from "../store/dataset/index";
+import { VariableSummary } from "../store/dataset/index";
 import { Activity } from "../util/userEvents";
+import { overlayRouteEntry, RouteArgs } from "../util/routes";
 
 export default Vue.extend({
   name: "TargetVariable",
@@ -54,29 +62,67 @@ export default Vue.extend({
 
   data() {
     return {
-      hasDefaultedAlready: false,
-      logActivity: Activity.DATA_PREPARATION,
       instanceName: TARGET_VAR_INSTANCE,
+      logActivity: Activity.DATA_PREPARATION,
+      positiveLabel: null as string,
     };
   },
 
   computed: {
-    isBinaryClassification(): boolean {
-      return routeGetters.isBinaryClassification(this.$store);
-    },
-
     targetSummaries(): VariableSummary[] {
       return routeGetters.getTargetVariableSummaries(this.$store);
     },
 
-    labels(): string[] {
-      if (!this.isBinaryClassification) return;
+    // Define the posible options for the positive label <select>.
+    options(): string[] {
+      // Check that we are on a binary classification task
+      if (!routeGetters.isBinaryClassification(this.$store)) return;
 
-      const buckets = this.targetSummaries?.[0]?.baseline?.buckets as Bucket[];
+      // retreive the target variable buckets
+      const buckets = this.targetSummaries?.[0]?.baseline?.buckets;
       if (!buckets) return;
 
-      const labels = buckets.map((bucket) => bucket.key);
-      return labels;
+      // Use the buckets key as <options>
+      const options = buckets.map((bucket) => bucket.key);
+
+      // Pre-select the label that's most likely to be a positive label
+      this.findPositiveLabel(options);
+
+      return options;
+    },
+
+    routePositiveLabel(): string {
+      return routeGetters.getPositiveLabel(this.$store);
+    },
+  },
+
+  watch: {
+    positiveLabel(label: string, oldLabel: string): void {
+      if (label === oldLabel) return;
+      if (label === this.routePositiveLabel) return;
+      this.updateRoute({ positiveLabel: label });
+    },
+  },
+
+  beforeMount() {
+    // If the positive label is already set in the route, pre-select it.
+    if (!!this.routePositiveLabel && !this.positiveLabel) {
+      this.positiveLabel = this.routePositiveLabel;
+    }
+  },
+
+  methods: {
+    // Find which options is most suited to be the positive label
+    findPositiveLabel(options: string[]): void {
+      // Do not find a new label if the positiveLabel is already set
+      if (!!this.positiveLabel) return;
+      const label = options[0];
+      this.positiveLabel = label;
+    },
+
+    updateRoute(args: RouteArgs): void {
+      const entry = overlayRouteEntry(this.$route, args);
+      this.$router.push(entry).catch((err) => console.warn(err));
     },
   },
 });

--- a/public/components/TargetVariable.vue
+++ b/public/components/TargetVariable.vue
@@ -26,10 +26,8 @@
       :log-activity="logActivity"
     />
 
-    <positive-label
-      v-if="isBinaryClassification"
-      :target-summary="targetSummaries[0]"
-    />
+    <!-- Dropdown to select a positive label for Binary Classification task -->
+    <positive-label v-if="labels" :labels="labels" />
   </div>
 </template>
 
@@ -58,12 +56,20 @@ export default Vue.extend({
   },
 
   computed: {
-    isBinaryClassification(): boolean {
-      return routeGetters.isBinaryClassification(this.$store);
-    },
-
     targetSummaries(): VariableSummary[] {
       return routeGetters.getTargetVariableSummaries(this.$store);
+    },
+
+    labels(): string[] {
+      // make sure we are only on a binary classification task
+      if (!routeGetters.isBinaryClassification(this.$store)) return;
+
+      // retreive the target variable buckets
+      const buckets = this.targetSummaries?.[0]?.baseline?.buckets;
+      if (!buckets) return;
+
+      // use the buckets keys as labels
+      return buckets.map((bucket) => bucket.key);
     },
   },
 });

--- a/public/components/TargetVariable.vue
+++ b/public/components/TargetVariable.vue
@@ -25,16 +25,24 @@
       :instance-name="instanceName"
       :log-activity="logActivity"
     />
+
+    <form v-if="labels">
+      <label for="positive-label">Positive Label</label>
+      <select id="positive-label">
+        <option v-for="(label, index) in labels" :key="index" :value="label">
+          {{ label }}
+        </option>
+      </select>
+    </form>
   </div>
 </template>
 
 <script lang="ts">
-import _ from "lodash";
 import Vue from "vue";
 import VariableFacets from "./facets/VariableFacets.vue";
 import { getters as routeGetters } from "../store/route/module";
 import { TARGET_VAR_INSTANCE } from "../store/route/index";
-import { VariableSummary } from "../store/dataset/index";
+import { Bucket, VariableSummary } from "../store/dataset/index";
 import { Activity } from "../util/userEvents";
 
 export default Vue.extend({
@@ -48,26 +56,28 @@ export default Vue.extend({
     return {
       hasDefaultedAlready: false,
       logActivity: Activity.DATA_PREPARATION,
+      instanceName: TARGET_VAR_INSTANCE,
     };
   },
 
   computed: {
+    isBinaryClassification(): boolean {
+      return routeGetters.isBinaryClassification(this.$store);
+    },
+
     targetSummaries(): VariableSummary[] {
       return routeGetters.getTargetVariableSummaries(this.$store);
     },
-    instanceName(): string {
-      return TARGET_VAR_INSTANCE;
+
+    labels(): string[] {
+      if (!this.isBinaryClassification) return;
+
+      const buckets = this.targetSummaries?.[0]?.baseline?.buckets as Bucket[];
+      if (!buckets) return;
+
+      const labels = buckets.map((bucket) => bucket.key);
+      return labels;
     },
   },
 });
 </script>
-
-<style>
-.target-summary
-  .variable-facets-container
-  .facets-root-container
-  .facets-group-container
-  .facets-group {
-  box-shadow: none;
-}
-</style>

--- a/public/components/TargetVariable.vue
+++ b/public/components/TargetVariable.vue
@@ -26,37 +26,27 @@
       :log-activity="logActivity"
     />
 
-    <!-- Dropdown to select a positive label for Binary Classification task -->
-    <b-form-group
-      v-if="options"
-      label="Positive Label:"
-      label-class="font-weight-bold"
-      label-cols="auto"
-      label-size="sm"
-    >
-      <b-form-select
-        id="positive-label"
-        v-model="positiveLabel"
-        :options="options"
-        size="sm"
-      />
-    </b-form-group>
+    <positive-label
+      v-if="isBinaryClassification"
+      :target-summary="targetSummaries[0]"
+    />
   </div>
 </template>
 
 <script lang="ts">
 import Vue from "vue";
+import PositiveLabel from "./buttons/PositiveLabel.vue";
 import VariableFacets from "./facets/VariableFacets.vue";
 import { getters as routeGetters } from "../store/route/module";
 import { TARGET_VAR_INSTANCE } from "../store/route/index";
 import { VariableSummary } from "../store/dataset/index";
 import { Activity } from "../util/userEvents";
-import { overlayRouteEntry, RouteArgs } from "../util/routes";
 
 export default Vue.extend({
   name: "TargetVariable",
 
   components: {
+    PositiveLabel,
     VariableFacets,
   },
 
@@ -64,65 +54,16 @@ export default Vue.extend({
     return {
       instanceName: TARGET_VAR_INSTANCE,
       logActivity: Activity.DATA_PREPARATION,
-      positiveLabel: null as string,
     };
   },
 
   computed: {
+    isBinaryClassification(): boolean {
+      return routeGetters.isBinaryClassification(this.$store);
+    },
+
     targetSummaries(): VariableSummary[] {
       return routeGetters.getTargetVariableSummaries(this.$store);
-    },
-
-    // Define the posible options for the positive label <select>.
-    options(): string[] {
-      // Check that we are on a binary classification task
-      if (!routeGetters.isBinaryClassification(this.$store)) return;
-
-      // retreive the target variable buckets
-      const buckets = this.targetSummaries?.[0]?.baseline?.buckets;
-      if (!buckets) return;
-
-      // Use the buckets key as <options>
-      const options = buckets.map((bucket) => bucket.key);
-
-      // Pre-select the label that's most likely to be a positive label
-      this.findPositiveLabel(options);
-
-      return options;
-    },
-
-    routePositiveLabel(): string {
-      return routeGetters.getPositiveLabel(this.$store);
-    },
-  },
-
-  watch: {
-    positiveLabel(label: string, oldLabel: string): void {
-      if (label === oldLabel) return;
-      if (label === this.routePositiveLabel) return;
-      this.updateRoute({ positiveLabel: label });
-    },
-  },
-
-  beforeMount() {
-    // If the positive label is already set in the route, pre-select it.
-    if (!!this.routePositiveLabel && !this.positiveLabel) {
-      this.positiveLabel = this.routePositiveLabel;
-    }
-  },
-
-  methods: {
-    // Find which options is most suited to be the positive label
-    findPositiveLabel(options: string[]): void {
-      // Do not find a new label if the positiveLabel is already set
-      if (!!this.positiveLabel) return;
-      const label = options[0];
-      this.positiveLabel = label;
-    },
-
-    updateRoute(args: RouteArgs): void {
-      const entry = overlayRouteEntry(this.$route, args);
-      this.$router.push(entry).catch((err) => console.warn(err));
     },
   },
 });

--- a/public/components/buttons/PositiveLabel.vue
+++ b/public/components/buttons/PositiveLabel.vue
@@ -1,0 +1,112 @@
+<!--
+
+    Copyright © 2021 Uncharted Software Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<!-- Dropdown to select a positive label for Binary Classification task -->
+<template>
+  <b-form-group
+    label="Positive Label:"
+    label-class="font-weight-bold"
+    label-cols="auto"
+    label-size="sm"
+  >
+    <b-form-select
+      id="positive-label"
+      v-model="positiveLabel"
+      :options="options"
+      size="sm"
+    />
+  </b-form-group>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { findBestMatch } from "string-similarity";
+import { VariableSummary } from "../../store/dataset/index";
+import { getters as routeGetters } from "../../store/route/module";
+import { overlayRouteEntry, RouteArgs } from "../../util/routes";
+
+export default Vue.extend({
+  name: "PositiveLabel",
+
+  props: {
+    targetSummary: {
+      type: Object as () => VariableSummary,
+      default: null,
+    },
+  },
+
+  data() {
+    return {
+      positiveLabel: null as string,
+    };
+  },
+
+  computed: {
+    // Define the posible options for the positive label <select>.
+    options(): string[] {
+      // retreive the target variable buckets
+      const buckets = this.targetSummary?.baseline?.buckets;
+      if (!buckets) return;
+
+      // Use the buckets key as <options>
+      const options = buckets.map((bucket) => bucket.key);
+
+      // Pre-select the label that's most likely to be a positive label
+      this.findPositiveLabel(options);
+
+      return options;
+    },
+
+    routePositiveLabel(): string {
+      return routeGetters.getPositiveLabel(this.$store);
+    },
+  },
+
+  watch: {
+    positiveLabel(label: string, oldLabel: string): void {
+      if (label === oldLabel) return;
+      if (label === this.routePositiveLabel) return;
+      this.updateRoute({ positiveLabel: label });
+    },
+  },
+
+  beforeMount() {
+    // If the positive label is already set in the route, pre-select it.
+    if (!!this.routePositiveLabel && !this.positiveLabel) {
+      this.positiveLabel = this.routePositiveLabel;
+    }
+  },
+
+  methods: {
+    // Find which options is most suited to be the positive label
+    findPositiveLabel(options: string[]): void {
+      // Do not find a new label if the positiveLabel is already set
+      if (!!this.positiveLabel) return;
+
+      // findBestMatch();
+
+      const label = options[0];
+      this.positiveLabel = label;
+    },
+
+    updateRoute(args: RouteArgs): void {
+      const entry = overlayRouteEntry(this.$route, args);
+      this.$router.push(entry).catch((err) => console.warn(err));
+    },
+  },
+});
+</script>

--- a/public/components/buttons/PositiveLabel.vue
+++ b/public/components/buttons/PositiveLabel.vue
@@ -20,6 +20,7 @@
     label="Positive Label:"
     label-class="font-weight-bold"
     label-cols="auto"
+    label-for="positive-label"
     label-size="sm"
   >
     <b-form-select
@@ -90,17 +91,13 @@ export default Vue.extend({
     // otherwise, find the label that's most likely to be a positive one.
     this.positiveLabel = !!this.routePositiveLabel
       ? this.routePositiveLabel
-      : this.findAPositiveLabel();
+      : this.findAPositiveLabel(this.labels);
   },
 
   methods: {
     // Find which labels is most suited to be the positive one
-    findAPositiveLabel(): string {
-      // Do not find a new label if the positive label is already set
-      if (!!this.positiveLabel) return;
-
-      // Calculate the string simularity ratings of each labels
-      const ratings = this.labels.map((label) => {
+    findAPositiveLabel(labels: string[]): string {
+      const ratings = labels.map((label) => {
         return {
           positive: findBestRating(label, positives),
           negative: findBestRating(label, negatives),
@@ -108,7 +105,7 @@ export default Vue.extend({
       });
 
       // Default to the first label
-      let positiveLabel = this.labels[0];
+      let positiveLabel = labels[0];
 
       // Select the second label, if the first label...
       if (
@@ -117,7 +114,7 @@ export default Vue.extend({
         // has a higher negative rating
         ratings[0].negative > ratings[1].negative
       ) {
-        positiveLabel = this.labels[1];
+        positiveLabel = labels[1];
       }
 
       return positiveLabel;

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -63,16 +63,17 @@ interface StatusMessage {
 }
 
 // Search request message used in web socket context
-interface SolutionRequestMsg {
+export interface SolutionRequestMsg {
   dataset: string;
-  target: string;
+  filters: FilterParams;
   metrics: string[];
   maxSolutions: number;
   maxTime: number;
+  positiveLabel?: string;
   quality: ModelQuality;
-  filters: FilterParams;
-  trainTestSplit: number;
+  target: string;
   timestampSplitValue?: number;
+  trainTestSplit: number;
 }
 
 // Solution status message used in web socket context
@@ -571,6 +572,7 @@ export const actions = {
       stream.send(MessageType.CREATE_SOLUTIONS, {
         dataset: request.dataset,
         target: request.target,
+        positiveLabel: request.positiveLabel,
         metrics: request.metrics,
         maxSolutions: request.maxSolutions,
         maxTime: request.maxTime,

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -597,6 +597,7 @@ export const getters = {
     const orderBy = state.query.orderBy as string;
     return !!orderBy;
   },
+
   /* Check if the current task includes Remote Sensing. */
   isMultiBandImage(state: Route): boolean {
     // Get the list of task of the route.
@@ -694,5 +695,23 @@ export const getters = {
   /* Get the active pane on the route */
   getRoutePane(state: Route): string {
     return state.query.pane as string;
+  },
+
+  /* Check if the current task includes a Binary classification. */
+  isBinaryClassification(state: Route): boolean {
+    // Get the list of task of the route.
+    const task = state.query.task as string;
+    if (!task) return false;
+
+    // Check if BINARY and CLASSIFICATION are part of it.
+    const isBinary = task.includes(TaskTypes.BINARY);
+    const isClassification = task.includes(TaskTypes.CLASSIFICATION);
+
+    return isBinary && isClassification;
+  },
+
+  /* Get the Binary Classification Positive Lable */
+  getPositiveLabel(state: Route): string {
+    return (state.query?.positiveLabel as string) ?? null;
   },
 };

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -710,7 +710,7 @@ export const getters = {
     return isBinary && isClassification;
   },
 
-  /* Get the Binary Classification Positive Lable */
+  /* Get the Binary Classification Positive Label */
   getPositiveLabel(state: Route): string {
     return (state.query?.positiveLabel as string) ?? null;
   },

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -147,4 +147,6 @@ export const getters = {
   getRoutePane: read(moduleGetters.getRoutePane),
   hasOrderBy: read(moduleGetters.hasOrderBy),
   getOrderBy: read(moduleGetters.getOrderBy),
+  isBinaryClassification: read(moduleGetters.isBinaryClassification),
+  getPositiveLabel: read(moduleGetters.getPositiveLabel),
 };

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -76,6 +76,7 @@ export interface RouteArgs {
   orderBy?: string;
   outlier?: string;
   priorRoute?: string;
+  positiveLabel?: string;
 }
 
 function validateQueryArgs(args: RouteArgs): RouteArgs {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5954,6 +5954,11 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
+string-similarity@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
+
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"


### PR DESCRIPTION
fix #2360

Allow the user to select which target label is the positive one during a binary classification task.
On the first load the component will preselect the most "positive" label of the two by comparing them with the two following lists, using a [string-simularity library](https://github.com/aceakash/string-similarity).
```js
const positives = ["true", "positive", "aff", "1", "yes", "good", "high"];
const negatives = ["false", "negative", "not", "0", "no", "bad", "low"];
```
<img width="553" alt="Screen Shot 2021-03-19 at 15 54 32" src="https://user-images.githubusercontent.com/636801/111835482-68079c80-88cb-11eb-92dd-38899fc0b611.png">

The selected positive label will be added to the _SolutionRequestMsg_ under the property `positiveLabel`.
