### PR TITLE
Chaining Labels

### DIFF
--- a/api/compute/pipeline.go
+++ b/api/compute/pipeline.go
@@ -272,6 +272,7 @@ func SubmitPipeline(client *compute.Client, datasets []string, datasetsProduce [
 	}
 
 	resultChan := queue.Enqueue(hashedPipelineEquivKey, queueTask)
+	defer queue.Done()
 
 	result := <-resultChan
 	if result.Error != nil {
@@ -280,7 +281,6 @@ func SubmitPipeline(client *compute.Client, datasets []string, datasetsProduce [
 
 	datasetURI := result.Output.(string)
 	cache.cache.Set(hashedPipelineUniqueKey, datasetURI, gc.DefaultExpiration)
-	queue.Done()
 	err = cache.PersistCache()
 	if err != nil {
 		log.Warnf("error persisting cache: %v", err)

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -85,14 +85,14 @@ type SolutionRequest struct {
 	DatasetAugmentations []*model.DatasetOrigin
 	TrainTestSplit       float64
 	CancelFuncs          map[string]context.CancelFunc
-	PosLabel			 string
-	mu               *sync.Mutex
-	wg               *sync.WaitGroup
-	requestChannel   chan SolutionStatus
-	solutionChannels []chan SolutionStatus
-	listener         SolutionStatusListener
-	finished         chan error
-	useParquet       bool
+	PosLabel             string
+	mu                   *sync.Mutex
+	wg                   *sync.WaitGroup
+	requestChannel       chan SolutionStatus
+	solutionChannels     []chan SolutionStatus
+	listener             SolutionStatusListener
+	finished             chan error
+	useParquet           bool
 }
 
 // NewSolutionRequest instantiates a new SolutionRequest.

--- a/api/task/solution.go
+++ b/api/task/solution.go
@@ -49,15 +49,11 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 		ranks[fw.FeatureName] = fw.Weight
 	}
 
+	// use target ranking if we do not have feature weights
+	// ignore errors in this part because they are secondary to saving the model
 	if len(ranks) == 0 {
-		summaryVariables, err := api.FetchSummaryVariables(dataset.ID, metadataStorage)
-		if err != nil {
-			return nil, err
-		}
-		ranks, err = TargetRank(dataset.Folder, request.TargetFeature(), summaryVariables, dataset.Source)
-		if err != nil {
-			return nil, err
-		}
+		summaryVariables, _ := api.FetchSummaryVariables(dataset.ID, metadataStorage)
+		ranks, _ = TargetRank(dataset.Folder, request.TargetFeature(), summaryVariables, dataset.Source)
 	}
 
 	varMap := make(map[string]*model.Variable)

--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -30,7 +30,7 @@
     <label-annotation
       v-if="containsUserAnnotation"
       :item="item"
-      :labelFeatureName="labelFeatureName"
+      :label-feature-name="labelFeatureName"
     />
   </ol>
 </template>

--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -27,7 +27,11 @@
     >
       {{ label.value }}
     </li>
-    <label-annotation v-if="containsUserAnnotation" :item="item" />
+    <label-annotation
+      v-if="containsUserAnnotation"
+      :item="item"
+      :labelFeatureName="labelFeatureName"
+    />
   </ol>
 </template>
 
@@ -41,7 +45,7 @@ import { getters as routeGetters } from "../store/route/module";
 import { getters as resultGetters } from "../store/results/module";
 import LabelAnnotation from "./labelingComponents/LabelAnnotation.vue";
 import _ from "lodash";
-import { minimumRouteKey, LOW_SHOT_LABEL_COLUMN_NAME } from "../util/data";
+import { minimumRouteKey } from "../util/data";
 
 interface Label {
   status: string;
@@ -75,6 +79,7 @@ export default Vue.extend({
       default: false,
     },
     isResult: { type: Boolean as () => boolean, default: false },
+    labelFeatureName: { type: String, default: "" },
   },
 
   computed: {
@@ -206,7 +211,7 @@ export default Vue.extend({
       if (!this.item) {
         return false;
       }
-      return this.item[LOW_SHOT_LABEL_COLUMN_NAME] !== undefined;
+      return this.item[this.labelFeatureName] !== undefined;
     },
   },
 

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -45,7 +45,7 @@
               alignHorizontal
               :item="item"
               :is-result="isResult"
-              :labelFeatureName="labelFeatureName"
+              :label-feature-name="labelFeatureName"
             />
           </div>
         </template>

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -45,6 +45,7 @@
               alignHorizontal
               :item="item"
               :is-result="isResult"
+              :labelFeatureName="labelFeatureName"
             />
           </div>
         </template>
@@ -98,6 +99,7 @@ export default Vue.extend({
     dataItems: Array as () => any[],
     dataFields: Object as () => Dictionary<TableColumn>,
     isResult: { type: Boolean as () => boolean, default: false },
+    labelFeatureName: { type: String, default: "" },
   },
 
   data() {

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -61,7 +61,7 @@
             shorten-labels
             align-horizontal
             :item="data.item"
-            :labelFeatureName="labelFeatureName"
+            :label-feature-name="labelFeatureName"
           />
         </div>
       </template>

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -61,6 +61,7 @@
             shorten-labels
             align-horizontal
             :item="data.item"
+            :labelFeatureName="labelFeatureName"
           />
         </div>
       </template>
@@ -180,6 +181,7 @@ export default Vue.extend({
     instanceName: { type: String as () => string, default: "" },
     dataItems: { type: Array as () => TableRow[], default: null },
     includedActive: { type: Boolean, default: true },
+    labelFeatureName: { type: String, default: "" },
   },
 
   data() {

--- a/public/components/labelingComponents/CreateLabelingForm.vue
+++ b/public/components/labelingComponents/CreateLabelingForm.vue
@@ -47,7 +47,7 @@ import { circleSpinnerHTML } from "../../util/spinner";
 import { getters as datasetGetters } from "../../store/dataset/module";
 import { VariableSummary } from "../../store/dataset";
 import { Dictionary } from "../../util/dict";
-import { LowShotLabels, LOW_SHOT_LABEL_COLUMN_NAME } from "../../util/data";
+import { LowShotLabels } from "../../util/data";
 import { getters as routeGetters } from "../../store/route/module";
 const enum COMPONENT_EVENT {
   EXPORT = "export",
@@ -59,6 +59,7 @@ export default Vue.extend({
   props: {
     isLoading: { type: Boolean as () => boolean, default: false },
     lowShotSummary: Object as () => VariableSummary,
+    labelFeatureName: { type: String, default: "" },
   },
   computed: {
     spinnerHTML(): string {
@@ -92,7 +93,7 @@ export default Vue.extend({
         this.$store
       );
       return summaryDictionary
-        ? summaryDictionary[LOW_SHOT_LABEL_COLUMN_NAME]
+        ? summaryDictionary[this.labelFeatureName]
         : null;
     },
   },

--- a/public/components/labelingComponents/LabelAnnotation.vue
+++ b/public/components/labelingComponents/LabelAnnotation.vue
@@ -24,15 +24,16 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { LowShotLabels, LOW_SHOT_LABEL_COLUMN_NAME } from "../../util/data";
+import { LowShotLabels } from "../../util/data";
 export default Vue.extend({
   name: "label-annotation",
   props: {
     item: Object as () => any,
+    labelFeatureName: { type: String, default: "" },
   },
   computed: {
     getLabel(): string {
-      switch (this.item[LOW_SHOT_LABEL_COLUMN_NAME].value) {
+      switch (this.item[this.labelFeatureName].value) {
         case LowShotLabels.positive:
           return "fa fa-plus-circle text-success p-1 fa-stack-1x";
           break;

--- a/public/components/labelingComponents/LabelGeoplot.vue
+++ b/public/components/labelingComponents/LabelGeoplot.vue
@@ -45,9 +45,7 @@ import { getters as routeGetters } from "../../store/route/module";
 import {
   getVariableSummariesByState,
   getAllDataItems,
-  LOW_SHOT_LABEL_COLUMN_NAME,
   LowShotLabels,
-  LOW_SHOT_SCORE_COLUMN_NAME,
 } from "../../util/data";
 import { isGeoLocatedType } from "../../util/types";
 import { actions as viewActions } from "../../store/view/module";
@@ -67,6 +65,8 @@ export default Vue.extend({
     includedActive: Boolean as () => boolean,
     dataItems: { type: Array as () => TableRow[], default: null },
     hasConfidence: { type: Boolean as () => boolean, default: false },
+    labelFeatureName: { type: String, default: "" },
+    labelScoreName: { type: String, default: "" },
   },
 
   computed: {
@@ -127,14 +127,14 @@ export default Vue.extend({
   },
   methods: {
     getConfidenceRank(item: TableRow, idx: number): number {
-      if (item[LOW_SHOT_LABEL_COLUMN_NAME] === LowShotLabels.positive) {
+      if (item[this.labelFeatureName] === LowShotLabels.positive) {
         return 1.0;
       }
-      if (item[LOW_SHOT_LABEL_COLUMN_NAME] === LowShotLabels.negative) {
+      if (item[this.labelFeatureName] === LowShotLabels.negative) {
         return 0;
       }
       // comes back order by confidence so the rank is already engrained in the array
-      if (item[LOW_SHOT_SCORE_COLUMN_NAME]) {
+      if (item[this.labelScoreName]) {
         return 1.0 - idx / this.dataItems.length;
       }
       return undefined;

--- a/public/components/labelingComponents/LabelScorePopUp.vue
+++ b/public/components/labelingComponents/LabelScorePopUp.vue
@@ -62,11 +62,7 @@ import {
   VariableSummary,
   TableColumn,
 } from "../../store/dataset/index";
-import {
-  LOW_SHOT_LABEL_COLUMN_NAME,
-  LowShotLabels,
-  getRandomInt,
-} from "../../util/data";
+import { LowShotLabels, getRandomInt } from "../../util/data";
 import SelectDataTable from "../SelectDataTable.vue";
 import ImageMosaic from "../ImageMosaic.vue";
 import LabelHeaderButtons from "./LabelHeaderButtons.vue";
@@ -97,6 +93,7 @@ export default Vue.extend({
     isLoading: { type: Boolean as () => boolean, default: false },
     modalId: { type: String as () => string, default: "score-popup" },
     isRemoteSensing: { type: Boolean as () => boolean, default: false }, // default to false to support every dataset
+    labelFeatureName: { type: String, default: "" },
   },
   data() {
     return { sampleSize: 10 };
@@ -117,7 +114,7 @@ export default Vue.extend({
     },
     randomItems(): TableRow[] {
       const random = this.data?.filter((d) => {
-        return d[LOW_SHOT_LABEL_COLUMN_NAME]?.value === LowShotLabels.unlabeled;
+        return d[this.labelFeatureName]?.value === LowShotLabels.unlabeled;
       });
       if (!random) {
         return null;

--- a/public/components/labelingComponents/LabelingDataSlot.vue
+++ b/public/components/labelingComponents/LabelingDataSlot.vue
@@ -56,6 +56,8 @@
         :instance-name="instanceName"
         :summaries="summaries"
         :has-confidence="hasConfidence"
+        :label-feature-name="labelFeatureName"
+        :label-score-name="labelScoreName"
         pagination
         includedActive
       />

--- a/public/components/labelingComponents/LabelingDataSlot.vue
+++ b/public/components/labelingComponents/LabelingDataSlot.vue
@@ -81,12 +81,7 @@ import {
 } from "../../store/dataset/index";
 import { getters as datasetGetters } from "../../store/dataset/module";
 import { getters as routeGetters } from "../../store/route/module";
-import {
-  LowShotLabels,
-  LOW_SHOT_LABEL_COLUMN_NAME,
-  LOW_SHOT_SCORE_COLUMN_NAME,
-  getAllDataItems,
-} from "../../util/data";
+import { LowShotLabels, getAllDataItems } from "../../util/data";
 import { createFiltersFromHighlights } from "../../util/highlights";
 import { Filter, INCLUDE_FILTER } from "../../util/filters";
 import LabelHeaderButtons from "./LabelHeaderButtons.vue";
@@ -114,6 +109,8 @@ export default Vue.extend({
     summaries: Array as () => VariableSummary[],
     instanceName: { type: String, default: "label" },
     hasConfidence: { type: Boolean as () => boolean, default: false },
+    labelFeatureName: { type: String, default: "" },
+    labelScoreName: { type: String, default: "" },
   },
   data() {
     return {
@@ -151,7 +148,7 @@ export default Vue.extend({
     },
     hasLowShotScores(): boolean {
       const orderBy = routeGetters.getOrderBy(this.$store);
-      return !orderBy ? false : orderBy.includes(LOW_SHOT_SCORE_COLUMN_NAME);
+      return !orderBy ? false : orderBy.includes(this.labelScoreName);
     },
     dataItems(): TableRow[] {
       const items =

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -107,15 +107,15 @@ export const ELASTIC_PROVENANCE = "elastic";
 export const FILE_PROVENANCE = "file";
 
 export const IMPORTANT_VARIABLE_RANKING_THRESHOLD = 0.5;
-export const LOW_SHOT_LABEL_COLUMN_NAME = "LowShotLabel";
-export const LOW_SHOT_SCORE_COLUMN_NAME =
-  "__query_" + LOW_SHOT_LABEL_COLUMN_NAME;
+export const LOW_SHOT_SCORE_COLUMN_PREFIX = "__query_";
+
 // LowShotLabels enum for labeling data in a binary classification
 export enum LowShotLabels {
   positive = "positive",
   negative = "negative",
   unlabeled = "unlabeled",
 }
+
 // DatasetUpdate is an interface that contains the data to update existing data
 export interface DatasetUpdate {
   index: string; // d3mIndex

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -108,7 +108,6 @@ import {
   NUM_PER_TARGET_PAGE,
   cloneDatasetUpdateRoute,
   LowShotLabels,
-  LOW_SHOT_LABEL_COLUMN_NAME,
   LOW_SHOT_SCORE_COLUMN_NAME,
   minimumRouteKey,
   addOrderBy,
@@ -157,7 +156,7 @@ export default Vue.extend({
   },
   data() {
     return {
-      labelName: LOW_SHOT_LABEL_COLUMN_NAME,
+      labelName: "",
       modalId: "label-input-form",
       isLoadingData: false,
       scorePopUpId: "modal-score-pop-up",
@@ -213,9 +212,7 @@ export default Vue.extend({
       const summaryDictionary = datasetGetters.getVariableSummariesDictionary(
         this.$store
       );
-      return summaryDictionary
-        ? summaryDictionary[LOW_SHOT_LABEL_COLUMN_NAME]
-        : null;
+      return summaryDictionary ? summaryDictionary[this.labelName] : null;
     },
     dataItems(): TableRow[] {
       return datasetGetters.getIncludedTableDataItems(this.$store);
@@ -238,10 +235,7 @@ export default Vue.extend({
     // filters out the low shot labels
     featureSummaries(): VariableSummary[] {
       return this.summaries.filter((s) => {
-        return (
-          s.key !== LOW_SHOT_LABEL_COLUMN_NAME &&
-          s.key !== LOW_SHOT_SCORE_COLUMN_NAME
-        );
+        return s.key !== this.labelName && s.key !== LOW_SHOT_SCORE_COLUMN_NAME;
       });
     },
     scoreSummary(): VariableSummary[] {
@@ -349,7 +343,7 @@ export default Vue.extend({
       this.isLoadingData = true;
       const res = (await requestActions.createQueryRequest(this.$store, {
         datasetId: this.dataset,
-        target: LOW_SHOT_LABEL_COLUMN_NAME,
+        target: this.labelName,
         filters: null,
       })) as { success: boolean; error: string };
       if (!res.success) {
@@ -375,7 +369,7 @@ export default Vue.extend({
         {
           context: this.instance,
           dataset: this.dataset,
-          key: LOW_SHOT_LABEL_COLUMN_NAME,
+          key: this.labelName,
           value: LowShotLabels.unlabeled,
         },
       ]; // exclude unlabeled from data export
@@ -401,7 +395,7 @@ export default Vue.extend({
         {
           context: this.instance,
           dataset: this.dataset,
-          key: LOW_SHOT_LABEL_COLUMN_NAME,
+          key: this.labelName,
           value: LowShotLabels.unlabeled,
         },
       ]; // exclude unlabeled from data export
@@ -454,7 +448,7 @@ export default Vue.extend({
       // add new field
       await datasetActions.addField<string>(this.$store, {
         dataset: this.dataset,
-        name: LOW_SHOT_LABEL_COLUMN_NAME,
+        name: this.labelName,
         fieldType: CATEGORICAL_TYPE,
         defaultValue: LowShotLabels.unlabeled,
         displayName: this.labelName,
@@ -477,7 +471,7 @@ export default Vue.extend({
         innerData.set(i, { LowShotLabel: label });
         return {
           index: i.toString(),
-          name: LOW_SHOT_LABEL_COLUMN_NAME,
+          name: this.labelName,
           value: label,
         };
       });
@@ -499,7 +493,7 @@ export default Vue.extend({
     async updateRoute() {
       const taskResponse = await datasetActions.fetchTask(this.$store, {
         dataset: this.dataset,
-        targetName: LOW_SHOT_LABEL_COLUMN_NAME,
+        targetName: this.labelName,
         variableNames: this.variables.map((v) => v.key),
       });
       const training = routeGetters.getDecodedTrainingVariableNames(


### PR DESCRIPTION
Fixes #2404 

The feature being labeled is no longer assumed to be `LowShotLabel`. It now uses the user given name as feature key. Consequently, the user can add multiple labels to a dataset, and models can be chained. Note that currently the user has to enter the specific name of the field if they want to go back and label more rows. It may be beneficial to add a mechanism so that the user can select any categorical feature for labeling.

Fixed how the pipeline queue handles errors to properly remove the item from the queue. Target ranking is now optional when saving a fitted solution.