### PR TITLE
Image rework

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	FeaturizationEnabled       bool    `env:"FEATURIZATION_ENABLED" envDefault:"false"`
 	GeocodingEnabled           bool    `env:"GEOCODING_ENABLED" envDefault:"false"`
 	HelpURL                    string  `env:"HELP_URL" envDefault:"https://d3m.uncharted.software/"`
+	ImageThreadPool			   int     `env:"IMAGE_THREAD_POOL" envDefault:"2"`
 	ImportErrorThreshold       float64 `env:"IMPORT_ERROR_THRESHOLD" envDefault:"0.1"`
 	IngestHardFail             bool    `env:"INGEST_HARD_FAIL" envDefault:"false"`
 	IngestOverwrite            bool    `env:"INGEST_OVERWRITE" envDefault:"false"`

--- a/api/env/config.go
+++ b/api/env/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	FeaturizationEnabled       bool    `env:"FEATURIZATION_ENABLED" envDefault:"false"`
 	GeocodingEnabled           bool    `env:"GEOCODING_ENABLED" envDefault:"false"`
 	HelpURL                    string  `env:"HELP_URL" envDefault:"https://d3m.uncharted.software/"`
-	ImageThreadPool			   int     `env:"IMAGE_THREAD_POOL" envDefault:"2"`
+	ImageThreadPool            int     `env:"IMAGE_THREAD_POOL" envDefault:"2"`
 	ImportErrorThreshold       float64 `env:"IMPORT_ERROR_THRESHOLD" envDefault:"0.1"`
 	IngestHardFail             bool    `env:"INGEST_HARD_FAIL" envDefault:"false"`
 	IngestOverwrite            bool    `env:"INGEST_OVERWRITE" envDefault:"false"`

--- a/api/routes/image_pack.go
+++ b/api/routes/image_pack.go
@@ -1,0 +1,144 @@
+//
+//   Copyright © 2020 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"path"
+
+	"github.com/pkg/errors"
+	"github.com/uncharted-distil/distil-compute/metadata"
+	"github.com/uncharted-distil/distil-compute/model"
+	"github.com/uncharted-distil/distil-compute/primitive/compute"
+	"github.com/uncharted-distil/distil/api/env"
+	api "github.com/uncharted-distil/distil/api/model"
+	"github.com/uncharted-distil/distil/api/util"
+)
+
+// MultiBandPackRequest is the expected post struct for MultiBandImagePackHandler
+type MultiBandPackRequest struct {
+	Dataset string 				`json:"dataset"`
+	BandCombination string		`json:"band"`
+	ImageIDs []string			`json:"imageIds"`
+}
+// MultiBandPackResult is the expected post result for MultiBandImagePackHandler
+type MultiBandPackResult struct {
+	ImagesBuffer  [][]byte 		`json:"images"`
+	ImageIDs []string			`json:"imageIds"`
+}
+type chanStruct struct {
+	data     [][]byte
+	IDs 	 []string
+}
+func postParamsToMultiBandPackRequest(r *http.Request)(*MultiBandPackRequest, error){
+	body, err := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to parse POST request")
+	}
+	result := &MultiBandPackRequest{}
+	err = json.Unmarshal(body, result)
+	return result, err
+}
+// MultiBandImagePackHandler fetches individual band images and combines them into a single RGB image using the supplied mapping.
+func MultiBandImagePackHandler(ctor api.MetadataStorageCtor, dataCtor api.DataStorageCtor, config env.Config) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		params, err := postParamsToMultiBandPackRequest(r)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		result := make(chan chanStruct)
+		for i:=0; i < config.ImageThreadPool; i++{
+			go getMultiBandImages(params, i, config.ImageThreadPool, result, ctor, dataCtor)
+		}
+		imagesBuffer := [][]byte{}
+		IDs := []string{}
+		for i:=0; i < config.ImageThreadPool; i++{
+			r := <-result
+			imagesBuffer = append(imagesBuffer, r.data...)
+			IDs = append(IDs, r.IDs...)
+		}
+		err = handleJSON(w, MultiBandPackResult{
+			ImagesBuffer: imagesBuffer,
+			ImageIDs: IDs,
+		})
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal dataset result into JSON"))
+			return
+		}
+	}
+}
+
+func getMultiBandImages(multiBandPackRequest *MultiBandPackRequest, threadID int, numThreads int, result chan chanStruct, ctor api.MetadataStorageCtor, dataCtor api.DataStorageCtor) {
+	temp := [][]byte{}
+	IDs := []string{}
+	for i := threadID; i < len(multiBandPackRequest.ImageIDs); i += numThreads {
+		imageID := multiBandPackRequest.ImageIDs[i]
+		// get metadata client
+		storage, err := ctor()
+		if err != nil {
+			continue
+		}
+		dataStorage, err := dataCtor()
+		if err != nil {
+			continue
+		}
+
+		res, err := storage.FetchDataset(multiBandPackRequest.Dataset, false, false, false)
+		if err != nil {
+			continue
+		}
+		sourcePath := env.ResolvePath(res.Source, res.Folder)
+
+		// need to read the dataset doc to determine the path to the data resource
+		metaDisk, err := metadata.LoadMetadataFromOriginalSchema(path.Join(sourcePath, compute.D3MDataSchema), false)
+		if err != nil {
+			continue
+		}
+		for _, dr := range metaDisk.DataResources {
+			if dr.IsCollection && dr.ResType == model.ResTypeImage {
+				sourcePath = model.GetResourcePathFromFolder(sourcePath, dr)
+				break
+			}
+		}
+		options := util.Options{Gain: 2.5, Gamma: 2.2, GainL: 1.0, Scale: 0} // default options for color correction
+		
+		imageScale := util.ImageScale{Width: ThumbnailDimensions, Height: ThumbnailDimensions}
+
+		// need to get the band -> filename from the data
+		bandMapping, err := getBandMapping(res, imageID, dataStorage)
+		if err != nil {
+			continue
+		}
+
+		img, err := util.ImageFromCombination(sourcePath, bandMapping, multiBandPackRequest.BandCombination, imageScale, options)
+		if err != nil {
+			continue
+		}
+
+		imageBytes, err := util.ImageToJPEG(img)
+		if err != nil {
+			continue
+		}
+		temp = append(temp, imageBytes)
+		IDs = append(IDs, imageID)
+	}
+
+	result <- chanStruct{data:temp,IDs:IDs}
+}

--- a/api/routes/image_pack.go
+++ b/api/routes/image_pack.go
@@ -186,7 +186,7 @@ func getMultiBandImages(multiBandPackRequest *ImagePackRequest, threadID int, nu
 		log.Error(err)
 		return
 	}
-			// need to read the dataset doc to determine the path to the data resource
+	// need to read the dataset doc to determine the path to the data resource
 	for _, dr := range metaDisk.DataResources {
 		if dr.IsCollection && dr.ResType == model.ResTypeImage {
 			sourcePath = model.GetResourcePathFromFolder(sourcePath, dr)

--- a/api/routes/image_pack.go
+++ b/api/routes/image_pack.go
@@ -186,19 +186,19 @@ func getMultiBandImages(multiBandPackRequest *ImagePackRequest, threadID int, nu
 		log.Error(err)
 		return
 	}
+			// need to read the dataset doc to determine the path to the data resource
 	for _, dr := range metaDisk.DataResources {
 		if dr.IsCollection && dr.ResType == model.ResTypeImage {
 			sourcePath = model.GetResourcePathFromFolder(sourcePath, dr)
 			break
 		}
 	}
+	options := util.Options{Gain: 2.5, Gamma: 2.2, GainL: 1.0, Scale: 0} // default options for color correction
+
+	imageScale := util.ImageScale{Width: ThumbnailDimensions, Height: ThumbnailDimensions}
 	// loop through image info
 	for i := threadID; i < len(multiBandPackRequest.ImageIDs); i += numThreads {
 		imageID := multiBandPackRequest.ImageIDs[i]
-		// need to read the dataset doc to determine the path to the data resource
-		options := util.Options{Gain: 2.5, Gamma: 2.2, GainL: 1.0, Scale: 0} // default options for color correction
-
-		imageScale := util.ImageScale{Width: ThumbnailDimensions, Height: ThumbnailDimensions}
 
 		// need to get the band -> filename from the data
 		bandMapping, err := getBandMapping(res, imageID, dataStorage)

--- a/main.go
+++ b/main.go
@@ -268,6 +268,7 @@ func main() {
 	registerRoutePost(mux, "/distil/grouping/:dataset", routes.GroupingHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/remove-grouping/:dataset/:variable", routes.RemoveGroupingHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/variables/:dataset", routes.VariableTypeHandler(pgDataStorageCtor, esMetadataStorageCtor))
+	registerRoutePost(mux, "/distil/image-pack", routes.MultiBandImagePackHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/data/:dataset/:include-grouping-col", routes.DataHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/import/:datasetID/:source/:provenance", routes.ImportHandler(pgDataStorageCtor, datamartCtors, fileMetadataStorageCtor, esMetadataStorageCtor, &config))
 	registerRoutePost(mux, "/distil/delete/:dataset/:variable", routes.DeleteHandler(pgDataStorageCtor, esMetadataStorageCtor))

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -122,7 +122,11 @@ export default Vue.extend({
       this.removeImages();
       this.fetchImagePack(this.paginatedItems);
     },
-    paginatedItems() {
+    paginatedItems(prev, cur) {
+      // check if all the indices are in the same order and prev == cur
+      if (this.sameData(prev, cur)) {
+        return;
+      }
       this.removeImages();
       this.fetchImagePack(this.paginatedItems);
     },
@@ -146,6 +150,7 @@ export default Vue.extend({
       const items = this.includedActive
         ? datasetGetters.getIncludedTableDataItems(this.$store)
         : datasetGetters.getExcludedTableDataItems(this.$store);
+
       return updateTableRowSelection(
         items,
         this.rowSelection,
@@ -188,6 +193,20 @@ export default Vue.extend({
     },
   },
   methods: {
+    sameData(old: [], cur: []): boolean {
+      if (old === null || cur === null) {
+        return false;
+      }
+      if (old.length !== cur.length) {
+        return false;
+      }
+      for (let i = 0; i < old.length; ++i) {
+        if (old[i][D3M_INDEX_FIELD] !== cur[i][D3M_INDEX_FIELD]) {
+          return false;
+        }
+      }
+      return true;
+    },
     selectAll() {
       bulkRowSelectionUpdate(
         this.$router,

--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -24,17 +24,18 @@
             <template v-for="(fieldInfo, fieldKey) in fields">
               <image-preview
                 v-if="fieldKey === imageField.key"
+                :key="fieldKey"
                 class="image-preview"
                 :row="item"
                 :image-url="item[fieldKey].value"
                 :width="imageWidth"
                 :height="imageHeight"
+                :type="imageField.type"
+                :unique-trail="uniqueTrail"
+                :should-clean-up="false"
+                :should-fetch-image="false"
                 @click="onImageClick"
                 @shift-click="onImageShiftClick"
-                :type="imageField.type"
-                :key="fieldKey"
-                uniqueTrail="mosaic"
-                :debounce="true"
               />
             </template>
             <image-label
@@ -74,7 +75,11 @@ import {
   TableRow,
   D3M_INDEX_FIELD,
 } from "../store/dataset/index";
-import { getters as datasetGetters } from "../store/dataset/module";
+import {
+  getters as datasetGetters,
+  actions as datasetActions,
+  mutations as datasetMutations,
+} from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
 import { Dictionary } from "../util/dict";
 import {
@@ -84,6 +89,7 @@ import {
   updateTableRowSelection,
   bulkRowSelectionUpdate,
 } from "../util/row";
+import { MULTIBAND_IMAGE_TYPE } from "../util/types";
 import { getImageFields } from "../util/data";
 
 export default Vue.extend({
@@ -101,7 +107,6 @@ export default Vue.extend({
     isResult: { type: Boolean as () => boolean, default: false },
     labelFeatureName: { type: String, default: "" },
   },
-
   data() {
     return {
       imageWidth: 128,
@@ -109,15 +114,31 @@ export default Vue.extend({
       currentPage: 1,
       perPage: 100,
       shiftClickInfo: { first: null, second: null },
+      uniqueTrail: "image-mosiac",
     };
+  },
+  watch: {
+    band() {
+      this.removeImages();
+      this.fetchImagePack(this.paginatedItems);
+    },
+    paginatedItems() {
+      this.removeImages();
+      this.fetchImagePack(this.paginatedItems);
+    },
   },
   destroyed() {
     window.removeEventListener("keyup", this.shiftRelease);
   },
   mounted() {
+    this.removeImages();
+    this.fetchImagePack(this.paginatedItems);
     window.addEventListener("keyup", this.shiftRelease);
   },
   computed: {
+    dataset(): string {
+      return routeGetters.getRouteDataset(this.$store);
+    },
     items(): TableRow[] {
       if (this.dataItems) {
         return this.dataItems;
@@ -162,8 +183,10 @@ export default Vue.extend({
     includedActive(): boolean {
       return routeGetters.getRouteInclude(this.$store);
     },
+    band(): string {
+      return routeGetters.getBandCombinationId(this.$store);
+    },
   },
-
   methods: {
     selectAll() {
       bulkRowSelectionUpdate(
@@ -172,6 +195,35 @@ export default Vue.extend({
         this.rowSelection,
         this.paginatedItems.map((pi) => pi.d3mIndex)
       );
+    },
+    removeImages() {
+      if (!this.imageFields.length) {
+        return;
+      }
+      const imageKey = this.imageFields[0].key;
+      datasetMutations.bulkRemoveFiles(this.$store, {
+        urls: this.paginatedItems.map((item) => {
+          return `${item[imageKey].value}/${this.uniqueTrail}`;
+        }),
+      });
+    },
+    fetchImagePack(items) {
+      if (!this.imageFields.length) {
+        return;
+      }
+      const key = this.imageFields[0].key;
+      const type = this.imageFields[0].type;
+      // if band is "" the route assumes it is an image not a multi-band image
+      datasetActions.fetchImagePack(this.$store, {
+        multiBandImagePackRequest: {
+          imageIds: items.map((item) => {
+            return item[key].value;
+          }),
+          dataset: this.dataset,
+          band: type === MULTIBAND_IMAGE_TYPE ? this.band : "",
+        },
+        uniqueTrail: this.uniqueTrail,
+      });
     },
     onImageClick(event: any) {
       if (!isRowSelected(this.rowSelection, event.row[D3M_INDEX_FIELD])) {

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -18,6 +18,7 @@
 <template>
   <div class="distil-table-container">
     <b-table
+      v-model="visibleRows"
       bordered
       hover
       small
@@ -60,8 +61,9 @@
           :row="data.item"
           :type="imageField.type"
           :image-url="data.item[imageField.key].value"
-          :debounce="true"
           :unique-trail="uniqueTrail"
+          :should-clean-up="false"
+          :should-fetch-image="false"
         />
       </template>
 
@@ -169,13 +171,18 @@ import {
   TableValue,
   Highlight,
 } from "../store/dataset/index";
-import { getters as datasetGetters } from "../store/dataset/module";
+import {
+  getters as datasetGetters,
+  mutations as datasetMutations,
+  actions as datasetActions,
+} from "../store/dataset/module";
 import {
   getters as resultsGetters,
   actions as resultsActions,
 } from "../store/results/module";
 import { getters as routeGetters } from "../store/route/module";
 import { getters as requestGetters } from "../store/requests/module";
+
 import { actions as appActions } from "../store/app/module";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 import { Solution } from "../store/requests/index";
@@ -185,6 +192,7 @@ import {
   isTextType,
   hasComputedVarPrefix,
   TIMESERIES_TYPE,
+  MULTIBAND_IMAGE_TYPE,
 } from "../util/types";
 import {
   addRowSelection,
@@ -233,6 +241,8 @@ export default Vue.extend({
       perPage: 100,
       uniqueTrail: "result-table",
       initialized: false,
+      // visibleRows is v-model with the b-table and contains all the items in the current b-table page
+      visibleRows: [],
     };
   },
 
@@ -260,7 +270,9 @@ export default Vue.extend({
     hasResults(): boolean {
       return this.hasData && this.items.length > 0;
     },
-
+    band(): string {
+      return routeGetters.getBandCombinationId(this.$store);
+    },
     target(): string {
       return routeGetters.getRouteTargetVariable(this.$store);
     },
@@ -415,6 +427,14 @@ export default Vue.extend({
   },
 
   watch: {
+    band() {
+      this.removeImages();
+      this.fetchImagePack(this.visibleRows);
+    },
+    visibleRows() {
+      this.removeImages();
+      this.fetchImagePack(this.visibleRows);
+    },
     highlights() {
       this.initialized = false;
     },
@@ -433,6 +453,35 @@ export default Vue.extend({
   },
 
   methods: {
+    removeImages() {
+      if (!this.imageFields.length) {
+        return;
+      }
+      const imageKey = this.imageFields[0].key;
+      datasetMutations.bulkRemoveFiles(this.$store, {
+        urls: this.visibleRows.map((item) => {
+          return `${item[imageKey].value}/${this.uniqueTrail}`;
+        }),
+      });
+    },
+    fetchImagePack(items) {
+      if (!this.imageFields.length) {
+        return;
+      }
+      const key = this.imageFields[0].key;
+      const type = this.imageFields[0].type;
+      // if band is "" the route assumes it is an image not a multi-band image
+      datasetActions.fetchImagePack(this.$store, {
+        multiBandImagePackRequest: {
+          imageIds: items.map((item) => {
+            return item[key].value;
+          }),
+          dataset: this.dataset,
+          band: type === MULTIBAND_IMAGE_TYPE ? this.band : "",
+        },
+        uniqueTrail: this.uniqueTrail,
+      });
+    },
     timeserieInfo(id: string): Extrema {
       const timeseries = resultsGetters.getPredictedTimeseries(this.$store);
       return timeseries?.[this.solutionId]?.info?.[id];

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -18,6 +18,7 @@
 <template>
   <div class="distil-table-container">
     <b-table
+      v-model="visibleRows"
       bordered
       hover
       small
@@ -54,6 +55,8 @@
             :image-url="data.item[imageField.key].value"
             :debounce="true"
             :unique-trail="uniqueTrail"
+            :should-clean-up="false"
+            :should-fetch-image="false"
           />
           <image-label
             class="image-label"
@@ -124,6 +127,7 @@ import ImagePreview from "./ImagePreview.vue";
 import {
   getters as datasetGetters,
   actions as datasetActions,
+  mutations as datasetMutations,
 } from "../store/dataset/module";
 import { Dictionary } from "../util/dict";
 import { Filter } from "../util/filters";
@@ -138,7 +142,7 @@ import {
   TableValue,
 } from "../store/dataset/index";
 import { getters as routeGetters } from "../store/route/module";
-import { hasComputedVarPrefix } from "../util/types";
+import { hasComputedVarPrefix, MULTIBAND_IMAGE_TYPE } from "../util/types";
 import {
   addRowSelection,
   removeRowSelection,
@@ -191,6 +195,8 @@ export default Vue.extend({
       uniqueTrail: "selected-table",
       initialized: false,
       shiftClickInfo: { first: null, second: null },
+      // this is v-model with b-table (it contains what is on the page in the sorted order)
+      visibleRows: [],
     };
   },
 
@@ -309,6 +315,10 @@ export default Vue.extend({
   },
 
   watch: {
+    visibleRows() {
+      this.removeImages();
+      this.fetchImagePack(this.visibleRows);
+    },
     includedActive() {
       if (this.items.length) {
         this.fetchTimeSeries();
@@ -322,16 +332,22 @@ export default Vue.extend({
       // checks to see if items exist and if the timeseries has been queried for the new data
       if (!this.initialized && this.items.length) {
         this.fetchTimeSeries();
+        this.fetchImagePack(this.visibleRows);
         this.initialized = true;
       }
       if (prev?.length !== this.items.length) {
         this.fetchTimeSeries();
+        this.fetchImagePack(this.visibleRows);
       }
       // if the itemCount changes such that it's less than page
       // we were on, reset to page 1.
       if (this.itemCount < this.perPage * this.currentPage) {
         this.currentPage = 1;
       }
+    },
+    band() {
+      this.removeImages();
+      this.fetchImagePack(this.visibleRows);
     },
   },
   destroyed() {
@@ -359,18 +375,31 @@ export default Vue.extend({
         });
       });
     },
-    fetchImagePack() {
+    removeImages() {
       if (!this.imageFields.length) {
         return;
       }
       const imageKey = this.imageFields[0].key;
+      datasetMutations.bulkRemoveFiles(this.$store, {
+        urls: this.visibleRows.map((item) => {
+          return `${item[imageKey].value}/${this.uniqueTrail}`;
+        }),
+      });
+    },
+    fetchImagePack(items) {
+      if (!this.imageFields.length) {
+        return;
+      }
+      const key = this.imageFields[0].key;
+      const type = this.imageFields[0].type;
+      // if band is "" the route assumes it is an image not a multi-band image
       datasetActions.fetchImagePack(this.$store, {
         multiBandImagePackRequest: {
-          imageIds: this.pageItems.map((item) => {
-            return item[imageKey].value as string;
+          imageIds: items.map((item) => {
+            return item[key].value;
           }),
           dataset: this.dataset,
-          band: this.band,
+          band: type === MULTIBAND_IMAGE_TYPE ? this.band : "",
         },
         uniqueTrail: this.uniqueTrail,
       });
@@ -385,7 +414,6 @@ export default Vue.extend({
       this.currentPage = page;
       // fetch new data
       this.fetchTimeSeries();
-      this.fetchImagePack();
     },
     selectAll() {
       bulkRowSelectionUpdate(

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -53,7 +53,6 @@
             :type="imageField.type"
             :row="data.item"
             :image-url="data.item[imageField.key].value"
-            :debounce="true"
             :unique-trail="uniqueTrail"
             :should-clean-up="false"
             :should-fetch-image="false"

--- a/public/components/SelectDataTable.vue
+++ b/public/components/SelectDataTable.vue
@@ -303,6 +303,9 @@ export default Vue.extend({
         !isEmpty(this.timeseriesGroupings)
       );
     },
+    band(): string {
+      return routeGetters.getBandCombinationId(this.$store);
+    },
   },
 
   watch: {
@@ -356,6 +359,22 @@ export default Vue.extend({
         });
       });
     },
+    fetchImagePack() {
+      if (!this.imageFields.length) {
+        return;
+      }
+      const imageKey = this.imageFields[0].key;
+      datasetActions.fetchImagePack(this.$store, {
+        multiBandImagePackRequest: {
+          imageIds: this.pageItems.map((item) => {
+            return item[imageKey].value as string;
+          }),
+          dataset: this.dataset,
+          band: this.band,
+        },
+        uniqueTrail: this.uniqueTrail,
+      });
+    },
     onPagination(page: number) {
       // remove old data from store
       removeTimeseries(
@@ -366,6 +385,7 @@ export default Vue.extend({
       this.currentPage = page;
       // fetch new data
       this.fetchTimeSeries();
+      this.fetchImagePack();
     },
     selectAll() {
       bulkRowSelectionUpdate(

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1264,7 +1264,6 @@ export const actions = {
     if (!validateArgs(args, ["dataset", "imageId", "bandCombination"])) {
       return null;
     }
-    return;
     const options = !!args.options ? `${JSON.stringify(args.options)}` : "";
     try {
       const response = await loadImage(

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1296,6 +1296,9 @@ export const actions = {
           return `${id}/${args.uniqueTrail}`;
         });
       }
+      response.data.errorIds.forEach((id) => {
+        console.error(`Error fetching image with ${id}`);
+      });
       mutations.bulkUpdateFiles(context, {
         urls: urls,
         files: response.data.images,

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -224,6 +224,7 @@ export const mutations = {
   // files
   updateFile: commit(moduleMutations.updateFile),
   removeFile: commit(moduleMutations.removeFile),
+  bulkRemoveFiles: commit(moduleMutations.bulkRemoveFiles),
   bulkUpdateFiles: commit(moduleMutations.bulkUpdateFiles),
   bulkUpdateTimeseries: commit(moduleMutations.bulkUpdateTimeseries),
   // included / excluded table data

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -166,6 +166,7 @@ export const actions = {
   // files
   fetchFiles: dispatch(moduleActions.fetchFiles),
   fetchImage: dispatch(moduleActions.fetchImage),
+  fetchImagePack: dispatch(moduleActions.fetchImagePack),
   fetchMultiBandImage: dispatch(moduleActions.fetchMultiBandImage),
   fetchImageAttention: dispatch(moduleActions.fetchImageAttention),
   fetchTimeseries: dispatch(moduleActions.fetchTimeseries),
@@ -223,6 +224,7 @@ export const mutations = {
   // files
   updateFile: commit(moduleMutations.updateFile),
   removeFile: commit(moduleMutations.removeFile),
+  bulkUpdateFiles: commit(moduleMutations.bulkUpdateFiles),
   bulkUpdateTimeseries: commit(moduleMutations.bulkUpdateTimeseries),
   // included / excluded table data
   setJoinDatasetsTableData: commit(moduleMutations.setJoinDatasetsTableData),

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -288,7 +288,11 @@ export const mutations = {
   updateFile(state: DatasetState, args: { url: string; file: any }) {
     Vue.set(state.files, args.url, args.file);
   },
-
+  bulkUpdateFiles(state: DatasetState, args: { urls: string[]; files: any[] }) {
+    for (let i = 0; i < args.urls.length; ++i) {
+      Vue.set(state.files, args.urls[i], args.files[i]);
+    }
+  },
   removeFile(state: DatasetState, url: string) {
     Vue.delete(state.files, url);
   },

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -293,6 +293,11 @@ export const mutations = {
       Vue.set(state.files, args.urls[i], args.files[i]);
     }
   },
+  bulkRemoveFiles(state: DatasetState, args: { urls: string[] }) {
+    args.urls.forEach((url) => {
+      Vue.delete(state.files, url);
+    });
+  },
   removeFile(state: DatasetState, url: string) {
     Vue.delete(state.files, url);
   },

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -279,7 +279,7 @@ export const RANKABLE_VARIABLE_TYPES = new Set([
 ]);
 export interface MultiBandImagePackRequest {
   dataset: string;
-  band: string;
+  band?: string;
   imageIds: string[];
 }
 export function isEquivalentType(a: string, b: string): boolean {

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -277,7 +277,11 @@ export const RANKABLE_VARIABLE_TYPES = new Set([
   COUNTRY_TYPE,
   COUNTRY_CODE_TYPE,
 ]);
-
+export interface MultiBandImagePackRequest {
+  dataset: string;
+  band: string;
+  imageIds: string[];
+}
 export function isEquivalentType(a: string, b: string): boolean {
   const equiv = EQUIV_TYPES[a];
   if (!equiv) {


### PR DESCRIPTION
closes #2398
- Bulk fetching images has been added
- image-pack route returns an array of image bytes and the imageID for each image
- IMAGE_THREAD_POOL is the env var that depicts how many threads should be used for fetching images (tested 2-6 left it defaulting to 2 for mac books; however, I have not tested more threads on the mac)
- Each DataTable and imageMosiac is responsible for fetching the needed images now (effectively reducing the number of request per page from 100 to 1)
- Removed some debounce from imagePreview it is no longer needed
- Removed element appending in ImagePreview it now has images in the html and changes the src
- Tested with images and multi-band both work.
- ImageFacet still do individual fetches (can be changed but at most it is 4 requests)
- visibleRows has been added to every b-table (visibleRows contains exactly what is on the current page and includes the sorting order)
- bulk fetching supports changing the b-table order