### PR TITLE
Fix Training/Test split UI numbers issue

### DIFF
--- a/public/components/SettingsModal.vue
+++ b/public/components/SettingsModal.vue
@@ -196,7 +196,7 @@ export default Vue.extend({
     },
 
     totalDataCount(): number {
-      return routeGetters.getRouteDataSize(this.$store);
+      return datasetGetters.getIncludedTableDataNumRows(this.$store);
     },
 
     trainTestSplit(): number {


### PR DESCRIPTION
fix #2362 
Use the number of included rows, instead of the number of rows displayed, to inform the training/test split UI.