### PR TITLE
Geobounds User Switch

### DIFF
--- a/api/model/storage/postgres/vector.go
+++ b/api/model/storage/postgres/vector.go
@@ -117,6 +117,6 @@ func (f *VectorField) subSelect() string {
 	if f.Count != "" {
 		countSQL = fmt.Sprintf(", \"%s\"", f.Count)
 	}
-	return fmt.Sprintf("(SELECT \"%s\"%s, unnest(\"%s\") as %s FROM %s)",
+	return fmt.Sprintf("(SELECT \"%s\"%s, unnest(\"%s\") as \"%s\" FROM %s)",
 		model.D3MIndexFieldName, countSQL, f.Unnested, f.Key, f.DatasetStorageName)
 }

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -690,15 +690,6 @@ func (d *Database) IsArray(typ string) bool {
 	return strings.HasSuffix(typ, "Vector")
 }
 
-//func (d *Database) dataIsArray(data string) bool {
-//	dataLength := len(data)
-//	if dataLength < 2 {
-//		return false
-//	}
-
-//	return data[0] == '{' && data[dataLength-1] == '}'
-//}
-
 // MapD3MTypeToPostgresType generates a postgres type from a d3m type.
 func MapD3MTypeToPostgresType(typ string) string {
 	// Integer types can be returned as floats.
@@ -915,8 +906,7 @@ func IsColumnType(client DatabaseDriver, tableName string, variable *model.Varia
 		return false
 	}
 
-	// there should only be 1 row, even with the group by
-	// if there are more than 1 row, then it is not the expected type
+	// there should only be 1 row
 	count := 0
 	result := 0
 	for rows.Next() {


### PR DESCRIPTION
Added special handling to flag potential geobounds fields properly. It now checks for a vector of length 8.

The vector handling was also updated slightly to no longer add the curly braces on ingest. Instead, the curly braces are added as part of the view, thus enabling retyping to vectors/geobounds.