### PR TITLE
Image Bulk Performance

### DIFF
--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -441,7 +441,7 @@ func (s *Storage) buildSelectStatement(variables []*model.Variable, filterVariab
 	}
 	return strings.Join(distincts, ",") + " " + strings.Join(fields, ","), nil
 }
-func (s *Storage) buildFilteredQueryField(variables []*model.Variable, filterVariables []string) (string, error) {
+func (s *Storage) buildFilteredQueryField(variables []*model.Variable, filterVariables []string, distinct bool) (string, error) {
 
 	distincts := make([]string, 0)
 	fields := make([]string, 0)
@@ -451,7 +451,7 @@ func (s *Storage) buildFilteredQueryField(variables []*model.Variable, filterVar
 			continue
 		}
 
-		if variable.DistilRole == model.VarDistilRoleGrouping {
+		if variable.DistilRole == model.VarDistilRoleGrouping && distinct {
 			distincts = append(distincts, fmt.Sprintf("DISTINCT ON (\"%s\")", variable.Key))
 		}
 
@@ -806,7 +806,7 @@ func (s *Storage) FetchData(dataset string, storageName string, filterParams *ap
 			filterParams.Variables = append(filterParams.Variables, orderByVar.HeaderName)
 		}
 	}
-	fields, err := s.buildFilteredQueryField(variables, filterParams.Variables)
+	fields, err := s.buildFilteredQueryField(variables, filterParams.Variables, !includeGroupingCol)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not build field list")
 	}

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -171,10 +171,10 @@ func getBandMapping(ds *api.Dataset, groupKeys []string, dataStorage api.DataSto
 		},
 	},
 	}
-	filter.Variables = []string{fileCol.Key, bandCol.Key}
+	filter.Variables = []string{fileCol.Key, bandCol.Key, groupingCol.Key}
 
 	// pull back all rows for a group id
-	data, err := dataStorage.FetchData(ds.ID, ds.StorageName, filter, false, nil)
+	data, err := dataStorage.FetchData(ds.ID, ds.StorageName, filter, true, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -103,13 +103,13 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, dataCtor api.DataStorag
 		}
 
 		// need to get the band -> filename from the data
-		bandMapping, err := getBandMapping(res, imageID, dataStorage)
+		bandMapping, err := getBandMapping(res, []string{imageID}, dataStorage)
 		if err != nil {
 			handleError(w, err)
 			return
 		}
 
-		img, err := util.ImageFromCombination(sourcePath, bandMapping, bandCombo, imageScale, options)
+		img, err := util.ImageFromCombination(sourcePath, bandMapping[imageID], bandCombo, imageScale, options)
 		if err != nil {
 			handleError(w, err)
 			return
@@ -137,7 +137,7 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, dataCtor api.DataStorag
 	}
 }
 
-func getBandMapping(ds *api.Dataset, groupKey string, dataStorage api.DataStorage) (map[string]string, error) {
+func getBandMapping(ds *api.Dataset, groupKeys []string, dataStorage api.DataStorage) (map[string]map[string]string, error) {
 	// build a filter to only include rows matching a group id
 	var groupingCol *model.Variable
 	var bandCol *model.Variable
@@ -166,7 +166,7 @@ func getBandMapping(ds *api.Dataset, groupKey string, dataStorage api.DataStorag
 		{
 			Key:        groupingCol.Key,
 			Type:       model.CategoricalFilter,
-			Categories: []string{groupKey},
+			Categories: groupKeys,
 			Mode:       model.IncludeFilter,
 		},
 	},
@@ -180,27 +180,32 @@ func getBandMapping(ds *api.Dataset, groupKey string, dataStorage api.DataStorag
 	}
 
 	// cycle through results to build the band mapping
-	fileColumn := -1
-	bandColumn := -1
+	outputColumns := map[string]int{}
 	for i, c := range data.Columns {
-		if c.Key == fileCol.Key {
-			fileColumn = i
-		} else if c.Key == bandCol.Key {
-			bandColumn = i
-		}
+		outputColumns[c.Key] = i
 	}
-	if fileColumn == -1 {
+	fileColumn, ok := outputColumns[fileCol.Key]
+	if !ok {
 		return nil, errors.Errorf("no file column found in stored data")
 	}
-	if bandColumn == -1 {
+	bandColumn, ok := outputColumns[bandCol.Key]
+	if !ok {
 		return nil, errors.Errorf("no band column found in stored data")
 	}
+	groupColumn, ok := outputColumns[groupingCol.Key]
+	if !ok {
+		return nil, errors.Errorf("no group column found in stored data")
+	}
 
-	mapping := map[string]string{}
+	mapping := map[string]map[string]string{}
 	for _, r := range data.Values {
+		groupKey := r[groupColumn].Value.(string)
+		if mapping[groupKey] == nil {
+			mapping[groupKey] = map[string]string{}
+		}
 		// the mapping expects bXX but the database only stores XX
 		bandKey := fmt.Sprintf("b%s", r[bandColumn].Value.(string))
-		mapping[bandKey] = r[fileColumn].Value.(string)
+		mapping[groupKey][bandKey] = r[fileColumn].Value.(string)
 	}
 
 	return mapping, nil


### PR DESCRIPTION
The image-pack route now pulls all group id -> band file mapping from the database in one set of queries rather than do queries for each group id. In the end, it cut the end point processing time by about half for the locusts tiny dataset. It does look like the remaining time is all spent creating the images from the underlying image files. There may still be quick wins in that bit if proper profiling were done.