### PR TITLE
Geobounds type switch

### DIFF
--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -416,6 +416,14 @@ func (s *Storage) IsValidDataType(dataset string, storageName string, varName st
 // SetDataType updates the data type of the specified variable.
 // Multiple simultaneous calls to the function can result in discarded changes.
 func (s *Storage) SetDataType(dataset string, storageName string, varName string, varType string) error {
+	// geometry types need special handling to make sure the backing field exists properly
+	if model.IsGeoBounds(varType) {
+		err := s.createGeometryField(dataset, storageName, varName)
+		if err != nil {
+			return err
+		}
+	}
+
 	// get all existing fields to rebuild the view.
 	fields, err := s.getExistingFields(dataset, storageName)
 	if err != nil {
@@ -825,4 +833,63 @@ func getJoinSQL(join *joinDefinition, inner bool) string {
 	return fmt.Sprintf("%s %s AS %s ON %s.\"%s\" = %s.\"%s\"",
 		joinType, join.joinTableName, join.joinAlias, join.joinAlias,
 		join.joinColumn, join.baseAlias, join.baseColumn)
+}
+
+func (s *Storage) createGeometryField(dataset string, storageName string, varName string) error {
+	postgisFieldName := fmt.Sprintf("__geo_%s", varName)
+	exists, _ := s.DoesVariableExist(dataset, storageName, postgisFieldName)
+	if !exists {
+		err := s.AddField(dataset, storageName, varName, "geometry", postgres.DefaultPostgresValueFromD3MType(model.GeoBoundsType).(string))
+		if err != nil {
+			return err
+		}
+
+		// create index on the field
+		err = s.createIndex(storageName, varName, "geometry")
+		if err != nil {
+			return err
+		}
+	}
+
+	// query the vector field to get the data for the geometry field
+	querySQL := fmt.Sprintf("SELECT \"%s\", \"%s\" FROM %s;", model.D3MIndexFieldName, varName, storageName)
+	rows, err := s.client.Query(querySQL)
+	if err != nil {
+		return errors.Wrapf(err, "unable to query for geobounds")
+	}
+
+	updates := map[string]string{}
+	for rows.Next() {
+		var d3mIndex string
+		var geometry []float64
+		err := rows.Scan(&d3mIndex, &geometry)
+		if err != nil {
+			return errors.Wrapf(err, "unable to read geometry fields from psotgres")
+		}
+		if len(geometry) != 8 {
+			return errors.Errorf("field '%s' is not a vector denoting 4 points", varName)
+		}
+
+		// add the link back to the first point since a polygon must be closed
+		geometry = append(geometry, geometry[0], geometry[1])
+
+		// geometry string should have the coordinates of a point separate by a space
+		// and the points separated by commas
+		geometryString := ""
+		for i := 0; i < len(geometry); i += 2 {
+			geometryString = fmt.Sprintf("%s,%f %f", geometryString, geometry[i], geometry[i+1])
+		}
+		updates[d3mIndex] = fmt.Sprintf("POLYGON((%s))", geometryString[1:])
+	}
+	err = rows.Err()
+	if err != nil {
+		return errors.Wrapf(err, "error reading geometry data from postgres")
+	}
+
+	err = s.UpdateData(dataset, storageName, postgisFieldName, updates, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/api/routes/variable_type.go
+++ b/api/routes/variable_type.go
@@ -67,33 +67,10 @@ func VariableTypeHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataS
 			handleError(w, err)
 			return
 		}
-		storageName := ds.StorageName
 
-		// check the variable type to make sure it is valid
-		isValid, err := storage.IsValidDataType(dataset, storageName, field, typ)
+		err = updateType(ds, field, typ, storage, meta)
 		if err != nil {
-			handleError(w, errors.Wrap(err, "unable to verify the data type in storage"))
-			return
-		}
-		if !isValid {
-			handleErrorType(
-				w,
-				fmt.Errorf("unable to verify the data type in storage"),
-				http.StatusBadRequest)
-			return
-		}
-
-		// update the variable type in the storage
-		err = setDataType(meta, storage, dataset, storageName, field, typ)
-		if err != nil {
-			handleError(w, errors.Wrap(err, "unable to update the data type in storage"))
-			return
-		}
-
-		// update the extremas stored in ES
-		err = api.UpdateExtremas(dataset, field, meta, storage)
-		if err != nil {
-			handleError(w, errors.Wrap(err, "unable to update the extremas in metadata"))
+			handleError(w, err)
 			return
 		}
 
@@ -123,6 +100,51 @@ func VariableTypeHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataS
 			return
 		}
 	}
+}
+
+func updateType(ds *api.Dataset, field string, typ string, storage api.DataStorage, meta api.MetadataStorage) error {
+	// check the variable type to make sure it is valid
+	isValid, err := storage.IsValidDataType(ds.ID, ds.StorageName, field, typ)
+	if err != nil {
+		return err
+	}
+	if !isValid {
+		return errors.Errorf("unable to verify the data type in storage")
+	}
+
+	// update the variable type in the storage
+	err = setDataType(meta, storage, ds.ID, ds.StorageName, field, typ)
+	if err != nil {
+		return err
+	}
+
+	// update the extremas stored in ES
+	err = api.UpdateExtremas(ds.ID, field, meta, storage)
+	if err != nil {
+		return err
+	}
+
+	// geobounds has special processing
+	if model.IsGeoBounds(typ) {
+		err = setGeoBoundsField(ds.ID, field, storage, meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setGeoBoundsField(datasetID string, field string, storage api.DataStorage, meta api.MetadataStorage) error {
+	// create the grouping
+	// HACK: assume the name of the geometry field!!!
+	geometryFieldName := fmt.Sprintf("__geo_%s", field)
+	grouping := &model.GeoBoundsGrouping{}
+	grouping.Type = model.GeoBoundsType
+	grouping.CoordinatesCol = field
+	grouping.PolygonCol = geometryFieldName
+	grouping.Hidden = []string{field, geometryFieldName}
+	return meta.AddGroupedVariable(datasetID, fmt.Sprintf("%s_group", field), field, model.GeoBoundsType, model.VarDistilRoleGrouping, grouping)
 }
 
 func getPostParameters(r *http.Request) (map[string]interface{}, error) {


### PR DESCRIPTION
Geobounds type switching has a lot of special processing due to it needing a backing geometry field as well as being a grouping. A lot of assumption are made on the structure of the data right now and there isn't too clean of a way to hide most of this properly since the grouping captures most of the client facing info which means the metadata needs to be aware of the data structures.