### PR TITLE
Type change menu cut off

### DIFF
--- a/public/components/TypeChangeMenu.vue
+++ b/public/components/TypeChangeMenu.vue
@@ -25,6 +25,7 @@
         :text="label"
         :disabled="isDisabled"
         :boundary="boundary"
+        menu-class="multi-columns"
         lazy
       >
         <template v-if="!isComputedFeature">
@@ -52,7 +53,6 @@
                 <icon-bookmark />
               </icon-base>
             </b-dropdown-item>
-            <b-dropdown-divider />
           </template>
           <b-dropdown-item
             v-for="grouping in groupingOptions()"
@@ -256,9 +256,8 @@ export default Vue.extend({
 
     // Change the boundary of the dropdown so that it display appropriately.
     // https://bootstrap-vue.org/docs/components/dropdown#boundary-constraint
-    const variableFacet = this.$el.closest("[class^=variable]") as HTMLElement;
-    this.boundary =
-      (variableFacet.offsetParent as HTMLElement) ?? this.boundary;
+    const varFacet = this.$el.closest("[class^=variable]") as HTMLElement;
+    this.boundary = (varFacet.offsetParent as HTMLElement) ?? this.boundary;
   },
 
   methods: {
@@ -458,5 +457,12 @@ export default Vue.extend({
 }
 .type-change-dropdown-wrapper {
   position: relative;
+}
+
+/* Display the dropdown menu in a multi-columns fashion. */
+.dropdown-menu.show.multi-columns {
+  column-gap: 1em;
+  display: grid;
+  grid-template-columns: repeat(3, 10em);
 }
 </style>

--- a/public/components/facets/FacetCategorical.vue
+++ b/public/components/facets/FacetCategorical.vue
@@ -50,7 +50,7 @@
         </div>
       </div>
       <div
-        v-if="this.html"
+        v-if="html"
         v-child="computeCustomHTML()"
         class="facet-footer-custom-html"
       />
@@ -60,6 +60,7 @@
 
 <script lang="ts">
 import Vue from "vue";
+import _ from "lodash";
 
 import "@uncharted.software/facets-core";
 import { FacetTermsData } from "@uncharted.software/facets-core/dist/types/facet-terms/FacetTerms";
@@ -76,7 +77,6 @@ import {
   viewLessData,
   facetTypeChangeState,
 } from "../../util/facets";
-import _ from "lodash";
 
 export default Vue.extend({
   name: "FacetCategorical",

--- a/public/components/facets/VariableFacets.vue
+++ b/public/components/facets/VariableFacets.vue
@@ -39,7 +39,8 @@
         <div
           v-for="summary in summaries"
           :key="summary.key"
-          class="variable-facets-item flex-fill my-2 mx-1"
+          class="variable-facets-item flex-fill my-2"
+          :class="{ 'mx-1': !noMargin }"
         >
           <template v-if="summary.pending">
             <facet-loading :summary="summary" />
@@ -253,6 +254,7 @@ export default Vue.extend({
       type: String as () => Activity,
       default: Activity.DATA_PREPARATION,
     },
+    noMargin: { type: Boolean, default: false },
     summaries: { type: Array as () => VariableSummary[], default: [] },
     subtitle: { type: String, default: null },
     rowsPerPage: { type: Number, default: 0 },
@@ -270,24 +272,28 @@ export default Vue.extend({
         const entry = overlayRouteEntry(this.$route, {
           [this.routePageKey()]: page,
         });
-        this.$router.push(entry).catch((err) => console.debug(err));
+        this.$router.push(entry).catch((err) => console.warn(err));
         this.$emit("page", page);
       },
       get(): number {
         return getRouteFacetPage(this.routePageKey(), this.$route);
       },
     },
+
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);
     },
+
     variables(): Variable[] {
       return datasetGetters.getVariables(this.$store);
     },
+
     timeseriesSummaries(): VariableSummary[] {
       return this.summaries.filter((s) => {
         return s.varType === TIMESERIES_TYPE;
       });
     },
+
     timeseriesVars(): Variable[] | null {
       const checkMap = new Map(
         this.timeseriesSummaries.map((ts) => {
@@ -298,6 +304,7 @@ export default Vue.extend({
         return checkMap.has(v.key);
       });
     },
+
     highlights(): Highlight[] {
       return routeGetters.getDecodedHighlights(this.$store);
     },
@@ -354,9 +361,11 @@ export default Vue.extend({
         FACET_COLOR_FILTERED,
       ]);
     },
+
     numFacetPerPage(): number {
       return !this.rowsPerPage ? NUM_PER_PAGE : this.rowsPerPage;
     },
+
     pagination(): boolean {
       return this.facetCount > this.numFacetPerPage;
     },
@@ -381,6 +390,7 @@ export default Vue.extend({
         });
       }
     },
+
     search(newTerm, oldTerm) {
       if (newTerm === undefined || newTerm === oldTerm) return;
 
@@ -405,6 +415,7 @@ export default Vue.extend({
     routePageKey(): string {
       return `${this.instanceName}${ROUTE_PAGE_SUFFIX}`;
     },
+
     routeSearchKey(): string {
       return `${this.instanceName}${ROUTE_SEARCH_SUFFIX}`;
     },

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -702,12 +702,12 @@ export const getters = {
   },
 
   /* Check if the current page is SELECT_TARGET_ROUTE. */
-  isPageSelectTarget(state: Route): Boolean {
+  isPageSelectTarget(state: Route): boolean {
     return state.path === SELECT_TARGET_ROUTE;
   },
 
   /* Check if the current page is SELECT_TRAINING_ROUTE. */
-  isPageSelectTraining(state: Route): Boolean {
+  isPageSelectTraining(state: Route): boolean {
     return state.path === SELECT_TRAINING_ROUTE;
   },
 

--- a/public/views/SelectTarget.vue
+++ b/public/views/SelectTarget.vue
@@ -71,6 +71,7 @@
           :pagination="searchedActiveVariables.length > numRowsPerPage"
           :rows-per-page="numRowsPerPage"
           :summaries="summaries"
+          no-margin
         />
       </div>
     </section>


### PR DESCRIPTION
closes #2426 

- clean up
- changed which boundary the dropdown is using to keep the list within view.
- used CSS grid to display the list in three columns to avoid cut-off
- added the `lazy` property to only load the list on click, which helps the page render slightly faster.

<img width="935" alt="Screen Shot 2021-04-01 at 15 52 54" src="https://user-images.githubusercontent.com/636801/113346835-57f7b000-9302-11eb-8ea2-83ec7670fdd6.png">
