### PR TITLE
Add colours to ImagePreview from the confidence scale

### DIFF
--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -400,7 +400,7 @@ func createRGBAFromRamp(xSize int, ySize int, bandImages []*image.Gray16, transf
 	// Create a new RGBA image to hold the collected bands
 	outputImage := image.NewRGBA(image.Rect(0, 0, xSize, ySize))
 
-	rampElements := (len(ramp)-2) / 3
+	rampElements := (len(ramp) - 2) / 3
 
 	// Copy the 16 bit band images into the 8 bit target image.  If a band image couldn't be processed
 	// earlier, we set to grey.

--- a/public/components/DrillDown.vue
+++ b/public/components/DrillDown.vue
@@ -20,9 +20,9 @@
     <div>
       <div class="toolbar">
         <div class="title">{{ title }}</div>
-        <b-button class="exit-button" @click="onExitClicked"
-          ><span aria-hidden="true">&times;</span></b-button
-        >
+        <b-button class="exit-button" @click="onExitClicked">
+          <span aria-hidden="true">&times;</span>
+        </b-button>
       </div>
       <div class="grid-container" :style="gridColStyle">
         <template v-for="(r, i) in renderTiles.length">
@@ -30,10 +30,10 @@
             <div class="image-container">
               <image-label
                 class="image-label"
-                :dataFields="dataFields"
-                includedActive
-                shortenLabels
-                alignHorizontal
+                :data-fields="dataFields"
+                included-active
+                shorten-labels
+                align-horizontal
                 :item="renderTiles[i][j].selected.item"
               />
               <image-preview
@@ -44,18 +44,18 @@
                 :height="imageHeight"
                 :type="imageType"
                 :gray="renderTiles[i][j].selected.gray"
-                @click="onImageClick"
-                :overlappedUrls="
+                :overlapped-urls="
                   renderTiles[i][j].overlapped.map((o) => o.imageUrl)
                 "
+                @click="onImageClick"
               />
               <overlap-selection
                 :items="renderTiles[i][j].overlapped"
                 :indices="{ y: i, x: j }"
-                :instanceName="`over-lap-${i}-${j}`"
+                :instance-name="`over-lap-${i}-${j}`"
                 :width="imageWidth"
                 :height="imageHeight"
-                :imageType="imageType"
+                :image-type="imageType"
                 @item-selected="onOverlapSelected"
               />
             </div>
@@ -67,7 +67,6 @@
 </template>
 
 <script lang="ts">
-import _ from "lodash";
 import Vue from "vue";
 import ImagePreview from "./ImagePreview.vue";
 import ImageLabel from "./ImageLabel.vue";
@@ -108,7 +107,7 @@ interface Dimensions {
 }
 
 export default Vue.extend({
-  name: "drill-down",
+  name: "DrillDown",
 
   components: {
     ImagePreview,
@@ -122,7 +121,7 @@ export default Vue.extend({
     cols: { type: Number, default: 7 },
     imageWidth: { type: Number, default: 124 },
     imageHeight: { type: Number, default: 124 },
-    imageType: { type: String },
+    imageType: { type: String, default: null },
     dataFields: Object as () => Dictionary<TableColumn>,
     bounds: { type: Array as () => number[][] },
     centerTile: {
@@ -131,19 +130,13 @@ export default Vue.extend({
     },
     instanceName: { type: String as () => string, default: "" },
   },
+
   data() {
     return {
       renderTiles: [] as RenderTile[][],
     };
   },
-  mounted() {
-    this.renderTiles = this.spatialSort();
-  },
-  watch: {
-    tiles() {
-      this.renderTiles = this.spatialSort();
-    },
-  },
+
   computed: {
     tileDims(): Dimensions {
       return {
@@ -169,6 +162,17 @@ export default Vue.extend({
       return routeGetters.getDecodedRowSelection(this.$store);
     },
   },
+
+  watch: {
+    tiles() {
+      this.renderTiles = this.spatialSort();
+    },
+  },
+
+  mounted() {
+    this.renderTiles = this.spatialSort();
+  },
+
   methods: {
     getIndex(x: number, y: number): SpatialIndex {
       const minX = this.bounds[0][1];

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -617,7 +617,7 @@ export default Vue.extend({
 
     clusterState(): MapState {
       return {
-        onHover: (id: number) => {
+        onHover: () => {
           return;
         }, // onHover empty for cluster state
         onClick: (id: number) => {
@@ -1086,7 +1086,7 @@ export default Vue.extend({
       if (this.getCoordinateType === CoordinateType.PointBased) {
         return this.pointGroups(tableData);
       }
-      const areas = tableData.map((item, i) => {
+      const areas = tableData?.map((item, i) => {
         const imageUrl = this.isMultiBandImage
           ? item[this.multibandImageGroupColumn].value
           : null;

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -18,6 +18,7 @@
 <template>
   <div
     id="geo-test"
+    ref="geoPlotContainer"
     class="geo-plot-container"
     :class="{ 'selection-mode': isSelectionMode }"
   >
@@ -735,7 +736,14 @@ export default Vue.extend({
 
   mounted() {
     this.createLumoMap();
+
+    // Make the map container square to avoid webGl issue.
+    // https://github.com/uncharted-distil/distil/issues/2015
+    const container = this.$refs.geoPlotContainer as HTMLElement;
+    const width = container?.getBoundingClientRect().width ?? 500;
+    container.style.height = width + "px";
   },
+
   methods: {
     createLumoMap() {
       // create map
@@ -1315,7 +1323,7 @@ export default Vue.extend({
   position: relative;
   z-index: 0;
   width: 100%;
-  height: 100%;
+  max-height: 100%;
   bottom: 0;
 }
 
@@ -1423,8 +1431,6 @@ export default Vue.extend({
   top: -7px; /*works out to 4 pixels from top (this is based off the font size)*/
   display: inline;
   position: absolute;
-}
-.toggle {
 }
 .toggle:hover {
   background-color: #f4f4f4;

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -1086,7 +1086,7 @@ export default Vue.extend({
       if (this.getCoordinateType === CoordinateType.PointBased) {
         return this.pointGroups(tableData);
       }
-      const areas = tableData?.map((item, i) => {
+      const areas = tableData.map((item, i) => {
         const imageUrl = this.isMultiBandImage
           ? item[this.multibandImageGroupColumn].value
           : null;

--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -27,17 +27,19 @@
       <b-button
         v-if="isCarousel"
         class="position-absolute left"
-        @click="rotateSelection(-1)"
         :disabled="carouselPosition === 0"
-        ><b>&lt</b></b-button
+        @click="rotateSelection(-1)"
       >
+        <b>&lt;</b>
+      </b-button>
       <b-button
         v-if="isCarousel"
         class="position-absolute right"
-        @click="rotateSelection(1)"
         :disabled="carouselPosition === imageUrls.length - 1"
-        ><b>&gt</b></b-button
+        @click="rotateSelection(1)"
       >
+        <b>&gt;</b>
+      </b-button>
       <image-transformer
         ref="transformer"
         :width="width"
@@ -57,11 +59,11 @@
           <label> {{ toggleStateString }} image explanation: </label>
           <div>
             <input
+              id="drill-down-filter-toggle"
+              v-model="isFilteredToggled"
               class="form-check-input"
               type="checkbox"
               value=""
-              id="drill-down-filter-toggle"
-              v-model="isFilteredToggled"
             />
           </div>
         </li>
@@ -83,8 +85,8 @@
           </label>
           <b-button
             v-if="shouldImagesScale"
-            @click="upscaleFetch"
             :disabled="disableUpscale"
+            @click="upscaleFetch"
           >
             <b-spinner v-if="fetchingUpscale" small />
             Upscale Image
@@ -137,7 +139,7 @@ export default Vue.extend({
   props: {
     info: Object as () => DrillDownInfo,
     type: { type: String, default: IMAGE_TYPE },
-    url: String,
+    url: { type: String, default: null },
     visible: Boolean,
     imageUrls: { type: Array as () => string[], default: () => [] as string[] },
     items: { type: Array as () => TableRow[], default: () => [] as TableRow[] },

--- a/public/components/ImagePreview.vue
+++ b/public/components/ImagePreview.vue
@@ -23,6 +23,7 @@
       width: `${width}px`, // + 2 for boarder
       height: `${height}px`, // boarder
       filter: `grayscale(${gray}%)`,
+      '--confidence': confidenceColor,
     }"
   >
     <div class="image-container" :class="{ selected: isSelected && isLoaded }">
@@ -79,7 +80,7 @@ import {
 import { isRowSelected } from "../util/row";
 import { Dictionary } from "../util/dict";
 import { MULTIBAND_IMAGE_TYPE, IMAGE_TYPE } from "../util/types";
-import { ColorScaleNames } from "../util/data";
+import { ColorScaleNames, COLOR_SCALES } from "../util/data";
 
 export default Vue.extend({
   name: "ImagePreview",
@@ -120,6 +121,13 @@ export default Vue.extend({
   },
 
   computed: {
+    confidenceColor(): string {
+      if (!this.isLoaded) return;
+      const confidenceScale = this.row?.confidenceScale;
+      if (!confidenceScale) return;
+      return COLOR_SCALES.get(this.colorScale)(confidenceScale);
+    },
+
     colorScale(): ColorScaleNames {
       return routeGetters.getColorScale(this.$store);
     },
@@ -435,6 +443,7 @@ export default Vue.extend({
 
 .image-container {
   position: relative;
+  outline: solid 2px var(--confidence);
 }
 
 .image-container.selected {

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -241,6 +241,7 @@ export interface TableRow {
   coordinates: any;
   d3mIndex?: number;
   isExcluded?: boolean;
+  confidenceScale?: number;
 }
 
 export interface TimeseriesExtrema {

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -949,7 +949,7 @@ export const actions = {
     predictionMutations.clearTrainingSummaries(store);
     predictionMutations.setIncludedPredictionTableData(store, null);
 
-    const produceRequestId = <string>context.getters.getRouteProduceRequestId;
+    const produceRequestId = context.getters.getRouteProduceRequestId as string;
     const fittedSolutionId = context.getters.getRouteFittedSolutionId;
 
     // fetch the predictions
@@ -972,15 +972,16 @@ export const actions = {
 
   updatePredictionTrainingSummaries(context: ViewContext) {
     // fetch new state
-    const produceRequestId = <string>context.getters.getRouteProduceRequestId;
+    const produceRequestId = context.getters.getRouteProduceRequestId as string;
     const inferenceDataset = getPredictionsById(
       context.getters.getPredictions,
       produceRequestId
     ).dataset;
     const highlights = context.getters.getDecodedHighlights as Highlight[];
-    const varModes = <Map<string, SummaryMode>>(
-      context.getters.getDecodedVarModes
-    );
+    const varModes = context.getters.getDecodedVarModes as Map<
+      string,
+      SummaryMode
+    >;
     const currentSearch = context.getters
       .getRouteResultTrainingVarsSearch as string;
     const trainingVariables = searchVariables(

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -26,6 +26,7 @@ import {
   TableColumn,
   TableData,
   TableRow,
+  TableValue,
   TimeseriesGrouping,
   Variable,
   VariableSummary,
@@ -938,8 +939,31 @@ export function fetchLowShotScores() {
     orderBy: lowShotScore,
   });
 }
+
+/** Create the method to get the scale [0, 1] of a TableValue 
+    to visually display its ranking or confidence. */
+function getConfidenceScale(dataLength: number): Function {
+  const solutionId = requestGetters.getActiveSolution(store)?.solutionId;
+  const rankSummary = resultsGetters
+    .getRankingSummaries(store)
+    .filter((rank) => rank.solutionId === solutionId)[0];
+
+  // The max value is either the ranking summary max value,
+  // or the length of the dataset.
+  const max = rankSummary?.baseline.extrema.max ?? dataLength;
+
+  // Create the scale that uses ranking before confidence.
+  return function (value: TableValue): number {
+    if (value.rank !== undefined) return value.rank / max;
+    if (value.confidence !== undefined) return value.confidence;
+    return;
+  };
+}
+
 export function getTableDataItems(data: TableData): TableRow[] {
   if (validateData(data)) {
+    const confidenceScale = getConfidenceScale(data.numRows);
+
     // convert fetched result data rows into table data rows
     const formattedTable = data.values.map((resultRow, rowIndex) => {
       const row = {} as TableRow;
@@ -961,6 +985,12 @@ export function getTableDataItems(data: TableData): TableRow[] {
             const conKey = "rank";
             row[conKey] = {};
             row[conKey].value = colValue.rank;
+          }
+          if (
+            colValue.rank !== undefined ||
+            colValue.confidence !== undefined
+          ) {
+            row.confidenceScale = confidenceScale(colValue);
           }
         } else {
           row[key] = formatValue(colValue.value, colType);


### PR DESCRIPTION
fix #2440, fix #2015 

- Added the confidence scale to the `TableRow` items for easier access to the `ImagePreview` component.
- Display the scale colour as an outline to not conflict with the selection tool.
- Made the WebGL container a fixed height, to make it a square, as a patch up for #2015.

This needs to be tested more thoroughly, as I have limited access to remote sensing results, and WebGL does not work well on my browsers.

<img width="1147" alt="Screen Shot 2021-04-06 at 09 38 52" src="https://user-images.githubusercontent.com/636801/113719705-e9c53b80-96bb-11eb-9166-d6e82130d9b3.png">

