### PR TITLE
Image fetch URLs

### DIFF
--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -79,15 +79,8 @@ func (s *Storage) fetchExplainHistogram(dataset string, storageName string, targ
 	// use a numerical sub select
 	field := NewNumericalFieldSubSelect(s, dataset, storageName, explainFieldAlias, explainFieldName, model.RealType, "", s.explainSubSelect(storageName, explainFieldName, explainFieldAlias))
 
-	// use predefined ranged of [0,1] for everything except rank
 	// rank extrema should be pulled now to optimize the query
-	var extrema *api.Extrema
-	var err error
-	if explainFieldName == "rank" {
-		extrema, err = s.fetchExplainExtrema(storageName, explainFieldName, resultURI)
-	} else {
-		extrema, _ = api.NewExtrema(0.0, 1.0)
-	}
+	extrema, err := s.fetchExplainExtrema(storageName, explainFieldName, resultURI)
 	if err != nil {
 		return nil, err
 	}

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -177,8 +177,7 @@ func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) floa
 		bandImage, err := loadAsGray16(filePath)
 		bandImages = append(bandImages, bandImage)
 		if err != nil {
-			log.Error(err, "band file not loaded")
-			continue
+			return nil, err
 		}
 	}
 	if imageScale.shouldScale() {

--- a/public/components/ImageLabel.vue
+++ b/public/components/ImageLabel.vue
@@ -68,38 +68,36 @@ export default Vue.extend({
   },
 
   props: {
-    includedActive: Boolean as () => boolean,
+    dataFields: {
+      type: Object as () => Dictionary<TableColumn>,
+      default: () => {
+        return {} as Dictionary<TableColumn>;
+      },
+    },
+    includedActive: {
+      type: Boolean as () => boolean,
+      default: false,
+    },
     item: Object as () => TableRow,
     shortenLabels: {
       type: Boolean as () => boolean,
-      default: false,
+      default: true,
     },
     alignHorizontal: {
       type: Boolean as () => boolean,
       default: false,
     },
-    isResult: { type: Boolean as () => boolean, default: false },
     labelFeatureName: { type: String, default: "" },
   },
 
   computed: {
-    fields(): Dictionary<TableColumn> {
-      if (this.isResult) {
-        return this.includedActive
-          ? resultGetters.getIncludedResultTableDataFields(this.$store)
-          : resultGetters.getExcludedResultTableDataFields(this.$store);
-      }
-      return this.includedActive
-        ? datasetGetters.getIncludedTableDataFields(this.$store)
-        : datasetGetters.getExcludedTableDataFields(this.$store);
-    },
     labels(): Label[] {
       const labels: Label[] = [];
       let status: string;
       if (!this.item) {
         return [];
       }
-      for (const key in this.fields) {
+      for (const key in this.dataFields) {
         status = null;
 
         // If we're showing error, we want to show

--- a/public/components/PredictionsDataSlot.vue
+++ b/public/components/PredictionsDataSlot.vue
@@ -58,7 +58,8 @@
         :data-items="dataItems"
         :instance-name="instanceName"
         :summaries="summaries"
-        :areaOfInterestItems="{ inner: inner, outer: outer }"
+        :area-of-interest-items="{ inner: inner, outer: outer }"
+        :dataset="dataset"
         @tileClicked="onTileClick"
       />
     </div>
@@ -156,7 +157,7 @@ export default Vue.extend({
       return requestGetters.getActivePredictionTrainingVariables(this.$store);
     },
     dataset(): string {
-      return routeGetters.getRouteDataset(this.$store);
+      return routeGetters.getRoutePredictionsDataset(this.$store);
     },
     allVariables(): Variable[] {
       let predictionVariables = [];

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -46,6 +46,7 @@
         :area-of-interest-items="{ inner: inner, outer: outer }"
         :confidence-access-func="colorTile"
         :is-result="true"
+        :dataset="dataset"
         @tileClicked="onTileClick"
       />
     </div>

--- a/public/components/SelectDataSlot.vue
+++ b/public/components/SelectDataSlot.vue
@@ -102,6 +102,9 @@
         :is="viewComponent"
         :included-active="includedActive"
         :instance-name="instanceName"
+        :dataset="dataset"
+        :data-items="items"
+        :data-fields="fields"
       />
     </div>
   </div>
@@ -117,7 +120,6 @@ import SearchBar from "../components/layout/SearchBar.vue";
 import SelectTimeseriesView from "./SelectTimeseriesView.vue";
 import SelectGeoPlot from "./SelectGeoPlot.vue";
 import SelectGraphView from "./SelectGraphView.vue";
-import FilterBadge from "./FilterBadge.vue";
 import ViewTypeToggle from "./ViewTypeToggle.vue";
 import LayerSelection from "./LayerSelection.vue";
 import { overlayRouteEntry } from "../util/routes";
@@ -130,6 +132,7 @@ import {
   Variable,
   Highlight,
   RowSelection,
+  TableColumn,
 } from "../store/dataset/index";
 import { getters as routeGetters } from "../store/route/module";
 import {
@@ -155,6 +158,7 @@ import {
 import { actions as appActions } from "../store/app/module";
 import { actions as viewActions } from "../store/view/module";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
+import { Dictionary } from "lodash";
 
 const GEO_VIEW = "geo";
 const GRAPH_VIEW = "graph";
@@ -251,6 +255,14 @@ export default Vue.extend({
           ? datasetGetters.getIncludedTableDataLength(this.$store)
           : datasetGetters.getExcludedTableDataLength(this.$store)
         : 0;
+    },
+
+    fields(): Dictionary<TableColumn> {
+      return this.hasData
+        ? this.includedActive
+          ? datasetGetters.getIncludedTableDataFields(this.$store)
+          : datasetGetters.getExcludedTableDataFields(this.$store)
+        : {};
     },
 
     // return as filters for easier comparison in setting include/exclude state options.

--- a/public/components/facets/GeocoordinateFacet.vue
+++ b/public/components/facets/GeocoordinateFacet.vue
@@ -1092,7 +1092,7 @@ export default Vue.extend({
 
     // type guard for geo table data
     isGeoTableRows(rows: TableRow[]): rows is GeoTableRow[] {
-      return (rows as GeoTableRow[])[0].latitude !== undefined;
+      return (rows as GeoTableRow[])[0]?.latitude !== undefined;
     },
   },
 

--- a/public/components/labelingComponents/LabelScorePopUp.vue
+++ b/public/components/labelingComponents/LabelScorePopUp.vue
@@ -23,22 +23,23 @@
         <h5 class="header-title">Most Similar</h5>
         <component
           :is="viewComponent"
-          :instanceName="instanceName"
+          :instance-name="instanceName"
           :data-items="items"
           :data-fields="dataFields"
           :summaries="summaries"
-          includedActive
+          included-active
         />
       </div>
       <div class="col-12 col-md-6 d-flex flex-column h-100">
         <h5 class="header-title">Randomly Chosen</h5>
         <component
           :is="viewComponent"
-          :instanceName="instanceName"
+          :instance-name="instanceName"
           :data-items="randomItems"
           :data-fields="dataFields"
           :summaries="summaries"
-          includedActive
+          :dataset="dataset"
+          included-active
         />
       </div>
     </div>
@@ -46,7 +47,7 @@
       <!-- Emulate built in modal footer ok and cancel button actions -->
       <b-button size="lg" variant="secondary" @click="onApply">
         <template v-if="isLoading">
-          <div v-html="spinnerHTML"></div>
+          <div v-html="spinnerHTML" />
         </template>
         <template v-else> Apply </template>
       </b-button>
@@ -67,9 +68,10 @@ import SelectDataTable from "../SelectDataTable.vue";
 import ImageMosaic from "../ImageMosaic.vue";
 import LabelHeaderButtons from "./LabelHeaderButtons.vue";
 import { circleSpinnerHTML } from "../../util/spinner";
+import { getters as routeGetters } from "../../store/route/module";
 
 export default Vue.extend({
-  name: "label-score-pop-up",
+  name: "LabelScorePopUp",
   components: {
     SelectDataTable,
     ImageMosaic,
@@ -130,6 +132,9 @@ export default Vue.extend({
         return "SelectDataTable";
       }
       return "ImageMosaic";
+    },
+    dataset(): string {
+      return routeGetters.getRouteDataset(this.$store);
     },
   },
   methods: {

--- a/public/components/labelingComponents/LabelingDataSlot.vue
+++ b/public/components/labelingComponents/LabelingDataSlot.vue
@@ -58,8 +58,9 @@
         :has-confidence="hasConfidence"
         :label-feature-name="labelFeatureName"
         :label-score-name="labelScoreName"
+        :dataset="dataset"
         pagination
-        includedActive
+        included-active
       />
     </div>
   </div>
@@ -97,7 +98,7 @@ interface DataView {
   selectAll: () => void;
 }
 export default Vue.extend({
-  name: "labeling-data-slot",
+  name: "LabelingDataSlot",
   components: {
     ViewTypeToggle,
     LabelGeoPlot,
@@ -107,8 +108,18 @@ export default Vue.extend({
     FilterBadge,
   },
   props: {
-    variables: Array as () => Variable[],
-    summaries: Array as () => VariableSummary[],
+    variables: {
+      type: Array as () => Variable[],
+      default: () => {
+        return [] as Variable[];
+      },
+    },
+    summaries: {
+      type: Array as () => VariableSummary[],
+      default: () => {
+        return [] as Variable[];
+      },
+    },
     instanceName: { type: String, default: "label" },
     hasConfidence: { type: Boolean as () => boolean, default: false },
     labelFeatureName: { type: String, default: "" },

--- a/public/util/row.ts
+++ b/public/util/row.ts
@@ -20,6 +20,7 @@ import {
   Row,
   D3M_INDEX_FIELD,
   state,
+  TableRow,
 } from "../store/dataset/index";
 import { getters as routeGetters } from "../store/route/module";
 import {
@@ -107,10 +108,10 @@ export function isRowSelected(
 }
 
 export function updateTableRowSelection(
-  items: any,
+  items: TableRow[],
   selection: RowSelection,
   context: string
-) {
+): TableRow[] {
   if (!items) {
     return null;
   }
@@ -133,7 +134,7 @@ export function updateTableRowSelection(
   selection.d3mIndices.forEach((index) => {
     d3mIndices[index] = true;
   });
-  items.forEach((item: any) => {
+  items.forEach((item) => {
     if (d3mIndices[item[D3M_INDEX_FIELD]]) {
       item._rowVariant = "selected-row";
     }

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -91,6 +91,7 @@
           :is="viewComponent"
           :instance-name="instanceName"
           :included-active="includedActive"
+          :dataset="dataset"
         />
       </section>
 


### PR DESCRIPTION
Fixes #2438 by ensuring that the image component uses the correct dataset when fetching.  This required updating the mosaic to take the dataset as a parameter, and the fields and items were shifted to being parameters as well to keep things consistent.  A few additional fixes were made for issues found during testing:
- always uses extracted confidence extrema to ensure range is correct in facet for uncalibrated confidences
- skips loading an image when an error is encountered to avoid panics
- properly handles unselected rows in geo table type guard
