### PR TITLE
ensures images are fetched an an image feature is added

### DIFF
--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -52,7 +52,7 @@
       </template>
     </div>
     <b-pagination
-      v-if="dataItems && dataItems.length > perPage"
+      v-if="dataItems.length > perPage"
       v-model="currentPage"
       align="center"
       first-number
@@ -104,7 +104,12 @@ export default Vue.extend({
 
   props: {
     instanceName: { type: String as () => string, default: "" },
-    dataItems: { type: Array as () => TableRow[], default: null },
+    dataItems: {
+      type: Array as () => TableRow[],
+      default: () => {
+        return [];
+      },
+    },
     dataFields: {
       type: Object as () => Dictionary<TableColumn>,
       default: () => {
@@ -120,7 +125,6 @@ export default Vue.extend({
       imageWidth: 128,
       imageHeight: 128,
       currentPage: 1,
-      previousPage: 0,
       perPage: 100,
       shiftClickInfo: { first: null, second: null },
       uniqueTrail: "image-mosiac",

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -451,14 +451,6 @@ export default Vue.extend({
         this.currentPage = 1;
       }
     },
-
-    pageItems(prev: TableRow[], curr: TableRow[]) {
-      // check if all the indices are in the same order and prev == cur
-      if (sameData(prev, curr)) {
-        return;
-      }
-      this.debounceImageFetch();
-    },
   },
 
   methods: {

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -208,7 +208,6 @@ import {
   getListFields,
   removeTimeseries,
   getTimeseriesVariablesFromFields,
-  sameData,
 } from "../util/data";
 import { getSolutionIndex } from "../util/solutions";
 
@@ -230,9 +229,24 @@ export default Vue.extend({
   },
 
   props: {
-    dataItems: Array as () => any[],
-    dataFields: Object as () => Dictionary<TableColumn>,
-    instanceName: String as () => string,
+    dataItems: {
+      type: Array as () => TableRow[],
+      default: () => {
+        return [];
+      },
+    },
+    dataFields: {
+      type: Object as () => Dictionary<TableColumn>,
+      default: () => {
+        return {};
+      },
+    },
+    instanceName: {
+      type: String as () => string,
+      default: () => {
+        return "";
+      },
+    },
   },
 
   data() {
@@ -245,7 +259,6 @@ export default Vue.extend({
       // visibleRows is v-model with the b-table and contains all the items in the current b-table page
       visibleRows: [],
       debounceKey: null,
-      imagesFetched: false,
     };
   },
 

--- a/public/components/ResultsDataTable.vue
+++ b/public/components/ResultsDataTable.vue
@@ -208,6 +208,7 @@ import {
   getListFields,
   removeTimeseries,
   getTimeseriesVariablesFromFields,
+  sameData,
 } from "../util/data";
 import { getSolutionIndex } from "../util/solutions";
 
@@ -244,6 +245,7 @@ export default Vue.extend({
       // visibleRows is v-model with the b-table and contains all the items in the current b-table page
       visibleRows: [],
       debounceKey: null,
+      imagesFetched: false,
     };
   },
 
@@ -449,6 +451,14 @@ export default Vue.extend({
         this.currentPage = 1;
       }
     },
+
+    pageItems(prev: TableRow[], curr: TableRow[]) {
+      // check if all the indices are in the same order and prev == cur
+      if (sameData(prev, curr)) {
+        return;
+      }
+      this.debounceImageFetch();
+    },
   },
 
   methods: {
@@ -459,6 +469,7 @@ export default Vue.extend({
         this.fetchImagePack(this.visibleRows);
       }, 1000);
     },
+
     removeImages() {
       if (!this.imageFields.length) {
         return;
@@ -470,6 +481,7 @@ export default Vue.extend({
         }),
       });
     },
+
     fetchImagePack(items) {
       if (!this.imageFields.length) {
         return;
@@ -488,6 +500,7 @@ export default Vue.extend({
         uniqueTrail: this.uniqueTrail,
       });
     },
+
     timeserieInfo(id: string): Extrema {
       const timeseries = resultsGetters.getPredictedTimeseries(this.$store);
       return timeseries?.[this.solutionId]?.info?.[id];
@@ -595,6 +608,7 @@ export default Vue.extend({
       this.fetchTimeseries();
       this.removeImages();
     },
+
     fetchTimeseries() {
       if (!this.isTimeseries) {
         return;

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -559,6 +559,21 @@ export function formatFieldsAsArray(
   return _.map(fields, (field) => field);
 }
 
+export function sameData(old: TableRow[], cur: TableRow[]): boolean {
+  if (old === null || cur === null) {
+    return false;
+  }
+  if (old.length !== cur.length) {
+    return false;
+  }
+  for (let i = 0; i < old.length; ++i) {
+    if (old[i][D3M_INDEX_FIELD] !== cur[i][D3M_INDEX_FIELD]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function createPendingSummary(
   key: string,
   label: string,


### PR DESCRIPTION
When an image feature was first added (or removed, then re-added) in the mosaic and table views, the fetch didn't take place.  We now watch on the image field computed property, and run the debounced image fetch when the image is first added to the feature set.