### PR TITLE
Filter group variable

### DIFF
--- a/api/compute/featurize.go
+++ b/api/compute/featurize.go
@@ -52,7 +52,7 @@ func (s *SolutionRequest) createPreFeaturizedPipeline(learningDataset string,
 	name := fmt.Sprintf("prefeaturized-%s-%s-%s", s.Dataset, learningDataset, uuid.String())
 	desc := fmt.Sprintf("Prefeaturized pipeline capturing user feature selection and type information. Dataset: `%s` ID: `%s`", s.Dataset, uuid.String())
 
-	expandedFilters, err := api.ExpandFilterParams(s.Dataset, s.Filters, true, metaStorage)
+	expandedFilters, err := api.ExpandFilterParams(s.Dataset, api.NewFilterParamsFromRaw(s.Filters), true, metaStorage)
 	if err != nil {
 		return nil, err
 	}

--- a/api/compute/filter.go
+++ b/api/compute/filter.go
@@ -32,7 +32,7 @@ import (
 	"github.com/uncharted-distil/distil/api/util"
 )
 
-func filterData(client *compute.Client, ds *api.Dataset, filterParams *api.FilterParams, dataStorage api.DataStorage) (string, *api.FilterParams, error) {
+func filterData(client *compute.Client, ds *api.Dataset, filterParams *api.FilterParamsRaw, dataStorage api.DataStorage) (string, *api.FilterParamsRaw, error) {
 	inputPath := ds.GetLearningFolder()
 
 	log.Infof("checking if solution search for dataset %s found in '%s' needs prefiltering", ds.ID, inputPath)
@@ -99,7 +99,7 @@ func filterData(client *compute.Client, ds *api.Dataset, filterParams *api.Filte
 	return outputFolder, updatedParams, nil
 }
 
-func mapFilterKeys(dataset string, filters *api.FilterParams, variables []*model.Variable) *api.FilterParams {
+func mapFilterKeys(dataset string, filters *api.FilterParamsRaw, variables []*model.Variable) *api.FilterParamsRaw {
 	filtersUpdated := filters.Clone()
 
 	varsMapped := api.MapVariables(variables, func(variable *model.Variable) string { return variable.Key })
@@ -116,11 +116,11 @@ func mapFilterKeys(dataset string, filters *api.FilterParams, variables []*model
 	return filtersUpdated
 }
 
-func hashFilter(schemaFile string, filterParams *api.FilterParams) (uint64, error) {
+func hashFilter(schemaFile string, filterParams *api.FilterParamsRaw) (uint64, error) {
 	// generate the hash from the params
 	hashStruct := struct {
 		Schema       string
-		FilterParams *api.FilterParams
+		FilterParams *api.FilterParamsRaw
 	}{
 		Schema:       schemaFile,
 		FilterParams: filterParams,
@@ -132,7 +132,7 @@ func hashFilter(schemaFile string, filterParams *api.FilterParams) (uint64, erro
 	return hash, nil
 }
 
-func getPreFiltering(ds *api.Dataset, filterParams *api.FilterParams) (*api.FilterParams, *api.FilterParams) {
+func getPreFiltering(ds *api.Dataset, filterParams *api.FilterParamsRaw) (*api.FilterParamsRaw, *api.FilterParamsRaw) {
 	vars := map[string]*model.Variable{}
 	for _, v := range ds.Variables {
 		vars[v.Key] = v
@@ -141,7 +141,7 @@ func getPreFiltering(ds *api.Dataset, filterParams *api.FilterParams) (*api.Filt
 	// filter if a clustering or outlier detection metadata feature exist
 	// remove pre filters from the rest of the filters since they should not be in the main pipeline
 	// TODO: NEED TO HANDLE OUTLIER FILTERS!
-	preFilters := &api.FilterParams{
+	preFilters := &api.FilterParamsRaw{
 		Filters: api.FilterObject{List: []*model.Filter{}, Invert: false},
 	}
 	filters := clone.Filters

--- a/api/compute/query_request.go
+++ b/api/compute/query_request.go
@@ -27,7 +27,7 @@ import (
 type QueryRequest struct {
 	DatasetID string
 	Target    string
-	Filters   *api.FilterParams
+	Filters   *api.FilterParamsRaw
 
 	requestChannel chan QueryStatus
 	finished       chan error

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -99,6 +99,7 @@ func NewFilterParamsFromRaw(raw *FilterParamsRaw) *FilterParams {
 		Size:      rawClone.Size,
 		Variables: rawClone.Variables,
 		DataMode:  rawClone.DataMode,
+		Filters:   map[string][]FilterObject{},
 	}
 
 	// add filters and highlights to the params
@@ -108,6 +109,8 @@ func NewFilterParamsFromRaw(raw *FilterParamsRaw) *FilterParams {
 	for _, h := range rawClone.Highlights.List {
 		params.AddFilter(h)
 	}
+	// TODO: THIS MAKES NO SENSE BUT WE SOMEHOW HAVE TO SET THE INVERT PROPERLY!
+	// OR DO WE INVERT THINGS HERE? (IE INVERT HIGHLIGHT = MAKE IT FILTER AND VICE VERSE)
 	if len(rawClone.Filters.List) > 0 {
 		for _, f := range params.Filters[rawClone.Filters.List[0].Mode] {
 			f.Invert = rawClone.Filters.Invert
@@ -161,7 +164,9 @@ func (f FilterObject) getBaselineFilter() []*model.Filter {
 
 // Clone returns a deep copy of the filter params.
 func (f *FilterParams) Clone() *FilterParams {
-	clone := &FilterParams{}
+	clone := &FilterParams{
+		Filters: map[string][]FilterObject{},
+	}
 	for mode, filters := range f.Filters {
 		if clone.Filters[mode] == nil {
 			clone.Filters[mode] = []FilterObject{}
@@ -200,9 +205,9 @@ func (f *FilterParams) AddFilter(filter *model.Filter) {
 	}
 
 	// find the list of filters for that feature
-	for _, feature := range filters {
+	for i, feature := range filters {
 		if feature.List[0].Key == filter.Key {
-			feature.List = append(feature.List, filter)
+			filters[i].List = append(filters[i].List, filter)
 			return
 		}
 	}

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -332,18 +332,61 @@ func (f *FilterParams) Merge(other *FilterParamsRaw) {
 		}
 	}
 
-	for _, highlight := range other.Filters.List {
+	for _, filter := range other.Filters.List {
 		found := false
-		for _, filters := range f.Filters[highlight.Mode] {
+		for _, filters := range f.Filters[filter.Mode] {
 			for _, currentFilter := range filters.List {
-				if filtersEqual(highlight, currentFilter) {
+				if filtersEqual(filter, currentFilter) {
 					found = true
 					break
 				}
 			}
 		}
 		if !found {
-			f.AddFilter(highlight)
+			f.AddFilter(filter)
+		}
+	}
+
+	for _, variable := range other.Variables {
+		found := false
+		for _, currentVariable := range f.Variables {
+			if variable == currentVariable {
+				found = true
+				break
+			}
+		}
+		if !found {
+			f.Variables = append(f.Variables, variable)
+		}
+	}
+}
+
+// MergeParams merges another set of filter params into this set, expanding all
+// properties.
+func (f *FilterParams) MergeParams(other *FilterParams) {
+
+	// If the filters has a nil or negative value, we use the value use by default on distil-model
+	// https://github.com/uncharted-distil/distil/blob/master/api/model/storage/postgres/request.go#L239
+	if other.Size >= 0 {
+		f.Size = other.Size
+	}
+
+	for _, mode := range other.Filters {
+		for _, features := range mode {
+			for _, filter := range features.List {
+				found := false
+				for _, filters := range f.Filters[filter.Mode] {
+					for _, currentFilter := range filters.List {
+						if filtersEqual(filter, currentFilter) {
+							found = true
+							break
+						}
+					}
+				}
+				if !found {
+					f.AddFilter(filter)
+				}
+			}
 		}
 	}
 

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -138,12 +138,17 @@ func GetBaselineFilter(filterParam *FilterParams) *FilterParams {
 	for key, filters := range filterParam.Filters {
 		baselineFilters := []FilterObject{}
 		for _, f := range filters {
-			baselineFilters = append(baselineFilters, FilterObject{
-				Invert: f.Invert,
-				List:   f.getBaselineFilter(),
-			})
+			baseline := f.getBaselineFilter()
+			if len(baseline) > 0 {
+				baselineFilters = append(baselineFilters, FilterObject{
+					Invert: f.Invert,
+					List:   f.getBaselineFilter(),
+				})
+			}
 		}
-		clone.Filters[key] = baselineFilters
+		if len(baselineFilters) > 0 {
+			clone.Filters[key] = baselineFilters
+		}
 	}
 	clone.Variables = append(clone.Variables, filterParam.Variables...)
 	clone.Size = filterParam.Size

--- a/api/model/grouped_variables.go
+++ b/api/model/grouped_variables.go
@@ -71,9 +71,8 @@ func ExpandFilterParams(dataset string, filterParams *FilterParams, includeHidde
 	for _, variable := range variables {
 		// Check if the highlight variable is a group variable, and if it has associated cluster data.
 		// If it does, update the filter key to use the highlight column.
-
 		for _, fo := range updatedFilterParams.Filters {
-			for _, fl := range fo {
+			for _, fl := range fo.FeatureFilters {
 				for _, f := range fl.List {
 					UpdateFilterKey(metaStore, dataset, updatedFilterParams.DataMode, f, variable)
 				}

--- a/api/model/grouped_variables.go
+++ b/api/model/grouped_variables.go
@@ -72,11 +72,12 @@ func ExpandFilterParams(dataset string, filterParams *FilterParams, includeHidde
 		// Check if the highlight variable is a group variable, and if it has associated cluster data.
 		// If it does, update the filter key to use the highlight column.
 
-		for _, h := range updatedFilterParams.Highlights.List {
-			UpdateFilterKey(metaStore, dataset, updatedFilterParams.DataMode, h, variable)
-		}
-		for _, f := range updatedFilterParams.Filters.List {
-			UpdateFilterKey(metaStore, dataset, updatedFilterParams.DataMode, f, variable)
+		for _, fo := range updatedFilterParams.Filters {
+			for _, fl := range fo {
+				for _, f := range fl.List {
+					UpdateFilterKey(metaStore, dataset, updatedFilterParams.DataMode, f, variable)
+				}
+			}
 		}
 	}
 

--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -98,7 +98,7 @@ func (s *Storage) fetchExplainHistogram(dataset string, storageName string, targ
 	}
 
 	// filter info derived from the sub select function
-	filterParams.Filters.List = append(filterParams.Filters.List, model.NewCategoricalFilter("result_key", model.IncludeFilter, []string{resultURI}))
+	filterParams.AddFilter(model.NewCategoricalFilter("result_key", model.IncludeFilter, []string{resultURI}))
 
 	return field.fetchHistogramByResult(resultURI, filterParams, extrema, 20)
 }

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -107,7 +107,7 @@ func createJoinStatements(joins []*joinDefinition) string {
 }
 
 // Checks to see if the highlighted variable has cluster data.  If so, the highlight key will be switched to the
-// cluster column ID to ensure that it is used in downstream queries.  This necessary when dealing with the timerseries
+// cluster column ID to ensure that it is used in downstream queries.  This is necessary when dealing with the timerseries
 // compound facet, which will display cluster info when available.
 func updateClusterFilters(metadataStorage api.MetadataStorage, dataset string, filterParams *api.FilterParams, mode api.SummaryMode) error {
 	if filterParams != nil && !filterParams.Empty(false) {

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -111,8 +111,8 @@ func createJoinStatements(joins []*joinDefinition) string {
 // compound facet, which will display cluster info when available.
 func updateClusterFilters(metadataStorage api.MetadataStorage, dataset string, filterParams *api.FilterParams, mode api.SummaryMode) error {
 	if filterParams != nil && !filterParams.Empty(false) {
-		for _, m := range filterParams.Filters {
-			for _, f := range m {
+		for _, s := range filterParams.Filters {
+			for _, f := range s.FeatureFilters {
 				for _, h := range f.List {
 					if err := updateClusterFilter(metadataStorage, dataset, filterParams.DataMode, h); err != nil {
 						return err

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -111,14 +111,13 @@ func createJoinStatements(joins []*joinDefinition) string {
 // compound facet, which will display cluster info when available.
 func updateClusterFilters(metadataStorage api.MetadataStorage, dataset string, filterParams *api.FilterParams, mode api.SummaryMode) error {
 	if filterParams != nil && !filterParams.Empty(false) {
-		for _, h := range filterParams.Highlights.List {
-			if err := updateClusterFilter(metadataStorage, dataset, filterParams.DataMode, h); err != nil {
-				return err
-			}
-		}
-		for _, f := range filterParams.Filters.List {
-			if err := updateClusterFilter(metadataStorage, dataset, filterParams.DataMode, f); err != nil {
-				return err
+		for _, m := range filterParams.Filters {
+			for _, f := range m {
+				for _, h := range f.List {
+					if err := updateClusterFilter(metadataStorage, dataset, filterParams.DataMode, h); err != nil {
+						return err
+					}
+				}
 			}
 		}
 	}

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -665,6 +665,10 @@ type filters struct {
 }
 
 func splitFilters(filterParams *api.FilterParams) (*filters, error) {
+	if filterParams == nil {
+		return &filters{}, nil
+	}
+
 	// Groups filters for handling downstream
 	predictedFilters := []api.FilterObject{}
 	residualFilters := []api.FilterObject{}
@@ -676,10 +680,6 @@ func splitFilters(filterParams *api.FilterParams) (*filters, error) {
 		Invert:    filterParams.Invert,
 		DataMode:  filterParams.DataMode,
 		Variables: filterParams.Variables,
-	}
-
-	if filterParams == nil {
-		return &filters{}, nil
 	}
 
 	for _, modeFilters := range filterParams.Filters {

--- a/api/model/storage/postgres/request.go
+++ b/api/model/storage/postgres/request.go
@@ -60,8 +60,8 @@ func (s *Storage) PersistRequestFilters(requestID string, filters *api.FilterPar
 		"INSERT INTO %s (request_id, feature_name, filter_type, filter_mode, filter_min, filter_max, filter_min_x, filter_max_x, filter_min_y, filter_max_y, filter_categories, filter_indices) "+
 			"VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);", postgres.RequestFilterTableName)
 
-	for _, filterMode := range filters.Filters {
-		for _, filterFeatures := range filterMode {
+	for _, filterSet := range filters.Filters {
+		for _, filterFeatures := range filterSet.FeatureFilters {
 			for _, filter := range filterFeatures.List {
 				switch filter.Type {
 				case model.NumericalFilter:

--- a/api/model/storage/postgres/request.go
+++ b/api/model/storage/postgres/request.go
@@ -60,27 +60,31 @@ func (s *Storage) PersistRequestFilters(requestID string, filters *api.FilterPar
 		"INSERT INTO %s (request_id, feature_name, filter_type, filter_mode, filter_min, filter_max, filter_min_x, filter_max_x, filter_min_y, filter_max_y, filter_categories, filter_indices) "+
 			"VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12);", postgres.RequestFilterTableName)
 
-	for _, filter := range filters.Filters.List {
-		switch filter.Type {
-		case model.NumericalFilter:
-			_, err := s.client.Exec(sql, requestID, filter.Key, model.NumericalFilter, filter.Mode, filter.Min, filter.Max, 0, 0, 0, 0, "", "")
-			if err != nil {
-				return errors.Wrap(err, "failed to persist numerical filter")
-			}
-		case model.BivariateFilter, model.GeoBoundsFilter:
-			_, err := s.client.Exec(sql, requestID, filter.Key, filter.Type, filter.Mode, 0, 0, filter.Bounds.MinX, filter.Bounds.MaxX, filter.Bounds.MinY, filter.Bounds.MaxY, "", "")
-			if err != nil {
-				return errors.Wrap(err, "failed to persist bivariate filter")
-			}
-		case model.CategoricalFilter, model.TextFilter:
-			_, err := s.client.Exec(sql, requestID, filter.Key, filter.Type, filter.Mode, 0, 0, 0, 0, 0, 0, strings.Join(filter.Categories, ","), "")
-			if err != nil {
-				return errors.Wrap(err, "failed to persist categorical filter")
-			}
-		case model.RowFilter:
-			_, err := s.client.Exec(sql, requestID, "", model.RowFilter, filter.Mode, 0, 0, 0, 0, 0, 0, "", strings.Join(filter.D3mIndices, ","))
-			if err != nil {
-				return errors.Wrap(err, "failed to persist row filter")
+	for _, filterMode := range filters.Filters {
+		for _, filterFeatures := range filterMode {
+			for _, filter := range filterFeatures.List {
+				switch filter.Type {
+				case model.NumericalFilter:
+					_, err := s.client.Exec(sql, requestID, filter.Key, model.NumericalFilter, filter.Mode, filter.Min, filter.Max, 0, 0, 0, 0, "", "")
+					if err != nil {
+						return errors.Wrap(err, "failed to persist numerical filter")
+					}
+				case model.BivariateFilter, model.GeoBoundsFilter:
+					_, err := s.client.Exec(sql, requestID, filter.Key, filter.Type, filter.Mode, 0, 0, filter.Bounds.MinX, filter.Bounds.MaxX, filter.Bounds.MinY, filter.Bounds.MaxY, "", "")
+					if err != nil {
+						return errors.Wrap(err, "failed to persist bivariate filter")
+					}
+				case model.CategoricalFilter, model.TextFilter:
+					_, err := s.client.Exec(sql, requestID, filter.Key, filter.Type, filter.Mode, 0, 0, 0, 0, 0, 0, strings.Join(filter.Categories, ","), "")
+					if err != nil {
+						return errors.Wrap(err, "failed to persist categorical filter")
+					}
+				case model.RowFilter:
+					_, err := s.client.Exec(sql, requestID, "", model.RowFilter, filter.Mode, 0, 0, 0, 0, 0, 0, "", strings.Join(filter.D3mIndices, ","))
+					if err != nil {
+						return errors.Wrap(err, "failed to persist row filter")
+					}
+				}
 			}
 		}
 	}
@@ -239,10 +243,7 @@ func (s *Storage) FetchRequestFilters(requestID string, features []*api.Feature)
 		defer rows.Close()
 	}
 
-	filters := &api.FilterParams{
-		Size: model.DefaultFilterSize,
-	}
-
+	filters := []*model.Filter{}
 	for rows.Next() {
 		var requestID string
 		var featureName string
@@ -264,26 +265,26 @@ func (s *Storage) FetchRequestFilters(requestID string, features []*api.Feature)
 
 		switch filterType {
 		case model.CategoricalFilter:
-			filters.Filters.List = append(filters.Filters.List, model.NewCategoricalFilter(
+			filters = append(filters, model.NewCategoricalFilter(
 				featureName,
 				filterMode,
 				strings.Split(filterCategories, ","),
 			))
 		case model.TextFilter:
-			filters.Filters.List = append(filters.Filters.List, model.NewTextFilter(
+			filters = append(filters, model.NewTextFilter(
 				featureName,
 				filterMode,
 				strings.Split(filterCategories, ","),
 			))
 		case model.NumericalFilter:
-			filters.Filters.List = append(filters.Filters.List, model.NewNumericalFilter(
+			filters = append(filters, model.NewNumericalFilter(
 				featureName,
 				filterMode,
 				filterMin,
 				filterMax,
 			))
 		case model.BivariateFilter:
-			filters.Filters.List = append(filters.Filters.List, model.NewBivariateFilter(
+			filters = append(filters, model.NewBivariateFilter(
 				featureName,
 				filterMode,
 				filterMinX,
@@ -292,7 +293,7 @@ func (s *Storage) FetchRequestFilters(requestID string, features []*api.Feature)
 				filterMaxY,
 			))
 		case model.GeoBoundsFilter:
-			filters.Filters.List = append(filters.Filters.List, model.NewGeoBoundsFilter(
+			filters = append(filters, model.NewGeoBoundsFilter(
 				featureName,
 				filterMode,
 				filterMinX,
@@ -301,7 +302,7 @@ func (s *Storage) FetchRequestFilters(requestID string, features []*api.Feature)
 				filterMaxY,
 			))
 		case model.RowFilter:
-			filters.Filters.List = append(filters.Filters.List, model.NewRowFilter(
+			filters = append(filters, model.NewRowFilter(
 				filterMode,
 				strings.Split(filterIndices, ","),
 			))
@@ -312,11 +313,13 @@ func (s *Storage) FetchRequestFilters(requestID string, features []*api.Feature)
 		return nil, errors.Wrapf(err, "error reading data from postgres")
 	}
 
+	filterParams := api.NewFilterParamsFromFilters(filters)
+
 	for _, feature := range features {
-		filters.Variables = append(filters.Variables, feature.FeatureName)
+		filterParams.Variables = append(filterParams.Variables, feature.FeatureName)
 	}
 
-	return filters, nil
+	return filterParams, nil
 }
 
 // FetchRequestByDatasetTarget pulls requests associated with a given dataset and target from postgres.

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -686,13 +686,11 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 
 		wheresMode := make([]string, 0)
 		// Create the filter portion of the where clause.
-		//this call is resulting in a nested not on exclusion filters!!!!!
 		where := ""
 		where, params = s.buildSelectionFilter(dataset, params, dataTableAlias, filters.genericFilters)
-		if filterSet.Mode == model.ExcludeFilter {
-			where = fmt.Sprintf("NOT(%s)", where)
+		if len(where) > 0 {
+			wheresMode = append(wheresMode, where)
 		}
-		wheresMode = append(wheresMode, where)
 
 		// Add the predicted filter into the where clause if it was included in the filter set
 		for _, pf := range filters.predictedFilters {

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -527,20 +527,22 @@ func isCorrectnessCategory(categoryName string) bool {
 	return strings.EqualFold(CorrectCategory, categoryName) || strings.EqualFold(categoryName, IncorrectCategory)
 }
 
-func addIncludeCorrectnessFilterToWhere(wheres []string, params []interface{}, correctnessFilter *model.Filter, target *model.Variable) ([]string, []interface{}, error) {
-	if len(correctnessFilter.Categories[0]) == 0 {
-		return nil, nil, fmt.Errorf("no category")
+func addIncludeCorrectnessFilterToWhere(wheres []string, params []interface{}, correctnessFilters api.FilterObject, target *model.Variable) ([]string, []interface{}, error) {
+	wheresFilter := []string{}
+	for _, correctnessFilter := range correctnessFilters.List {
+		if len(correctnessFilter.Categories[0]) == 0 {
+			return nil, nil, fmt.Errorf("no category")
+		}
+		// filter for result correctness which is based on well know category values
+		op := ""
+		if strings.EqualFold(correctnessFilter.Categories[0], CorrectCategory) {
+			op = "="
+		} else if strings.EqualFold(correctnessFilter.Categories[0], IncorrectCategory) {
+			op = "!="
+		}
+		wheresFilter = append(wheresFilter, fmt.Sprintf("(predicted.value %s data.\"%s\")", op, target.Key))
 	}
-	// filter for result correctness which is based on well know category values
-	where := ""
-	op := ""
-	if strings.EqualFold(correctnessFilter.Categories[0], CorrectCategory) {
-		op = "="
-	} else if strings.EqualFold(correctnessFilter.Categories[0], IncorrectCategory) {
-		op = "!="
-	}
-	where = fmt.Sprintf("predicted.value %s data.\"%s\"", op, target.Key)
-	wheres = append(wheres, where)
+	wheres = append(wheres, strings.Join(wheresFilter, " OR "))
 	return wheres, params, nil
 }
 
@@ -570,61 +572,64 @@ func getFullName(alias string, column string) string {
 	return fullName
 }
 
-func addIncludePredictedFilterToWhere(wheres []string, params []interface{}, predictedFilter *model.Filter, target *model.Variable) ([]string, []interface{}, error) {
+func addIncludePredictedFilterToWhere(wheres []string, params []interface{}, predictedFilters api.FilterObject, target *model.Variable) ([]string, []interface{}, error) {
 	// Handle the predicted column, which is accessed as `value` in the result query
-	where := ""
-	switch predictedFilter.Type {
-	case model.NumericalFilter:
-		// numerical range-based filter
-		where = fmt.Sprintf("cast(predicted.value AS double precision) >= $%d AND cast(predicted.value AS double precision) <= $%d", len(params)+1, len(params)+2)
-		params = append(params, *predictedFilter.Min)
-		params = append(params, *predictedFilter.Max)
+	wheresFilter := []string{}
+	for _, predictedFilter := range predictedFilters.List {
+		where := ""
+		switch predictedFilter.Type {
+		case model.NumericalFilter:
+			// numerical range-based filter
+			where = fmt.Sprintf("(cast(predicted.value AS double precision) >= $%d AND cast(predicted.value AS double precision) <= $%d)", len(params)+1, len(params)+2)
+			params = append(params, *predictedFilter.Min)
+			params = append(params, *predictedFilter.Max)
 
-	case model.BivariateFilter:
-		// cast to double precision in case of string based representation
-		// hardcode [lat, lon] format for now
-		where := fmt.Sprintf("predicted.value[2] >= $%d AND predicted.value[2] <= $%d predicted.value[1] >= $%d AND predicted.value[1] <= $%d", len(params)+1, len(params)+2, len(params)+3, len(params)+4)
-		wheres = append(wheres, where)
-		params = append(params, predictedFilter.Bounds.MinX)
-		params = append(params, predictedFilter.Bounds.MaxX)
-		params = append(params, predictedFilter.Bounds.MinY)
-		params = append(params, predictedFilter.Bounds.MaxY)
+		case model.BivariateFilter:
+			// cast to double precision in case of string based representation
+			// hardcode [lat, lon] format for now
+			where = fmt.Sprintf("(predicted.value[2] >= $%d AND predicted.value[2] <= $%d predicted.value[1] >= $%d AND predicted.value[1] <= $%d)", len(params)+1, len(params)+2, len(params)+3, len(params)+4)
+			params = append(params, predictedFilter.Bounds.MinX)
+			params = append(params, predictedFilter.Bounds.MaxX)
+			params = append(params, predictedFilter.Bounds.MinY)
+			params = append(params, predictedFilter.Bounds.MaxY)
 
-	case model.CategoricalFilter:
-		// categorical label based filter, with checks for special correct/incorrect metafilters
-		categories := make([]string, 0)
-		offset := len(params) + 1
+		case model.CategoricalFilter:
+			// categorical label based filter, with checks for special correct/incorrect metafilters
+			categories := make([]string, 0)
+			offset := len(params) + 1
 
-		for i, category := range predictedFilter.Categories {
-			if !isCorrectnessCategory(category) {
-				categories = append(categories, fmt.Sprintf("$%d", offset+i))
-				params = append(params, category)
+			for i, category := range predictedFilter.Categories {
+				if !isCorrectnessCategory(category) {
+					categories = append(categories, fmt.Sprintf("$%d", offset+i))
+					params = append(params, category)
+				}
 			}
-		}
 
-		if len(categories) >= 1 {
-			where = fmt.Sprintf("predicted.value IN (%s)", strings.Join(categories, ", "))
-		}
+			if len(categories) >= 1 {
+				where = fmt.Sprintf("(predicted.value IN (%s))", strings.Join(categories, ", "))
+			}
 
-	case model.RowFilter:
-		// row index based filter
-		indices := make([]string, 0)
-		offset := len(params) + 1
-		for i, d3mIndex := range predictedFilter.D3mIndices {
-			indices = append(indices, fmt.Sprintf("$%d", offset+i))
-			params = append(params, d3mIndex)
+		case model.RowFilter:
+			// row index based filter
+			indices := make([]string, 0)
+			offset := len(params) + 1
+			for i, d3mIndex := range predictedFilter.D3mIndices {
+				indices = append(indices, fmt.Sprintf("$%d", offset+i))
+				params = append(params, d3mIndex)
 
-		}
-		if len(indices) >= 1 {
-			where = fmt.Sprintf("predicted.value IN (%s)", strings.Join(indices, ", "))
-		}
+			}
+			if len(indices) >= 1 {
+				where = fmt.Sprintf("(predicted.value IN (%s))", strings.Join(indices, ", "))
+			}
 
-	default:
-		return nil, nil, errors.Errorf("unexpected type %s for variable %s", predictedFilter.Type, predictedFilter.Key)
+		default:
+			return nil, nil, errors.Errorf("unexpected type %s for variable %s", predictedFilter.Type, predictedFilter.Key)
+		}
+		wheresFilter = append(wheresFilter, where)
 	}
 
-	// Append the AND clause
-	wheres = append(wheres, where)
+	// Append the OR clause
+	wheres = append(wheres, strings.Join(wheresFilter, " OR "))
 	return wheres, params, nil
 }
 
@@ -687,15 +692,18 @@ func addExcludePredictedFilterToWhere(wheres []string, params []interface{}, pre
 	return wheres, params, nil
 }
 
-func addIncludeErrorFilterToWhere(wheres []string, params []interface{}, alias string, targetName string, residualFilter *model.Filter) ([]string, []interface{}, error) {
-	// Add a clause to filter residuals to the existing where
-	typedError := getErrorTyped(alias, targetName)
-	where := fmt.Sprintf("(%s >= $%d AND %s <= $%d)", typedError, len(params)+1, typedError, len(params)+2)
-	params = append(params, *residualFilter.Min)
-	params = append(params, *residualFilter.Max)
+func addIncludeErrorFilterToWhere(wheres []string, params []interface{}, alias string, targetName string, residualFilters api.FilterObject) ([]string, []interface{}, error) {
+	wheresFilter := []string{}
+	for _, residualFilter := range residualFilters.List {
+		// Add a clause to filter residuals to the existing where
+		typedError := getErrorTyped(alias, targetName)
+		wheresFilter = append(wheresFilter, fmt.Sprintf("(%s >= $%d AND %s <= $%d)", typedError, len(params)+1, typedError, len(params)+2))
+		params = append(params, *residualFilter.Min)
+		params = append(params, *residualFilter.Max)
+	}
 
 	// Append the AND clause
-	wheres = append(wheres, where)
+	wheres = append(wheres, strings.Join(wheresFilter, " OR "))
 	return wheres, params, nil
 }
 
@@ -776,77 +784,49 @@ func (s *Storage) FetchResults(dataset string, storageName string, resultURI str
 	fieldsExplain := addTableAlias("weights", fields, true)
 
 	// break filters out groups for specific handling
-	filters := splitFilters(filterParams)
-
-	genericFilterParams := &api.FilterParams{
-		Filters: filters.genericFilters,
+	filters, err := splitFilters(filterParams)
+	if err != nil {
+		return nil, err
 	}
+
+	genericFilterParams := filters.genericFilters
 	genericFilterParams.DataMode = filterParams.DataMode
-	genericFilterParams.Highlights = filters.genericHighlights
 	// Create the filter portion of the where clause.
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
 	wheres, params = s.buildFilteredQueryWhere(dataset, wheres, params, dataTableAlias, genericFilterParams)
 
 	// Add the predicted filter into the where clause if it was included in the filter set
-	for _, predictedFilter := range filters.predictedFilters.List {
-		if predictedFilter.Mode == model.IncludeFilter {
-			wheres, params, err = addIncludePredictedFilterToWhere(wheres, params, predictedFilter, variable)
-			if err != nil {
-				return nil, errors.Wrap(err, "Could not add result to where clause")
-			}
-		} else {
-			wheres, params, err = addExcludePredictedFilterToWhere(wheres, params, predictedFilter, variable)
-			if err != nil {
-				return nil, errors.Wrap(err, "Could not add result to where clause")
-			}
+	for _, pf := range filters.predictedFilters {
+		wheres, params, err = addIncludePredictedFilterToWhere(wheres, params, pf, variable)
+		if err != nil {
+			return nil, errors.Wrap(err, "Could not add result to where clause")
 		}
 	}
 
 	// Add the correctness filter into the where clause if it was included in the filter set
-	for _, correctnessFilter := range filters.correctnessFilters.List {
-		if correctnessFilter.Mode == model.IncludeFilter {
-			wheres, params, err = addIncludeCorrectnessFilterToWhere(wheres, params, correctnessFilter, variable)
-			if err != nil {
-				return nil, errors.Wrap(err, "Could not add result to where clause")
-			}
-		} else {
-			wheres, params, err = addExcludeCorrectnessFilterToWhere(wheres, params, correctnessFilter, variable)
-			if err != nil {
-				return nil, errors.Wrap(err, "Could not add result to where clause")
-			}
+	for _, cf := range filters.correctnessFilters {
+		wheres, params, err = addIncludeCorrectnessFilterToWhere(wheres, params, cf, variable)
+		if err != nil {
+			return nil, errors.Wrap(err, "Could not add result to where clause")
 		}
 	}
 
 	// Add the error filter into the where clause if it was included in the filter set
-	for _, residualFilter := range filters.residualFilters.List {
-		if residualFilter.Mode == model.IncludeFilter {
-			wheres, params, err = addIncludeErrorFilterToWhere(wheres, params, dataTableAlias, targetName, residualFilter)
-			if err != nil {
-				return nil, errors.Wrap(err, "Could not add error to where clause")
-			}
-		} else {
-			wheres, params, err = addExcludeErrorFilterToWhere(wheres, params, dataTableAlias, targetName, residualFilter)
-			if err != nil {
-				return nil, errors.Wrap(err, "Could not add error to where clause")
-			}
+	for _, rf := range filters.residualFilters {
+		wheres, params, err = addIncludeErrorFilterToWhere(wheres, params, dataTableAlias, targetName, rf)
+		if err != nil {
+			return nil, errors.Wrap(err, "Could not add error to where clause")
 		}
 	}
 
 	// Add the error filter into the where clause if it was included in the filter set
-	for _, confidenceFilter := range filters.confidenceFilters.List {
-		if confidenceFilter.Mode == model.IncludeFilter {
-			wheres, params = s.buildConfidenceResultWhere(wheres, params, confidenceFilter, "predicted")
-		} else {
-			wheres, params = addExcludeConfidenceResultToWhere(wheres, params, confidenceFilter)
-		}
+	// note that all special result filters CANNOT be exclusions
+	for _, cf := range filters.confidenceFilters {
+		wheres, params = s.buildConfidenceResultWhere(wheres, params, cf, "predicted")
 	}
-	for _, rankFilter := range filters.rankFilters.List {
-		if rankFilter.Mode == model.IncludeFilter {
-			wheres, params = s.buildRankResultWhere(wheres, params, rankFilter, "predicted")
-		} else {
-			wheres, params = addExcludeRankResultToWhere(wheres, params, rankFilter)
-		}
+	for _, rf := range filters.rankFilters {
+		wheres, params = s.buildRankResultWhere(wheres, params, rf, "predicted")
 	}
 	// If this is a timeseries forecast we don't want to include the target, predicted target or error
 	// info in the returned data.  That information is fetched on a per-timeseries basis using the info

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -108,7 +108,7 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 
 	// if there are no filters, and we are returning the exclude set, we expect
 	// no results in the filtered set
-	if filterParams.Filters.Invert && filterParams.Filters.List == nil {
+	if filterParams.Invert && filterParams.Filters == nil {
 		summary.EmptyFilteredHistogram()
 	}
 

--- a/api/routes/clustering.go
+++ b/api/routes/clustering.go
@@ -211,16 +211,13 @@ func ClusteringExplainHandler(solutionCtor api.SolutionStorageCtor, metaCtor api
 
 		// update the batches
 		// TODO: THIS HAS WAY TOO MUCH KNOWLEDGE OF THE DATABASE BAKED INTO IT
-		filters := &api.FilterParams{
-			Filters: api.FilterObject{List: []*model.Filter{
-				{Key: "result_id",
-					Type:       model.CategoricalFilter,
-					Categories: []string{result.ResultURI},
-					Mode:       model.IncludeFilter,
-				},
+		filters := api.NewFilterParamsFromFilters([]*model.Filter{
+			{Key: "result_id",
+				Type:       model.CategoricalFilter,
+				Categories: []string{result.ResultURI},
+				Mode:       model.IncludeFilter,
 			},
-			},
-		}
+		})
 		err = dataStorage.UpdateData(result.Dataset, fmt.Sprintf("%s_explain", datasetMeta.StorageName), clusterVarName, clusteredData, filters)
 		if err != nil {
 			handleError(w, err)

--- a/api/routes/confidence.go
+++ b/api/routes/confidence.go
@@ -114,7 +114,7 @@ func ConfidenceSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api
 			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
 		}
 		// fetch summary histogram
-		summary, err := data.FetchConfidenceSummary(dataset, storageName, res.ResultURI, filterParams, api.SummaryMode(mode))
+		summary, err := data.FetchConfidenceSummary(dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/correctness_summary.go
+++ b/api/routes/correctness_summary.go
@@ -122,7 +122,7 @@ func CorrectnessSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor ap
 			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
 		}
 		// fetch summary histogram
-		summary, err := data.FetchCorrectnessSummary(dataset, storageName, res.ResultURI, filterParams, api.SummaryMode(mode))
+		summary, err := data.FetchCorrectnessSummary(dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/data.go
+++ b/api/routes/data.go
@@ -83,7 +83,7 @@ func DataHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataStorageCt
 		storageName := ds.StorageName
 
 		// replace any grouped variables in filter params with the group's
-		expandedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, metaStore)
+		expandedFilterParams, err := api.ExpandFilterParams(dataset, api.NewFilterParamsFromRaw(filterParams), false, metaStore)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable to expand filter params"))
 			return

--- a/api/routes/export.go
+++ b/api/routes/export.go
@@ -140,11 +140,11 @@ func ExportResultHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.Data
 			handleError(w, err)
 			return
 		}
-		filterParams := &api.FilterParams{
+		filterParamsRaw := &api.FilterParamsRaw{
 			Size: rowCount,
 		}
-		filterParams.Merge(req.Filters)
-		filterParams, err = api.ExpandFilterParams(dataset, filterParams, false, meta)
+		req.Filters.Merge(filterParamsRaw)
+		filterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/extract.go
+++ b/api/routes/extract.go
@@ -58,7 +58,7 @@ func ExtractHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCt
 			return
 		}
 		// replace any grouped variables in filter params with the group's
-		expandedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, metaStorage)
+		expandedFilterParams, err := api.ExpandFilterParams(dataset, api.NewFilterParamsFromRaw(filterParams), false, metaStorage)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable to expand filter params"))
 			return

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -162,15 +162,12 @@ func getBandMapping(ds *api.Dataset, groupKeys []string, dataStorage api.DataSto
 	}
 
 	filter := &api.FilterParams{}
-	filter.Filters = api.FilterObject{List: []*model.Filter{
-		{
-			Key:        groupingCol.Key,
-			Type:       model.CategoricalFilter,
-			Categories: groupKeys,
-			Mode:       model.IncludeFilter,
-		},
-	},
-	}
+	filter.AddFilter(&model.Filter{
+		Key:        groupingCol.Key,
+		Type:       model.CategoricalFilter,
+		Categories: groupKeys,
+		Mode:       model.IncludeFilter,
+	})
 	filter.Variables = []string{fileCol.Key, bandCol.Key, groupingCol.Key}
 
 	// pull back all rows for a group id

--- a/api/routes/prediction_result_summary.go
+++ b/api/routes/prediction_result_summary.go
@@ -144,7 +144,7 @@ func PredictionResultSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCt
 			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
 		}
 		// fetch summary histogram
-		summary, err := data.FetchPredictedSummary(prediction.Dataset, storageName, res.ResultURI, filterParams, extrema, api.SummaryMode(mode))
+		summary, err := data.FetchPredictedSummary(prediction.Dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), extrema, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/prediction_results.go
+++ b/api/routes/prediction_results.go
@@ -88,11 +88,11 @@ func PredictionResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api
 		}
 
 		// merge provided filterParams with those of the request
-		filterParams.Merge(req.Filters)
+		req.Filters.Merge(filterParams)
 
 		// Expand any grouped variables defined in filters into their subcomponents
 		dataset := predictResult.Dataset
-		updatedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, meta)
+		updatedFilterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/residuals_summary.go
+++ b/api/routes/residuals_summary.go
@@ -99,7 +99,7 @@ func ResidualsSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.
 		}
 
 		// fetch summary histogram
-		summary, err := data.FetchResidualsSummary(dataset, storageName, res.ResultURI, filterParams, extrema, api.SummaryMode(mode))
+		summary, err := data.FetchResidualsSummary(dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), extrema, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/results.go
+++ b/api/routes/results.go
@@ -93,10 +93,10 @@ func ResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.DataStora
 		}
 
 		// merge provided filterParams with those of the request
-		filterParams.Merge(req.Filters)
+		req.Filters.Merge(filterParams)
 
 		// Expand any grouped variables defined in filters into their subcomponents
-		updatedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, meta)
+		updatedFilterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/save_dataset.go
+++ b/api/routes/save_dataset.go
@@ -63,7 +63,7 @@ func SaveDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStora
 			return
 		}
 		// replace any grouped variables in filter params with the group's
-		expandedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, metaStorage)
+		expandedFilterParams, err := api.ExpandFilterParams(dataset, api.NewFilterParamsFromRaw(filterParams), false, metaStorage)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable to expand filter params"))
 			return
@@ -79,13 +79,13 @@ func SaveDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStora
 		}
 
 		// export needs to invert the filters
-		expandedFilterParams.Invert()
+		expandedFilterParams.InvertFilters()
 		_, _, err = task.ExportDataset(dataset, metaStorage, dataStorage, expandedFilterParams)
 		if err != nil {
 			handleError(w, err)
 			return
 		}
-		expandedFilterParams.Invert()
+		expandedFilterParams.InvertFilters()
 
 		// delete rows based on filterParams
 		err = dataStorage.SaveDataset(dataset, ds.StorageName, expandedFilterParams)

--- a/api/routes/solution_result_summary.go
+++ b/api/routes/solution_result_summary.go
@@ -167,7 +167,7 @@ func SolutionResultSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor
 		}
 
 		// fetch summary histogram
-		summary, err := data.FetchPredictedSummary(request.Dataset, storageName, res.ResultURI, filterParams, extrema, api.SummaryMode(mode))
+		summary, err := data.FetchPredictedSummary(request.Dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), extrema, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/target_summary.go
+++ b/api/routes/target_summary.go
@@ -119,7 +119,7 @@ func TargetSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.Sol
 		}
 
 		// fetch summary histogram
-		summary, err := data.FetchSummaryByResult(dataset, storageName, target, result.ResultURI, filterParams, extrema, api.SummaryMode(mode))
+		summary, err := data.FetchSummaryByResult(dataset, storageName, target, result.ResultURI, api.NewFilterParamsFromRaw(filterParams), extrema, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/timeseries.go
+++ b/api/routes/timeseries.go
@@ -48,7 +48,7 @@ func TimeseriesHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.DataSto
 		}
 
 		// get variable names and ranges out of the params
-		var filterParams *model.FilterParams
+		var filterParams *model.FilterParamsRaw
 		if params.FilterParams != nil {
 			filterParams, err = api.ParseFilterParamsFromJSONRaw(params.FilterParams)
 			if err != nil {
@@ -89,7 +89,7 @@ func TimeseriesHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.DataSto
 
 			// fetch timeseries
 			timeseriesData, err := storage.FetchTimeseries(dataset, storageName, t.VarKey, variable.Grouping.GetIDCol(),
-				xColName, yColName, []string{t.SeriesID}, operation, filterParams)
+				xColName, yColName, []string{t.SeriesID}, operation, api.NewFilterParamsFromRaw(filterParams))
 			if err != nil {
 				handleError(w, err)
 				return

--- a/api/routes/timeseries_forecast.go
+++ b/api/routes/timeseries_forecast.go
@@ -59,9 +59,9 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 		}
 
 		// get variable names and ranges out of the params
-		var filterParams *model.FilterParams
+		var filterParamsRaw *model.FilterParamsRaw
 		if params.FilterParams != nil {
-			filterParams, err = api.ParseFilterParamsFromJSONRaw(params.FilterParams)
+			filterParamsRaw, err = api.ParseFilterParamsFromJSONRaw(params.FilterParams)
 			if err != nil {
 				handleError(w, err)
 				return
@@ -125,6 +125,7 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 			}
 
 			// fetch timeseries and forecast
+			filterParams := api.NewFilterParamsFromRaw(filterParamsRaw)
 			timeseriesData, err := data.FetchTimeseries(truthDataset, truthStorageName, t.VarKey, variable.Grouping.GetIDCol(),
 				xColName, yColName, []string{t.SeriesID}, operation, filterParams)
 			if err != nil {

--- a/api/routes/training_summary.go
+++ b/api/routes/training_summary.go
@@ -128,7 +128,7 @@ func TrainingSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.S
 			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
 		}
 		// fetch summary histogram
-		summary, err := data.FetchSummaryByResult(dataset, storageName, variable, result.ResultURI, filterParams, nil, api.SummaryMode(mode))
+		summary, err := data.FetchSummaryByResult(dataset, storageName, variable, result.ResultURI, api.NewFilterParamsFromRaw(filterParams), nil, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/variable_summaries.go
+++ b/api/routes/variable_summaries.go
@@ -102,7 +102,7 @@ func VariableSummaryHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.Da
 		}
 
 		// fetch summary histogram
-		summary, err := storage.FetchSummary(dataset, storageName, variable, filterParams, mode)
+		summary, err := storage.FetchSummary(dataset, storageName, variable, api.NewFilterParamsFromRaw(filterParams), mode)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -400,7 +400,7 @@ func createRGBAFromRamp(xSize int, ySize int, bandImages []*image.Gray16, transf
 	// Create a new RGBA image to hold the collected bands
 	outputImage := image.NewRGBA(image.Rect(0, 0, xSize, ySize))
 
-	rampElements := (len(ramp)-2) / 3
+	rampElements := (len(ramp) - 2) / 3
 
 	// Copy the 16 bit band images into the 8 bit target image.  If a band image couldn't be processed
 	// earlier, we set to grey.

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -294,7 +294,7 @@ func handleQuery(conn *Connection, client *compute.Client, metadataCtor apiModel
 		MetaStorage: metaStorage,
 		Dataset:     req.DatasetID,
 		TargetName:  req.Target,
-		Filters:     req.Filters,
+		Filters:     apiModel.NewFilterParamsFromRaw(req.Filters),
 	}
 	_, err = task.Query(params)
 	if err != nil {


### PR DESCRIPTION
Initial switch to supporting more complicated filtering / highlighting. Only the database was updated to use the new approach. The pipeline filtering and the client were not changed. Since the client was not changed, the server assumes that all exclusive filters are part of the same filter set and all inclusive filters are part of another filter set.

The filters are now composed into filter sets which can be either inclusive or exclusive. Exclusive filter sets represent a subset of data that should be excluded from the dataset. They are processed as inclusive filter sets and then simply inverted (`NOT(equivalent inclusive filter set)`). All filter sets are evaluated and then combined via `AND` operations. Within a filter set, filters acting on the same feature (or result aspect) are combined with `OR` operations and then the clauses for the different features in the filter set are combined using an `AND` operation.

Part of this work also uncovered a lot of issues with query generation, especially with the result querying. Some data would be either ignored or duplicated when highlights were done on the result screen. There were also some issues with the highlighting of result specific fields (correctness, error, etc.) which have now been addressed.

Going forward, extending the filter set approach to pipeline filtering should be fairly straightforward. And if the client is updated to capture the idea that every click of exclude represents one distinct filter set, then it would definitely lead to cleaner code server side since all the translation between the two different structures can be done away with.

Testing was done on the baseball, auto and locust datasets. No testing was done on timeseries, and that part is definitely ripe for issues given the complicated query building that happens there. I felt it more prudent to get these changes in quicker so that we can see if we like the result.