### PR TITLE
Iterate on variables rather than metavars

### DIFF
--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -727,7 +727,7 @@ func (s *SolutionRequest) PersistAndDispatch(client *compute.Client, solutionSto
 		found := false
 
 		// update groupingVariable to the dateTime variable
-		for _, variable := range metaVars {
+		for _, variable := range variables {
 			if variable.Type == model.DateTimeType {
 				groupingVariableIndex = variable.Index
 				found = true


### PR DESCRIPTION
There was an error when using splitting by date in which it failed to find a variable with dateTime as its type to split on when the model went to build.  This seems to be happening because we loop over the metaVars list, and the types don't seem to be appropriately set there.