### PR TITLE
use variable key for result table target ID instead of header  name

### DIFF
--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -351,7 +351,7 @@ func (s *Storage) PersistResult(dataset string, storageName string, resultURI st
 		}
 		indicesParsed[parsedVal] = true
 
-		dataForInsert := []interface{}{resultURI, parsedVal, targetHeaderName, records[i][targetIndex]}
+		dataForInsert := []interface{}{resultURI, parsedVal, targetVariable.Key, records[i][targetIndex]}
 		explainValues, err := s.parseExplainValues(records[i], confidenceIndex, rankIndex)
 		if err != nil {
 			return err


### PR DESCRIPTION
The header name for the target field was being stored in the result table, but it is referenced downstream using the variable key.