### PR TITLE
Fixes height for results table and summaries introduced in new chrome / FF versions

### DIFF
--- a/public/components/ResultsComparison.vue
+++ b/public/components/ResultsComparison.vue
@@ -150,11 +150,11 @@ export default Vue.extend({
   flex-direction: column;
   flex: none;
 }
-.two-slots .results-data-slot {
+.two-slots {
   padding-top: 10px;
   height: 50%;
 }
-.one-slot .results-data-slot {
+.one-slot {
   height: 100%;
 }
 .layer-button {

--- a/public/views/Results.vue
+++ b/public/views/Results.vue
@@ -26,7 +26,7 @@
 
     <div class="row flex-1 pb-3">
       <div
-        class="variable-summaries col-12 col-md-3 border-gray-right results-variable-summaries"
+        class="variable-summaries col-12 col-md-3 border-gray-right results-variable-summaries h-100"
       >
         <p class="nav-link font-weight-bold">Feature Summaries</p>
         <variable-facets


### PR DESCRIPTION
The variable summaries panel on the left and the table view in the middle of the screen were being cut off by the bottom of the screen and not displaying scroll bars with latest version of firefox / chrome on on linux.  This fix may belong elsewhere, but this at least got things running for Richard.