### PR TITLE
Pred group summaries

### DIFF
--- a/public/components/PredictionGroup.vue
+++ b/public/components/PredictionGroup.vue
@@ -1,0 +1,143 @@
+<template>
+  <div class="prediction-group">
+    <component
+      enable-highlighting
+      :summary="predictedSummary"
+      :key="predictedSummary.key"
+      :is="getFacetByType(predictedSummary.type)"
+      :highlights="highlights"
+      :enabled-type-changes="[]"
+      :row-selection="rowSelection"
+      :instanceName="predictionInstanceName"
+      @facet-click="onCategoricalClick"
+      @numerical-click="onNumericalClick"
+      @range-change="onRangeChange"
+    />
+    <component
+      v-if="!!confidenceSummary"
+      enable-highlighting
+      :summary="confidenceSummary"
+      :key="confidenceSummary.key"
+      :is="getFacetByType(confidenceSummary.type)"
+      :highlights="highlights"
+      :enabled-type-changes="[]"
+      :row-selection="rowSelection"
+      :instanceName="confidenceInstanceName"
+      @facet-click="onCategoricalClick"
+      @numerical-click="onNumericalClick"
+      @range-change="onRangeChange"
+    />
+    <component
+      v-if="!!rankingSummary"
+      enable-highlighting
+      :summary="rankingSummary"
+      :key="rankingSummary.key"
+      :is="getFacetByType(rankingSummary.type)"
+      :highlights="highlights"
+      :enabled-type-changes="[]"
+      :row-selection="rowSelection"
+      :instanceName="rankingInstanceName"
+      @facet-click="onCategoricalClick"
+      @numerical-click="onNumericalClick"
+      @range-change="onRangeChange"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import FacetNumerical from "../components/facets/FacetNumerical.vue";
+import FacetCategorical from "../components/facets/FacetCategorical.vue";
+import {
+  VariableSummary,
+  RowSelection,
+  Highlight,
+} from "../store/dataset/index";
+import { getters as routeGetters } from "../store/route/module";
+import { getFacetByType } from "../util/facets";
+
+export default Vue.extend({
+  name: "PredictionGroup",
+  components: {
+    FacetNumerical,
+    FacetCategorical,
+  },
+  props: {
+    confidenceSummary: Object as () => VariableSummary,
+    predictedSummary: Object as () => VariableSummary,
+    rankingSummary: Object as () => VariableSummary,
+    highlights: Array as () => Highlight[],
+  },
+  computed: {
+    rowSelection(): RowSelection {
+      return routeGetters.getDecodedRowSelection(this.$store);
+    },
+    confidenceInstanceName(): string {
+      return `confidence-prediction-facet-${this.predictionDataset}`;
+    },
+    predictionDataset(): string {
+      return routeGetters.getRoutePredictionsDataset(this.$store);
+    },
+    predictionInstanceName(): string {
+      return `prediction-facet-${this.predictionDataset}`;
+    },
+    rankingInstanceName(): string {
+      return `ranking-prediction-facet-${this.predictionDataset}`;
+    },
+  },
+  methods: {
+    getFacetByType(type: string) {
+      return getFacetByType(type);
+    },
+    onCategoricalClick(
+      context: string,
+      key: string,
+      value: string,
+      dataset: string
+    ) {
+      this.$emit("categorical-click", { context, key, value, dataset });
+    },
+
+    onNumericalClick(
+      context: string,
+      key: string,
+      value: { from: number; to: number },
+      dataset: string
+    ) {
+      this.$emit("numerical-click", { context, key, value, dataset });
+    },
+
+    onRangeChange(
+      context: string,
+      key: string,
+      value: { from: { label: string[] }; to: { label: string[] } },
+      dataset: string
+    ) {
+      this.$emit("range-change", { context, key, value, dataset });
+    },
+  },
+});
+</script>
+<style scoped>
+.prediction-group {
+  margin: 5px;
+  padding: 10px;
+  border-bottom-style: solid;
+  border-bottom-color: lightgray;
+  border-bottom-width: 1px;
+}
+
+.prediction-group-title {
+  vertical-align: middle;
+}
+
+.prediction-group-title .badge {
+  display: inline;
+  vertical-align: middle;
+  padding: 0.45em 0.4em 0.3em 0.4em;
+}
+
+.prediction-group-body {
+  padding: 4px 0;
+}
+</style>

--- a/public/components/PredictionSummaries.vue
+++ b/public/components/PredictionSummaries.vue
@@ -18,27 +18,31 @@
 <template>
   <div class="prediction-summaries mh-100">
     <p class="nav-link font-weight-bold">Predictions for Dataset</p>
-    <div v-for="meta in metaSummaries" :key="meta.summary.key">
-      <div :class="active(meta.summary.key)" @click="onClick(meta.summary.key)">
-        <header class="prediction-group-title" :title="meta.summary.dataset">
-          {{ meta.summary.dataset }}
-        </header>
-        <div class="prediction-group-body">
-          <!-- we need the new facets in here-->
-          <prediction-group
-            :confidenceSummary="meta.confidence"
-            :predictedSummary="meta.summary"
-            :rankingSummary="meta.rank"
-            :highlights="highlights"
-            @categorical-click="onCategoricalClick"
-            @numerical-click="onNumericalClick"
-            @range-change="onRangeChange"
-          />
+    <div class="prediction-group-container overflow-auto">
+      <div v-for="meta in metaSummaries" :key="meta.summary.key">
+        <div
+          :class="active(meta.summary.key)"
+          @click="onClick(meta.summary.key)"
+        >
+          <header class="prediction-group-title" :title="meta.summary.dataset">
+            {{ meta.summary.dataset }}
+          </header>
+          <div class="prediction-group-body">
+            <!-- we need the new facets in here-->
+            <prediction-group
+              :confidenceSummary="meta.confidence"
+              :predictedSummary="meta.summary"
+              :rankingSummary="meta.rank"
+              :highlights="highlights"
+              @categorical-click="onCategoricalClick"
+              @numerical-click="onNumericalClick"
+              @range-change="onRangeChange"
+            />
+          </div>
         </div>
       </div>
     </div>
-
-    <b-button v-b-modal.save> Create Dataset </b-button>
+    <b-button v-b-modal.save class="mt-3"> Create Dataset </b-button>
 
     <b-modal id="save" title="Create Dataset" @ok="createDataset">
       <div class="check-message-container d-flex justify-content-around">
@@ -55,7 +59,7 @@
       </div>
     </b-modal>
 
-    <b-button variant="primary" class="float-right mt-2" v-b-modal.export>
+    <b-button variant="primary" class="float-right mt-3" v-b-modal.export>
       Export Predictions
     </b-button>
 
@@ -424,5 +428,8 @@ export default Vue.extend({
   border-width: 1px;
   border-radius: 2px;
   padding-bottom: 10px;
+}
+.prediction-group-container {
+  max-height: 87%;
 }
 </style>

--- a/public/store/predictions/getters.ts
+++ b/public/store/predictions/getters.ts
@@ -78,7 +78,12 @@ export const getters = {
   getPredictionSummaries(state: PredictionState): VariableSummary[] {
     return state.predictedSummaries;
   },
-
+  getConfidenceSummaries(state: PredictionState): VariableSummary[] {
+    return state.confidenceSummaries;
+  },
+  getRankSummaries(state: PredictionState): VariableSummary[] {
+    return state.rankSummaries;
+  },
   getTrainingSummariesDictionary(
     state: PredictionState
   ): Dictionary<Dictionary<VariableSummary>> {

--- a/public/store/predictions/index.ts
+++ b/public/store/predictions/index.ts
@@ -33,6 +33,8 @@ export interface PredictionState {
   targetSummary: VariableSummary;
   // predicted
   predictedSummaries: VariableSummary[];
+  confidenceSummaries: VariableSummary[];
+  rankSummaries: VariableSummary[];
   // forecasts
   timeseries: Dictionary<TimeSeries>;
   forecasts: Dictionary<Forecast>;
@@ -51,6 +53,8 @@ export const state: PredictionState = {
   targetSummary: null,
   // predicted
   predictedSummaries: [],
+  confidenceSummaries: [],
+  rankSummaries: [],
   // forecasts
   timeseries: {},
   forecasts: {},

--- a/public/store/predictions/module.ts
+++ b/public/store/predictions/module.ts
@@ -72,7 +72,8 @@ export const getters = {
   getTrainingSummariesDictionary: read(
     moduleGetters.getTrainingSummariesDictionary
   ),
-
+  getConfidenceSummaries: read(moduleGetters.getConfidenceSummaries),
+  getRankSummaries: read(moduleGetters.getRankSummaries),
   // result table data
   getPredictionDataNumRows: read(moduleGetters.getPredictionDataNumRows),
 
@@ -98,7 +99,8 @@ export const actions = {
   // predicted value summary
   fetchPredictedSummary: dispatch(moduleActions.fetchPredictionSummary),
   fetchPredictedSummaries: dispatch(moduleActions.fetchPredictionSummaries),
-
+  fetchConfidenceSummary: dispatch(moduleActions.fetchConfidenceSummary),
+  fetchRankSummary: dispatch(moduleActions.fetchRankSummary),
   // time series forecast data
   fetchForecastedTimeseries: dispatch(moduleActions.fetchForecastedTimeseries),
   // csv export data
@@ -127,6 +129,8 @@ export const mutations = {
   setBaselinePredictionTableData: commit(
     moduleMutations.setBaselinePredictionTableData
   ),
+  updateConfidenceSummary: commit(moduleMutations.updateConfidenceSummary),
+  updateRankSummary: commit(moduleMutations.updateRankSummary),
   // forecasts
   updatePredictedTimeseries: commit(moduleMutations.updatePredictedTimeseries),
   bulkUpdatePredictedTimeseries: commit(

--- a/public/store/predictions/mutations.ts
+++ b/public/store/predictions/mutations.ts
@@ -60,7 +60,12 @@ export const mutations = {
   updatePredictedSummary(state: PredictionState, summary: VariableSummary) {
     updateSummaries(summary, state.predictedSummaries);
   },
-
+  updateConfidenceSummary(state: PredictionState, summary: VariableSummary) {
+    updateSummaries(summary, state.confidenceSummaries);
+  },
+  updateRankSummary(state: PredictionState, summary: VariableSummary) {
+    updateSummaries(summary, state.rankSummaries);
+  },
   clearPredictedSummary(state: PredictionState) {
     state.predictedSummaries = [];
   },

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -415,7 +415,11 @@ export function updateSummaries(
   summaries: VariableSummary[]
 ) {
   const index = _.findIndex(summaries, (s) => {
-    return s.dataset === summary.dataset && s.key === summary.key;
+    return (
+      s.dataset === summary.dataset &&
+      s.key === summary.key &&
+      s.solutionId === summary.solutionId
+    );
   });
   if (index >= 0) {
     // freezing the return to prevent slow, unnecessary deep reactivity.

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -415,10 +415,12 @@ export function updateSummaries(
   summaries: VariableSummary[]
 ) {
   const index = _.findIndex(summaries, (s) => {
+    const solutionIdAvailable =
+      !s.solutionId || s.solutionId === summary.solutionId;
     return (
       s.dataset === summary.dataset &&
       s.key === summary.key &&
-      s.solutionId === summary.solutionId
+      solutionIdAvailable
     );
   });
   if (index >= 0) {

--- a/public/util/summaries.ts
+++ b/public/util/summaries.ts
@@ -94,7 +94,17 @@ export function getPredictionResultSummary(requestId: string): VariableSummary {
     .getPredictionSummaries(store)
     .find((s) => getIDFromKey(s.key) === requestId);
 }
-
+export function getPredictionConfidenceSummary(
+  requestId: string
+): VariableSummary {
+  const sums = predictionGetters.getConfidenceSummaries(store);
+  return sums.find((s) => s.solutionId === requestId);
+}
+export function getPredictionRankSummary(requestId: string): VariableSummary {
+  return predictionGetters
+    .getRankSummaries(store)
+    .find((s) => s.solutionId === requestId);
+}
 export function getConfidenceSummary(solutionID: string): VariableSummary {
   return resultGetters
     .getConfidenceSummaries(store)


### PR DESCRIPTION
closes #2442
- Added the boilerplate needed for prediction groups on the prediction view
- Altered updateSummaries to require the additional solutionId check for collision
- Added some css for the prediction screen
- Added store support for prediction meta summaries (rank and confidence)
