### PR TITLE
Join Prefeaturized Dataset

### DIFF
--- a/api/compute/filter.go
+++ b/api/compute/filter.go
@@ -213,7 +213,7 @@ func preparePrefilteringDataset(outputFolder string, sourceDataset *api.Dataset,
 	}
 
 	// update it
-	err = dsDisk.UpdateOnDisk(sourceDataset, data)
+	err = dsDisk.UpdateOnDisk(sourceDataset, data, false)
 	if err != nil {
 		return nil, err
 	}

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -63,14 +63,6 @@ type Dataset struct {
 	ParentDataset   string                 `json:"parentDataset"`
 }
 
-// QueriedDataset wraps dataset querying components into a single entity.
-type QueriedDataset struct {
-	Metadata *Dataset
-	Data     *FilteredData
-	Filters  *FilterParams
-	IsTrain  bool
-}
-
 // JoinSuggestion specifies potential joins between datasets.
 type JoinSuggestion struct {
 	BaseDataset   string               `json:"baseDataset"`
@@ -353,25 +345,6 @@ func ParseVariableUpdateList(data map[string]interface{}) ([]*VariableUpdate, er
 	}
 
 	return updatesParsed, nil
-}
-
-// FetchDataset builds a QueriedDataset from the needed parameters.
-func FetchDataset(dataset string, includeIndex bool, includeMeta bool, filterParams *FilterParams, storageMeta MetadataStorage, storageData DataStorage) (*QueriedDataset, error) {
-	metadata, err := storageMeta.FetchDataset(dataset, false, true, false)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := storageData.FetchData(dataset, metadata.StorageName, filterParams, false, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to fetch data")
-	}
-
-	return &QueriedDataset{
-		Metadata: metadata,
-		Data:     data,
-		Filters:  filterParams,
-	}, nil
 }
 
 // GetD3MIndexVariable returns the D3M index variable.

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -106,16 +106,17 @@ func MapVariables(variables []*model.Variable, mapper func(variable *model.Varia
 	return mapped
 }
 
-// LoadDiskDataset loads a dataset from disk.
+// LoadDiskDataset loads a dataset from disk. It will load the learning dataset
+// as the featurized dataset.
 func LoadDiskDataset(ds *Dataset) (*DiskDataset, error) {
 	folder := env.ResolvePath(ds.Source, ds.Folder)
-	output, err := loadDiskDatasetFromFolder(folder)
+	output, err := LoadDiskDatasetFromFolder(folder)
 	if err != nil {
 		return nil, err
 	}
 
 	if ds.LearningDataset != "" {
-		pre, err := loadDiskDatasetFromFolder(ds.LearningDataset)
+		pre, err := LoadDiskDatasetFromFolder(ds.LearningDataset)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +126,8 @@ func LoadDiskDataset(ds *Dataset) (*DiskDataset, error) {
 	return output, nil
 }
 
-func loadDiskDatasetFromFolder(folder string) (*DiskDataset, error) {
+// LoadDiskDatasetFromFolder loads a dataset from disk at the specified location.
+func LoadDiskDatasetFromFolder(folder string) (*DiskDataset, error) {
 	schemaPath := path.Join(folder, compute.D3MDataSchema)
 	dsDisk, err := serialization.ReadDataset(schemaPath)
 	if err != nil {

--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -147,11 +147,11 @@ func UpdateDiskDataset(ds *Dataset, data [][]string) error {
 	if err != nil {
 		return err
 	}
-	return dsDisk.UpdateOnDisk(ds, data)
+	return dsDisk.UpdateOnDisk(ds, data, false)
 }
 
 // UpdateOnDisk updates a disk dataset to have the new and updated data.
-func (d *DiskDataset) UpdateOnDisk(ds *Dataset, data [][]string) error {
+func (d *DiskDataset) UpdateOnDisk(ds *Dataset, data [][]string, updateImmutable bool) error {
 	// use the header row to determine the variables to update
 	varMap := MapVariables(ds.Variables, func(variable *model.Variable) string { return variable.HeaderName })
 	d3mIndexIndex := -1
@@ -165,7 +165,7 @@ func (d *DiskDataset) UpdateOnDisk(ds *Dataset, data [][]string) error {
 
 			// if source var doesnt exist, then no update possible
 			// (prefeaturized datasets have all the featurized values that dont exist outside of the disk version)
-			if sourceVar == nil || sourceVar.Immutable {
+			if sourceVar == nil || (!updateImmutable && sourceVar.Immutable) {
 				continue
 			}
 			headerMap[sourceVar.HeaderName] = i

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -466,6 +466,7 @@ type Column struct {
 	Key    string  `json:"key"`
 	Type   string  `json:"type"`
 	Weight float64 `json:"weight"`
+	Index  int     `json:"index"`
 }
 
 // FilteredDataValue represents a data value combined with an optional weight.
@@ -481,7 +482,7 @@ type FilteredDataValue struct {
 type FilteredData struct {
 	NumRows         int                    `json:"numRows"`
 	NumRowsFiltered int                    `json:"numRowsFiltered"`
-	Columns         []*Column              `json:"columns"`
+	Columns         map[string]*Column     `json:"columns"`
 	Values          [][]*FilteredDataValue `json:"values"`
 }
 
@@ -770,9 +771,9 @@ const (
 func ReplaceNaNs(data *FilteredData, replacementType NaNReplacement) *FilteredData {
 	// go does not marshal NaN values properly so make them empty
 	numericColumns := make([]int, 0)
-	for i, c := range data.Columns {
+	for _, c := range data.Columns {
 		if model.IsNumerical(c.Type) {
-			numericColumns = append(numericColumns, i)
+			numericColumns = append(numericColumns, 0)
 		}
 	}
 

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -773,7 +773,7 @@ func ReplaceNaNs(data *FilteredData, replacementType NaNReplacement) *FilteredDa
 	numericColumns := make([]int, 0)
 	for _, c := range data.Columns {
 		if model.IsNumerical(c.Type) {
-			numericColumns = append(numericColumns, 0)
+			numericColumns = append(numericColumns, c.Index)
 		}
 	}
 

--- a/api/model/model.go
+++ b/api/model/model.go
@@ -188,13 +188,6 @@ func SolutionVariableFromModelVariable(variable *model.Variable, rank float64) *
 	}
 }
 
-// PredictionResult represents the output from a model prediction.
-type PredictionResult struct {
-	*FilteredData
-	FittedSolutionID string `json:"fittedSolutionId"`
-	ProduceRequestID string `json:"produceRequestId"`
-}
-
 // GetPredictedKey returns a solutions predicted col key.
 func GetPredictedKey(solutionID string) string {
 	return solutionID + ":predicted"

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -486,8 +486,15 @@ func (s *Storage) AddVariable(dataset string, storageName string, key string, va
 		if len(defaultVal) > 0 {
 			defaultClause = fmt.Sprintf(" Default '%s'", defaultVal)
 		}
+
+		// geometry is not stored as a text field
+		fieldType := "TEXT"
+		if model.IsGeoBounds(varType) {
+			fieldType = postgres.MapD3MTypeToPostgresType(varType)
+		}
+
 		// add the empty column to the base table and the explain table
-		sql := fmt.Sprintf("ALTER TABLE %s_base ADD COLUMN \"%s\" TEXT%s;", storageName, key, defaultClause)
+		sql := fmt.Sprintf("ALTER TABLE %s_base ADD COLUMN \"%s\" %s%s;", storageName, key, fieldType, defaultClause)
 
 		_, err = s.client.Exec(sql)
 		if err != nil {

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -67,25 +67,27 @@ func (s *Storage) parseFilteredData(dataset string, filterVariables []*model.Var
 		// (timeries variables that use the same grouping column) so we iterate over the filter variable
 		// list to find any that map.
 		fields := rows.FieldDescriptions()
-		columns := []*api.Column{}
+		columns := map[string]*api.Column{}
 		fieldIndexMap := []int{}
 		for _, variable := range filterVariables {
 			// loop through the filter vars and find the key associated with each
 			for fieldIdx, f := range fields {
 				fieldKey := string(f.Name)
 				if variable.IsGrouping() && variable.Grouping.GetIDCol() == fieldKey {
-					columns = append(columns, &api.Column{
+					columns[variable.Key] = &api.Column{
 						Key:   variable.Key,
 						Label: variable.DisplayName,
 						Type:  variable.Type,
-					})
+						Index: len(columns),
+					}
 					fieldIndexMap = append(fieldIndexMap, fieldIdx)
 				} else if fieldKey == variable.Key && (includeGroupingCol || variable.DistilRole != model.VarDistilRoleGrouping) {
-					columns = append(columns, &api.Column{
+					columns[variable.Key] = &api.Column{
 						Key:   variable.Key,
 						Label: variable.DisplayName,
 						Type:  variable.Type,
-					})
+						Index: len(columns),
+					}
 					fieldIndexMap = append(fieldIndexMap, fieldIdx)
 				}
 			}
@@ -120,7 +122,7 @@ func (s *Storage) parseFilteredData(dataset string, filterVariables []*model.Var
 			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	} else {
-		result.Columns = make([]*api.Column, 0)
+		result.Columns = make(map[string]*api.Column, 0)
 	}
 
 	return result, nil

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -122,7 +122,7 @@ func (s *Storage) parseFilteredData(dataset string, filterVariables []*model.Var
 			return nil, errors.Wrapf(err, "error reading data from postgres")
 		}
 	} else {
-		result.Columns = make(map[string]*api.Column, 0)
+		result.Columns = map[string]*api.Column{}
 	}
 
 	return result, nil

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -419,7 +419,7 @@ func (s *Storage) parseFilteredResults(variables []*model.Variable, rows pgx.Row
 		for rows.Next() {
 			if columns == nil {
 				fields = rows.FieldDescriptions()
-				columns = make(map[string]*api.Column, 0)
+				columns = map[string]*api.Column{}
 				for i := 0; i < len(fields); i++ {
 					key := string(fields[i].Name)
 					var label, typ string
@@ -504,7 +504,7 @@ func (s *Storage) parseFilteredResults(variables []*model.Variable, rows pgx.Row
 		}
 		result.Columns = columns
 	} else {
-		result.Columns = make(map[string]*api.Column, 0)
+		result.Columns = map[string]*api.Column{}
 	}
 
 	return result, nil

--- a/api/routes/join.go
+++ b/api/routes/join.go
@@ -108,7 +108,7 @@ func JoinHandler(metaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *ht
 		}
 
 		// marshal output into JSON
-		bytes, err := json.Marshal(map[string]interface{}{"path": path, "data": data})
+		bytes, err := json.Marshal(map[string]interface{}{"path": path, "data": transformDataForClient(data, api.EmptyString)})
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal filtered data result into JSON"))
 			return

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -177,22 +177,21 @@ func getBandMapping(ds *api.Dataset, groupKeys []string, dataStorage api.DataSto
 	}
 
 	// cycle through results to build the band mapping
-	outputColumns := map[string]int{}
-	for i, c := range data.Columns {
-		outputColumns[c.Key] = i
-	}
-	fileColumn, ok := outputColumns[fileCol.Key]
+	fileVariable, ok := data.Columns[fileCol.Key]
 	if !ok {
 		return nil, errors.Errorf("no file column found in stored data")
 	}
-	bandColumn, ok := outputColumns[bandCol.Key]
+	bandVariable, ok := data.Columns[bandCol.Key]
 	if !ok {
 		return nil, errors.Errorf("no band column found in stored data")
 	}
-	groupColumn, ok := outputColumns[groupingCol.Key]
+	groupVariable, ok := data.Columns[groupingCol.Key]
 	if !ok {
 		return nil, errors.Errorf("no group column found in stored data")
 	}
+	fileColumn := fileVariable.Index
+	bandColumn := bandVariable.Index
+	groupColumn := groupVariable.Index
 
 	mapping := map[string]map[string]string{}
 	for _, r := range data.Values {

--- a/api/routes/prediction_results.go
+++ b/api/routes/prediction_results.go
@@ -25,6 +25,13 @@ import (
 	api "github.com/uncharted-distil/distil/api/model"
 )
 
+// PredictionResult represents the output from a model prediction.
+type PredictionResult struct {
+	*FilteredDataClient
+	FittedSolutionID string `json:"fittedSolutionId"`
+	ProduceRequestID string `json:"produceRequestId"`
+}
+
 // PredictionResultsHandler fetches a solution's test prediction, or the output of a prediction run against a fitted model.
 func PredictionResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.DataStorageCtor, metaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -121,12 +128,12 @@ func PredictionResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api
 		}
 
 		// replace any NaN values with an empty string
-		results = api.ReplaceNaNs(results, api.EmptyString)
+		resultsTransformed := transformDataForClient(results, api.EmptyString)
 
-		outputs := &api.PredictionResult{
-			FilteredData:     results,
-			FittedSolutionID: predictResult.FittedSolutionID,
-			ProduceRequestID: predictResult.ProduceRequestID,
+		outputs := &PredictionResult{
+			FilteredDataClient: resultsTransformed,
+			FittedSolutionID:   predictResult.FittedSolutionID,
+			ProduceRequestID:   predictResult.ProduceRequestID,
 		}
 		// marshal data and sent the response back
 		err = handleJSON(w, outputs)

--- a/api/routes/results.go
+++ b/api/routes/results.go
@@ -125,12 +125,12 @@ func ResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.DataStora
 		}
 
 		// replace any NaN values with an empty string
-		results = api.ReplaceNaNs(results, api.EmptyString)
+		resultsTransformed := transformDataForClient(results, api.EmptyString)
 
-		outputs := &api.PredictionResult{
-			FilteredData:     results,
-			FittedSolutionID: res[0].FittedSolutionID,
-			ProduceRequestID: res[0].ProduceRequestID,
+		outputs := &PredictionResult{
+			FilteredDataClient: resultsTransformed,
+			FittedSolutionID:   res[0].FittedSolutionID,
+			ProduceRequestID:   res[0].ProduceRequestID,
 		}
 		// marshal data and sent the response back
 		err = handleJSON(w, outputs)

--- a/api/task/dataset.go
+++ b/api/task/dataset.go
@@ -107,6 +107,22 @@ func CreateDataset(dataset string, datasetCtor DatasetConstructor, outputPath st
 	return dataset, formattedPath, nil
 }
 
+// CopyDiskDataset copies an existing dataset on disk to a new location,
+// updating the ID and the storage name.
+func CopyDiskDataset(existingURI string, newURI string, newDatasetID string, newStorageName string) (*api.DiskDataset, error) {
+	dsDisk, err := api.LoadDiskDatasetFromFolder(existingURI)
+	if err != nil {
+		return nil, err
+	}
+
+	dsDisk, err = dsDisk.Clone(newURI, newDatasetID, newStorageName)
+	if err != nil {
+		return nil, err
+	}
+
+	return dsDisk, nil
+}
+
 // ExportDataset extracts a dataset from the database and metadata storage, writing
 // it to disk in D3M dataset format.
 func ExportDataset(dataset string, metaStorage api.MetadataStorage, dataStorage api.DataStorage, filterParams *api.FilterParams) (string, string, error) {
@@ -335,7 +351,7 @@ func CreateDatasetFromResult(newDatasetName string, predictionDataset string, so
 
 	// if the prediction data is prefeaturized, then update the target variable with the new values
 	if predictionDS.LearningDataset != "" {
-		targetFolder := env.ResolvePath(newDS.Source, createFeaturizedDatasetID(newDatasetName))
+		targetFolder := env.ResolvePath(newDS.Source, CreateFeaturizedDatasetID(newDatasetName))
 		err := util.Copy(predictionDS.GetLearningFolder(), targetFolder)
 		if err != nil {
 			return "", err

--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -38,7 +38,8 @@ func submitForBatch(pip *description.FullySpecifiedPipeline) func(string) (strin
 	}
 }
 
-func createFeaturizedDatasetID(datasetID string) string {
+// CreateFeaturizedDatasetID creates a dataset id for a learning dataset.
+func CreateFeaturizedDatasetID(datasetID string) string {
 	return fmt.Sprintf("%s-featurized", datasetID)
 }
 
@@ -88,7 +89,7 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 	}
 
 	// create the dataset folder
-	featurizedDatasetID := createFeaturizedDatasetID(dataset)
+	featurizedDatasetID := CreateFeaturizedDatasetID(dataset)
 	featurizedDatasetID, err = GetUniqueOutputFolder(featurizedDatasetID, env.GetAugmentedPath())
 	if err != nil {
 		return "", "", err

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -72,6 +72,7 @@ type IngestSteps struct {
 	FallbackMerged          bool
 	CreateMetadataTables    bool
 	CheckMatch              bool
+	SkipFeaturization       bool
 }
 
 // NewDefaultClient creates a new client to use when submitting pipelines.
@@ -262,7 +263,7 @@ func IngestDataset(params *IngestParams, config *IngestTaskConfig, steps *Ingest
 	}
 
 	// featurize dataset for downstream efficiencies
-	if config.FeaturizationEnabled && canFeaturize(params.ID, metaStorage) {
+	if config.FeaturizationEnabled && !steps.SkipFeaturization && canFeaturize(params.ID, metaStorage) {
 		_, featurizedDatasetPath, err := FeaturizeDataset(originalSchemaFile, latestSchemaOutput, params.ID, metaStorage, config)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to featurize dataset")

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -255,7 +255,7 @@ func IngestDataset(params *IngestParams, config *IngestTaskConfig, steps *Ingest
 	// set the known grouping information
 	if params.RawGroupings != nil {
 		log.Infof("creating groupings in metadata")
-		err = SetGroups(datasetID, params.RawGroupings, metaStorage, config)
+		err = SetGroups(datasetID, params.RawGroupings, dataStorage, metaStorage, config)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to set grouping")
 		}

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -169,13 +169,14 @@ func createFilteredData(csvFile string, variables []*model.Variable, lineCount i
 
 	data := &apiModel.FilteredData{}
 
-	data.Columns = []*apiModel.Column{}
+	data.Columns = map[string]*apiModel.Column{}
 	for _, variable := range variables {
-		data.Columns = append(data.Columns, &apiModel.Column{
+		data.Columns[variable.Key] = &apiModel.Column{
 			Label: variable.DisplayName,
 			Key:   variable.Key,
 			Type:  variable.Type,
-		})
+			Index: len(data.Columns),
+		}
 	}
 
 	data.Values = [][]*apiModel.FilteredDataValue{}

--- a/api/task/join_test.go
+++ b/api/task/join_test.go
@@ -150,24 +150,32 @@ func TestJoin(t *testing.T) {
 		assert.ElementsMatch(t, records[i], expected[i])
 	}
 
-	assert.ElementsMatch(t, result.Columns, []*apiModel.Column{
+	actualColumns := []*apiModel.Column{
+		result.Columns["d3mIndex"],
+		result.Columns["alpha"],
+		result.Columns["charlie"],
+	}
+	assert.ElementsMatch(t, actualColumns, []*apiModel.Column{
 		{
 			Label:  "D3M Index",
 			Key:    "d3mIndex",
 			Type:   model.IntegerType,
 			Weight: float64(0),
+			Index:  0,
 		},
 		{
 			Label:  "Alpha",
 			Key:    "alpha",
 			Type:   model.RealType,
 			Weight: float64(0),
+			Index:  1,
 		},
 		{
 			Label:  "Charlie",
 			Key:    "charlie",
 			Type:   model.CategoricalType,
 			Weight: float64(0),
+			Index:  2,
 		},
 	})
 

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -695,22 +695,14 @@ func CreateComposedVariable(metaStorage api.MetadataStorage, dataStorage api.Dat
 
 	// Create a map of the retreived fields to column number.  Store d3mIndex since it needs to be directly referenced
 	// further along.
-	d3mIndexFieldindex := -1
-	colNameToIdx := make(map[string]int)
-	for i, c := range rawData.Columns {
-		if c.Label == model.D3MIndexFieldName {
-			d3mIndexFieldindex = i
-		} else {
-			colNameToIdx[c.Label] = i
-		}
-	}
+	d3mIndexFieldindex := rawData.Columns[model.D3MIndexFieldName].Index
 
 	if len(sourceVarNames) > 0 {
 		// Loop over the fetched data, composing each column value into a single new column value using the
 		// separator.
 		for _, r := range rawData.Values {
 			// create the hash from the specified columns
-			composed := createComposedFields(r, sourceVarNames, colNameToIdx, DefaultSeparator)
+			composed := createComposedFields(r, sourceVarNames, rawData.Columns, DefaultSeparator)
 			composedData[fmt.Sprintf("%v", r[d3mIndexFieldindex].Value)] = composed
 		}
 	} else {
@@ -729,10 +721,10 @@ func CreateComposedVariable(metaStorage api.MetadataStorage, dataStorage api.Dat
 	return nil
 }
 
-func createComposedFields(data []*api.FilteredDataValue, fields []string, mappedFields map[string]int, separator string) string {
+func createComposedFields(data []*api.FilteredDataValue, fields []string, mappedFields map[string]*api.Column, separator string) string {
 	dataToJoin := make([]string, len(fields))
 	for i, field := range fields {
-		dataToJoin[i] = fmt.Sprintf("%v", data[mappedFields[field]].Value)
+		dataToJoin[i] = fmt.Sprintf("%v", data[mappedFields[field].Index].Value)
 	}
 	return strings.Join(dataToJoin, separator)
 }

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -509,6 +509,16 @@ func SplitMultiBandImage(dataset gdal.Dataset, outputFolder string, bandMapping 
 	return files, nil
 }
 
+// CreatePolygonFromCoordinates creates a string that captures the polygon defined
+// by the coordinates.
+func CreatePolygonFromCoordinates(coordinates []float64) string {
+	geometryString := ""
+	for i := 0; i < len(coordinates); i += 2 {
+		geometryString = fmt.Sprintf("%s,%f %f", geometryString, coordinates[i], coordinates[i+1])
+	}
+	return fmt.Sprintf("POLYGON((%s))", geometryString[1:])
+}
+
 func lerp(v0 float64, v1 float64, t float64) float64 {
 	return (1.0-t)*v0 + t*v1
 }

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -512,6 +512,11 @@ func SplitMultiBandImage(dataset gdal.Dataset, outputFolder string, bandMapping 
 // CreatePolygonFromCoordinates creates a string that captures the polygon defined
 // by the coordinates.
 func CreatePolygonFromCoordinates(coordinates []float64) string {
+	// polygon must be closed, so if it isnt, then add the first point at the end to close it
+	if coordinates[0] != coordinates[len(coordinates)-2] || coordinates[1] != coordinates[len(coordinates)-1] {
+		coordinates = append(coordinates, coordinates[0], coordinates[1])
+	}
+
 	geometryString := ""
 	for i := 0; i < len(coordinates); i += 2 {
 		geometryString = fmt.Sprintf("%s,%f %f", geometryString, coordinates[i], coordinates[i+1])


### PR DESCRIPTION
Added handling of prefeaturized datasets. Rather than rely on a second featurization step, the joined columns are added to the prefeaturized dataset. Only one of the two datasets can be prefeaturized.

Note that currently, the resulting prefeaturized dataset will use the prefeaturized dataset as starting point, it will only contain rows that are in the already prefeaturized dataset. If we want to consider rows that are in the other dataset used in the join, then changes need to be made. Given that the other dataset is not prefeaturized, the extra rows can easily be appended to the prefeaturized dataset.

As part of this effort, some other changes were made to existing code. The queried dataset concept was removed. It seems it was never used. Filtered dataset columns were changed to a map (using field keys as lookup key) to simplify usage. Consequently, a new struct was created to mimic the client structure and routes translate to that structure for results. A new check is done when creating groups on ingest. Geobounds groups now confirm that the geometry field exists, and if it does not then it gets created.