### PR TITLE
Import Empty Column Name

### DIFF
--- a/api/dataset/table.go
+++ b/api/dataset/table.go
@@ -18,6 +18,7 @@ package dataset
 import (
 	"bytes"
 	"encoding/csv"
+	"fmt"
 	"path"
 	"strings"
 	"unicode"
@@ -77,6 +78,7 @@ func (t *Table) CreateDataset(rootDataPath string, datasetName string, config *e
 	if t.flagIndex {
 		header := t.CSVData[0]
 		for i, c := range header {
+			c = strings.TrimSpace(c)
 			if c == model.D3MIndexFieldName {
 				d3mIndexVar := model.NewVariable(i, model.D3MIndexFieldName, model.D3MIndexFieldName,
 					model.D3MIndexFieldName, model.D3MIndexFieldName, model.IntegerType, model.IntegerType, "D3M index",
@@ -84,6 +86,14 @@ func (t *Table) CreateDataset(rootDataPath string, datasetName string, config *e
 				dr.Variables = []*model.Variable{d3mIndexVar}
 				dr.ResType = model.ResTypeTable
 			}
+
+			// default the field name in the header if empty
+			if c == "" {
+				c = fmt.Sprintf("column_%d", i)
+			}
+
+			// set the header values
+			t.CSVData[0][i] = c
 		}
 	}
 


### PR DESCRIPTION
Fixes #2243 

On import, tabular datasets will have default column names if the column names are empty. For example, a dataset with the header row of `a,b,,d` will have the updated header row of `a,b,column_2,d`.