### PR TITLE
Remove Ingest Clustering

### DIFF
--- a/api/env/config.go
+++ b/api/env/config.go
@@ -33,9 +33,8 @@ type Config struct {
 	BatchSubFolder             string  `env:"BATCH_SUBFOLDER" envDefault:"batch"`
 	ClassificationOutputPath   string  `env:"CLASSIFICATION_OUTPUT_PATH" envDefault:"classification.json"`
 	ClassificationEnabled      bool    `env:"CLASSIFICATION_ENABLED" envDefault:"true"`
-	ClusteringEnabled          bool    `env:"CLUSTERING_ENABLED" envDefault:"true"` // This clustering is used during ingest
 	ClusteringKMeans           bool    `env:"CLUSTERING_KMEANS" envDefault:"true"`
-	ClusteringRouteEnabled     bool    `env:"CLUSTERING_ROUTE_ENABLED" envDefault:"true"` // This disables select view clustering see routes/clustering.go
+	ClusteringEnabled          bool    `env:"CLUSTERING_ENABLED" envDefault:"true"` // This disables select view clustering see routes/clustering.go
 	D3MInputDir                string  `env:"D3MINPUTDIR" envDefault:"datasets"`
 	D3MOutputDir               string  `env:"D3MOUTPUTDIR" envDefault:"outputs"`
 	DatamartURIISI             string  `env:"DATAMART_ISI_URL" envDefault:"https://dsbox02.isi.edu:9000"`

--- a/api/routes/clustering.go
+++ b/api/routes/clustering.go
@@ -40,7 +40,7 @@ type ClusteringResult struct {
 func ClusteringHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCtor, config env.Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// check if route is enabled
-		if !config.ClusteringRouteEnabled {
+		if !config.ClusteringEnabled {
 			// return empty result
 			err := handleJSON(w, empty.Empty{})
 			if err != nil {

--- a/api/task/cluster.go
+++ b/api/task/cluster.go
@@ -28,10 +28,6 @@ import (
 	api "github.com/uncharted-distil/distil/api/model"
 )
 
-const (
-	slothResultFieldName = "cluster_labels"
-)
-
 // ClusterPoint contains data that has been clustered.
 type ClusterPoint struct {
 	D3MIndex    string

--- a/api/task/explain.go
+++ b/api/task/explain.go
@@ -134,7 +134,7 @@ func ClusterExplainOutput(variable string, resultURI string, explainURI string, 
 		LearningDataset: meta.LearningDataset,
 	}
 
-	addMeta, clustered, err := Cluster(dsCreated, variable, true)
+	addMeta, clustered, err := Cluster(dsCreated, variable, config.ClusteringKMeans)
 	if err != nil {
 		return false, nil, err
 	}

--- a/api/task/format.go
+++ b/api/task/format.go
@@ -115,10 +115,8 @@ func addD3MIndex(schemaFile string, meta *model.Metadata, data [][]string) (*mod
 func checkD3MIndexExists(meta *model.Metadata) bool {
 	// check all variables for a d3m index
 	for _, dr := range meta.DataResources {
-		for _, v := range dr.Variables {
-			if v.Key == model.D3MIndexFieldName {
-				return true
-			}
+		if getD3MIndexField(dr) >= 0 {
+			return true
 		}
 	}
 

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -42,8 +42,6 @@ const (
 type IngestTaskConfig struct {
 	DatasetBatchSize                 int
 	HasHeader                        bool
-	ClusteringEnabled                bool
-	ClusteringKMeans                 bool
 	FeaturizationEnabled             bool
 	GeocodingEnabled                 bool
 	ClassificationOutputPathRelative string
@@ -93,8 +91,6 @@ func NewConfig(config env.Config) *IngestTaskConfig {
 	return &IngestTaskConfig{
 		DatasetBatchSize:                 config.DatasetBatchSize,
 		HasHeader:                        true,
-		ClusteringEnabled:                config.ClusteringEnabled,
-		ClusteringKMeans:                 config.ClusteringKMeans,
 		FeaturizationEnabled:             config.FeaturizationEnabled,
 		GeocodingEnabled:                 config.GeocodingEnabled,
 		ClassificationOutputPathRelative: config.ClassificationOutputPath,
@@ -161,21 +157,7 @@ func IngestDataset(params *IngestParams, config *IngestTaskConfig, steps *Ingest
 	originalSchemaFile := params.getSchemaDocPath()
 	latestSchemaOutput := originalSchemaFile
 
-	var output string
-	if config.ClusteringEnabled {
-		output, err = ClusterDataset(latestSchemaOutput, params.ID, config)
-		if err != nil {
-			if config.HardFail {
-				return nil, errors.Wrap(err, "unable to cluster all data")
-			}
-			log.Errorf("unable to cluster all data: %v", err)
-		} else {
-			latestSchemaOutput = output
-		}
-		log.Infof("finished clustering the dataset")
-	}
-
-	output, err = Merge(latestSchemaOutput, params.ID, config)
+	output, err := Merge(latestSchemaOutput, params.ID, config)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to merge all data into a single file")
 	}

--- a/run.sh
+++ b/run.sh
@@ -13,10 +13,10 @@ if [[ -z "${DATAMART_IMPORT_FOLDER}" ]]; then
 fi
 
 # Docker host IP for the services started by ./run_services.sh
-if [[ -z ${DOCKER_HOST} ]]; then 
+if [[ -z ${DOCKER_HOST} ]]; then
   export SOLUTION_COMPUTE_ENDPOINT=localhost:45042
   export ES_ENDPOINT=http://localhost:9200
-else 
+else
   export SOLUTION_COMPUTE_ENDPOINT="${DOCKER_HOST}:45042"
   export ES_ENDPOINT="http://${DOCKER_HOST}:9200"
   export PG_HOST="${DOCKER_HOST}"
@@ -28,7 +28,6 @@ export SOLUTION_SEARCH_MAX_TIME=30000
 export SOLUTION_COMPUTE_PULL_MAX=900000
 export SOLUTION_COMPUTE_PULL_TIMEOUT=60000
 export DATAMART_URL_NYU=https://auctus.vida-nyu.org
-export CLUSTERING_ENABLED=false # no image clustering on ingest
 export SUMMARY_ENABLED=false # no duke summarization on ingest
 export FEATURIZATION_ENABLED=true # featurize remote sensing imagery on ingest
 export CLUSTERING_KMEANS=true # 'true' if kmeans should be used for clustering 'false' if we should use hdbscan


### PR DESCRIPTION
Fixes #2501 

Ingest clustering has been removed since it is really superfluous given the clustering done on target selection. It was very limited (timeseries & images possibly), and was only really done for preingest since datasets ingested within distil would need additional information from the user to be candidates for clustering (ex: user has to specify the parts of the timeseries).

The related config flag was removed. The flag determining if route clustering should be run was renamed to the simplified `CLUSTERING_ENABLED` since there was no longer any ambiguity.

In removing ingest clustering, a bunch of other functions were no longer used so they also fell victim to the ax.