### PR TITLE
Variables Endpoint

### DIFF
--- a/api/routes/solutions.go
+++ b/api/routes/solutions.go
@@ -172,12 +172,12 @@ func SolutionHandler(solutionCtor api.SolutionStorageCtor, metadataCtor api.Meta
 
 		solutionResponse := SolutionResponse{
 			// request
-			RequestID: req.RequestID,
-			Dataset:   req.Dataset,
-			Feature:   req.TargetFeature(),
-			Features:  req.Features,
+			RequestID:    req.RequestID,
+			Dataset:      req.Dataset,
+			Feature:      req.TargetFeature(),
+			Features:     req.Features,
 			FeatureLabel: varMap[req.TargetFeature()].DisplayName,
-			Filters:   req.Filters,
+			Filters:      req.Filters,
 			// solution
 			SolutionID:       sol.SolutionID,
 			Scores:           sol.Scores,

--- a/api/routes/variables.go
+++ b/api/routes/variables.go
@@ -69,8 +69,11 @@ func VariablesHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorage
 					log.Warnf("defaulting extrema values due to error fetching extrema for '%s': %+v", v.Key, err)
 					extrema = getDefaultExtrema(v)
 				}
-				v.Min = extrema.Min
-				v.Max = extrema.Max
+				if extrema != nil {
+					// some times the extrema does not exist (ex: the target in a prediction dataset)
+					v.Min = extrema.Min
+					v.Max = extrema.Max
+				}
 			}
 		}
 		// marshal data


### PR DESCRIPTION
Fixes #2509 

Added a quick nil check when getting the variable extremas. Prediction target variables can be empty and as such can return an empty extrema.