### PR TITLE
Fix for join-view target

### DIFF
--- a/public/components/JoinDatasetsForm.vue
+++ b/public/components/JoinDatasetsForm.vue
@@ -149,7 +149,7 @@ export default Vue.extend({
       return datasetGetters.getDatasets(this.$store);
     },
     target(): string {
-      return routeGetters.getRouteTargetVariable(this.$store);
+      return routeGetters.getRoutePreviousTarget(this.$store);
     },
     returnPath(): string {
       return routeGetters.getPriorPath(this.$store);

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -292,6 +292,9 @@ export const getters = {
     pages[RESULTS_ROUTE] = [getters.getRouteResultTrainingVarsPage];
     return pages;
   },
+  getRoutePreviousTarget(state: Route): string {
+    return (state.query.previousTarget as string) ?? "";
+  },
   getRouteTopVarsSearch(state: Route): string {
     const searchVar = TOP_VARS_INSTANCE_SEARCH;
     return state.query[searchVar] ? _.toString(state.query[searchVar]) : "";

--- a/public/store/route/module.ts
+++ b/public/store/route/module.ts
@@ -98,6 +98,7 @@ export const getters = {
   getAllSearchesByQueryString: read(moduleGetters.getAllSearchesByQueryString),
   getRouteDataSize: read(moduleGetters.getRouteDataSize),
   getRouteTargetVariable: read(moduleGetters.getRouteTargetVariable),
+  getRoutePreviousTarget: read(moduleGetters.getRoutePreviousTarget),
   getRouteSolutionId: read(moduleGetters.getRouteSolutionId),
   getRouteFilters: read(moduleGetters.getRouteFilters),
   getRouteHighlight: read(moduleGetters.getRouteHighlight),

--- a/public/util/join.ts
+++ b/public/util/join.ts
@@ -56,6 +56,7 @@ export function loadJoinView(
   const entry = createRouteEntry(JOIN_DATASETS_ROUTE, {
     joinDatasets: datasetA + "," + datasetB,
     priorRoute: sourceRoute,
+    previousTarget: routeGetters.getRouteTargetVariable(store),
   });
   router.push(entry).catch((err) => console.warn(err));
 }

--- a/public/util/routes.ts
+++ b/public/util/routes.ts
@@ -61,6 +61,7 @@ export interface RouteArgs {
   varRanked?: string;
   produceRequestId?: string;
   fittedSolutionId?: string;
+  previousTarget?: string;
   singleSolution?: string;
   colorScale?: ColorScaleNames;
   predictionsDataset?: string;


### PR DESCRIPTION
- Previously the target of the prior route was kept in the url for back tracking at the end of the join
- This would cause components to fetch the target and pass it to the backend
- This would cause panics on the ta3
- It was removed and previousTarget is used instead