### PR TITLE
Left Outer Join

### DIFF
--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -425,9 +425,12 @@ func UpdateExtremas(dataset string, varName string, storageMeta MetadataStorage,
 		}
 
 		// store the extrema to ES
-		err = storageMeta.SetExtrema(dataset, varName, extrema)
-		if err != nil {
-			return err
+		// empty columns will have a nil extrema (potential bad join or some other empty column)
+		if extrema != nil {
+			err = storageMeta.SetExtrema(dataset, varName, extrema)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210423114313-af65c6e7ef7c
+	github.com/uncharted-distil/distil-compute v0.0.0-20210423153809-daca011354e6
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210415141229-9c7897aa21e9
+	github.com/uncharted-distil/distil-compute v0.0.0-20210423114313-af65c6e7ef7c
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210423114313-af65c6e7ef7c h1:J0TpG1Tl2itEUbi6D3jq57hF6h4HqD4IntIo9UR1JzA=
-github.com/uncharted-distil/distil-compute v0.0.0-20210423114313-af65c6e7ef7c/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210423153809-daca011354e6 h1:96hmcfmEg6dNJY+f/2u6CowMopfSawWrMho/SxM4DNU=
+github.com/uncharted-distil/distil-compute v0.0.0-20210423153809-daca011354e6/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210415141229-9c7897aa21e9 h1:9HrTRp4asIlci5+KNT2WoV4bKDh1IuH5FjGQi2tYyac=
-github.com/uncharted-distil/distil-compute v0.0.0-20210415141229-9c7897aa21e9/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210423114313-af65c6e7ef7c h1:J0TpG1Tl2itEUbi6D3jq57hF6h4HqD4IntIo9UR1JzA=
+github.com/uncharted-distil/distil-compute v0.0.0-20210423114313-af65c6e7ef7c/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=


### PR DESCRIPTION
Fixed an issue with the extrema update on ingest where empty columns could lead to crashes. Updated to latest compute which sets the join type explicitly in the pipeline rather than rely on defaults.