### PR TITLE
Swap Join Datasets

### DIFF
--- a/public/util/join.ts
+++ b/public/util/join.ts
@@ -22,7 +22,7 @@ import { JOIN_DATASETS_ROUTE } from "../store/route/index";
 import { getters as routeGetters } from "../store/route/module";
 import store from "../store/store";
 import { addRecentDataset, minimumRouteKey } from "./data";
-import { createRouteEntry } from "./routes";
+import { createRouteEntry, overlayRouteEntry } from "./routes";
 
 export function loadJoinedDataset(
   router: VueRouter,
@@ -57,6 +57,29 @@ export function loadJoinView(
     joinDatasets: datasetA + "," + datasetB,
     priorRoute: sourceRoute,
     previousTarget: routeGetters.getRouteTargetVariable(store),
+  });
+  router.push(entry).catch((err) => console.warn(err));
+}
+
+export function swapJoinView(router: VueRouter) {
+  const joinedDataset = routeGetters.getRouteJoinDatasets(store);
+  // swap the datasets themselves
+  const tmp = joinedDataset[1];
+  joinedDataset[1] = joinedDataset[0];
+  joinedDataset[0] = tmp;
+
+  const joinPairs = routeGetters.getJoinPairs(store);
+  const entry = overlayRouteEntry(routeGetters.getRoute(store), {
+    joinPairs: [
+      ...joinPairs.map((jp) => {
+        // swap the join pairs
+        const first = jp.first;
+        jp.first = jp.second;
+        jp.second = first;
+        return JSON.stringify(jp);
+      }),
+    ],
+    joinDatasets: joinedDataset.join(),
   });
   router.push(entry).catch((err) => console.warn(err));
 }

--- a/public/views/JoinDatasets.vue
+++ b/public/views/JoinDatasets.vue
@@ -83,6 +83,11 @@
           />
         </div>
         <div class="row pb-5">
+          <div class="col-12 d-flex flex-column align-items-center">
+            <b-button variant="primary" @click="swapDatasets">
+              Swap Datasets
+            </b-button>
+          </div>
           <div
             class="join-accuracy-slider col-12 d-flex flex-column align-items-center"
           >
@@ -143,7 +148,7 @@ import { TOP_VARS_INSTANCE, BOTTOM_VARS_INSTANCE } from "../store/route/index";
 import { actions as viewActions } from "../store/view/module";
 import { getters as routeGetters } from "../store/route/module";
 import { getters as datasetGetters } from "../store/dataset/module";
-import { getVariableSummaries } from "../util/join";
+import { getVariableSummaries, swapJoinView } from "../util/join";
 
 export default Vue.extend({
   name: "join-datasets",
@@ -402,6 +407,11 @@ export default Vue.extend({
         joinAccuracy: value.toString(),
       });
       this.$router.push(entry).catch((err) => console.warn(err));
+    },
+    swapDatasets() {
+      if (this.joinDatasets.length >= 2) {
+        swapJoinView(this.$router);
+      }
     },
   },
 });


### PR DESCRIPTION
Join now performs a left outer join rather than an inner join. Consequently, dataset order matters, with the top dataset mapping to the left dataset in the join. Since the user may not necessarily navigate to the join screen via the intended dataset, adding the swap ability lets the user select the correct dataset as top dataset.

Ideally, the Swap button would probably be some type of icon on the side or somehow not using more vertical space. That should be ironed out once we know exactly what we want to do.