### PR TITLE
Delete All Datasets

### DIFF
--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -61,6 +61,7 @@ type Dataset struct {
 	Clone           bool                   `json:"clone"`
 	Immutable       bool                   `json:"immutable"`
 	ParentDataset   string                 `json:"parentDataset"`
+	Deleted         bool                   `json:"deleted"`
 }
 
 // JoinSuggestion specifies potential joins between datasets.

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -195,7 +195,7 @@ type MetadataStorage interface {
 	DeleteVariable(dataset string, varName string) error
 	AddGroupedVariable(dataset string, varName string, varDisplayName string, varType string, varRole string, grouping model.BaseGrouping) error
 	RemoveGroupedVariable(datasetName string, grouping model.BaseGrouping) error
-	DeleteDataset(dataset string) error
+	DeleteDataset(dataset string, softDelete bool) error
 	IngestDataset(datasetSource metadata.DatasetSource, meta *model.Metadata) error
 	UpdateDataset(dataset *Dataset) error
 

--- a/api/model/storage/datamart/dataset.go
+++ b/api/model/storage/datamart/dataset.go
@@ -74,7 +74,7 @@ func (s *Storage) FetchDatasets(includeIndex bool, includeMeta bool, includeSyst
 }
 
 // DeleteDataset deletes a dataset from the datamart.
-func (s *Storage) DeleteDataset(dataset string) error {
+func (s *Storage) DeleteDataset(dataset string, softDelete bool) error {
 	return errors.Errorf("Not implemented")
 }
 

--- a/api/model/storage/file/dataset.go
+++ b/api/model/storage/file/dataset.go
@@ -55,7 +55,7 @@ func (s *Storage) UpdateDataset(dataset *api.Dataset) error {
 }
 
 // DeleteDataset deletes a dataset from the file system.
-func (s *Storage) DeleteDataset(dataset string) error {
+func (s *Storage) DeleteDataset(dataset string, softDelete bool) error {
 	return errors.Errorf("Not implemented")
 }
 

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -647,7 +647,7 @@ func matchDataset(storage api.MetadataStorage, meta *model.Metadata) (string, er
 func deleteDataset(name string, pg *postgres.Database, meta api.MetadataStorage) error {
 	success := false
 	for i := 0; i < 10 && !success; i++ {
-		err := meta.DeleteDataset(name)
+		err := meta.DeleteDataset(name, false)
 		if err != nil {
 			log.Error(err)
 		} else {

--- a/api/task/query.go
+++ b/api/task/query.go
@@ -139,7 +139,7 @@ func convertResultToRanking(results *[][]string) error {
 
 // DeleteQueryCache deletes the query cache folder if it exists.
 func DeleteQueryCache(datasetID string) {
-	log.Infof("removing %s", datasetID)
+	log.Infof("removing %s from query cache", datasetID)
 	cachePath := getQueryCachePath(datasetID)
 	if err := os.RemoveAll(cachePath); err != nil {
 		log.Warnf("failed to remove query cache - %s", err)

--- a/public/components/DatasetPreview.vue
+++ b/public/components/DatasetPreview.vue
@@ -37,7 +37,7 @@
       <a class="nav-link"><b>Rows</b> {{ dataset.numRows }}</a>
       <a class="nav-link"><b>Size</b> {{ formatBytes(dataset.numBytes) }}</a>
       <b-button
-        v-if="!dataset.immutable && !isImportReady"
+        v-if="!isImportReady"
         variant="danger"
         data-toggle="tooltip"
         title="Delete dataset"


### PR DESCRIPTION
Any dataset can now be deleted. Immutable datasets will be soft deleted, with the deleted flag in ES being flipped to true. Any soft deleted dataset will no longer be returned by ES.

There is a chance this causes a problem when a dataset is deleted but is also a parent dataset. The system may require that parent datasets exist to function properly (ie if the same model gets run again, or to update the labelling). A dataset will be a parent dataset of any inference dataset, or any derived dataset for user labelling purposes. If it does become an issue, we can handle it then.