### PR TITLE
Filter by set

### DIFF
--- a/api/compute/featurize.go
+++ b/api/compute/featurize.go
@@ -52,7 +52,7 @@ func (s *SolutionRequest) createPreFeaturizedPipeline(learningDataset string,
 	name := fmt.Sprintf("prefeaturized-%s-%s-%s", s.Dataset, learningDataset, uuid.String())
 	desc := fmt.Sprintf("Prefeaturized pipeline capturing user feature selection and type information. Dataset: `%s` ID: `%s`", s.Dataset, uuid.String())
 
-	expandedFilters, err := api.ExpandFilterParams(s.Dataset, api.NewFilterParamsFromRaw(s.Filters), true, metaStorage)
+	expandedFilters, err := api.ExpandFilterParams(s.Dataset, s.Filters, true, metaStorage)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (s *SolutionRequest) createPreFeaturizedPipeline(learningDataset string,
 			AllFeatures:      featurizedVariables,
 			TargetFeature:    featurizedVariables[targetIndex],
 			SelectedFeatures: expandedFilters.Variables,
-			Filters:          s.Filters.Filters.List,
+			Filters:          s.Filters.Filters,
 		}, nil)
 	if err != nil {
 		return nil, err

--- a/api/compute/filter.go
+++ b/api/compute/filter.go
@@ -32,7 +32,7 @@ import (
 	"github.com/uncharted-distil/distil/api/util"
 )
 
-func filterData(client *compute.Client, ds *api.Dataset, filterParams *api.FilterParamsRaw, dataStorage api.DataStorage) (string, *api.FilterParamsRaw, error) {
+func filterData(client *compute.Client, ds *api.Dataset, filterParams *api.FilterParams, dataStorage api.DataStorage) (string, *api.FilterParams, error) {
 	inputPath := ds.GetLearningFolder()
 
 	log.Infof("checking if solution search for dataset %s found in '%s' needs prefiltering", ds.ID, inputPath)
@@ -65,7 +65,7 @@ func filterData(client *compute.Client, ds *api.Dataset, filterParams *api.Filte
 	}
 
 	// run the filtering pipeline
-	pipeline, err := description.CreateDataFilterPipeline("Pre Filtering", "pre filter a dataset that has metadata features", resultingVariables, preFilters.Filters.List)
+	pipeline, err := description.CreateDataFilterPipeline("Pre Filtering", "pre filter a dataset that has metadata features", resultingVariables, preFilters.Filters)
 	if err != nil {
 		return "", nil, err
 	}
@@ -99,16 +99,20 @@ func filterData(client *compute.Client, ds *api.Dataset, filterParams *api.Filte
 	return outputFolder, updatedParams, nil
 }
 
-func mapFilterKeys(dataset string, filters *api.FilterParamsRaw, variables []*model.Variable) *api.FilterParamsRaw {
+func mapFilterKeys(dataset string, filters *api.FilterParams, variables []*model.Variable) *api.FilterParams {
 	filtersUpdated := filters.Clone()
 
 	varsMapped := api.MapVariables(variables, func(variable *model.Variable) string { return variable.Key })
-	for _, f := range filtersUpdated.Filters.List {
-		variable := varsMapped[f.Key]
-		if variable.Key == f.Key && variable.IsGrouping() {
-			if _, ok := variable.Grouping.(*model.GeoBoundsGrouping); ok {
-				grouping := variable.Grouping.(*model.GeoBoundsGrouping)
-				f.Key = grouping.CoordinatesCol
+	for _, fs := range filtersUpdated.Filters {
+		for _, ff := range fs.FeatureFilters {
+			for _, f := range ff.List {
+				variable := varsMapped[f.Key]
+				if variable.Key == f.Key && variable.IsGrouping() {
+					if _, ok := variable.Grouping.(*model.GeoBoundsGrouping); ok {
+						grouping := variable.Grouping.(*model.GeoBoundsGrouping)
+						f.Key = grouping.CoordinatesCol
+					}
+				}
 			}
 		}
 	}
@@ -116,11 +120,11 @@ func mapFilterKeys(dataset string, filters *api.FilterParamsRaw, variables []*mo
 	return filtersUpdated
 }
 
-func hashFilter(schemaFile string, filterParams *api.FilterParamsRaw) (uint64, error) {
+func hashFilter(schemaFile string, filterParams *api.FilterParams) (uint64, error) {
 	// generate the hash from the params
 	hashStruct := struct {
 		Schema       string
-		FilterParams *api.FilterParamsRaw
+		FilterParams *api.FilterParams
 	}{
 		Schema:       schemaFile,
 		FilterParams: filterParams,
@@ -132,37 +136,38 @@ func hashFilter(schemaFile string, filterParams *api.FilterParamsRaw) (uint64, e
 	return hash, nil
 }
 
-func getPreFiltering(ds *api.Dataset, filterParams *api.FilterParamsRaw) (*api.FilterParamsRaw, *api.FilterParamsRaw) {
+func getPreFiltering(ds *api.Dataset, filterParams *api.FilterParams) (*api.FilterParams, *api.FilterParams) {
 	vars := map[string]*model.Variable{}
 	for _, v := range ds.Variables {
 		vars[v.Key] = v
 	}
 	clone := filterParams.Clone()
+
 	// filter if a clustering or outlier detection metadata feature exist
 	// remove pre filters from the rest of the filters since they should not be in the main pipeline
-	// TODO: NEED TO HANDLE OUTLIER FILTERS!
-	preFilters := &api.FilterParamsRaw{
-		Filters: api.FilterObject{List: []*model.Filter{}, Invert: false},
-	}
-	filters := clone.Filters
-	clone.Filters = api.FilterObject{List: []*model.Filter{}, Invert: false}
-	for _, f := range filters.List {
-		variable := vars[f.Key]
-		params := clone
-		if variable.IsGrouping() {
-			cg, ok := variable.Grouping.(model.ClusteredGrouping)
-			if ok {
-				f.Key = cg.GetClusterCol()
-				params = preFilters
+	preFilters := api.NewFilterParamsFromRaw(nil)
+	clone.Filters = []*model.FilterSet{}
+	for _, fs := range filterParams.Filters {
+		for _, ff := range fs.FeatureFilters {
+			for _, f := range ff.List {
+				variable := vars[f.Key]
+				params := clone
+				if variable.IsGrouping() {
+					cg, ok := variable.Grouping.(model.ClusteredGrouping)
+					if ok {
+						f.Key = cg.GetClusterCol()
+						params = preFilters
+					}
+				}
+
+				// Pre-filters rows select by D3MIndex (i.e. row selection.)
+				if variable.Key == model.D3MIndexFieldName {
+					params = preFilters
+				}
+
+				params.AddFilter(f)
 			}
 		}
-
-		// Pre-filters rows select by D3MIndex (i.e. row selection.)
-		if variable.Key == model.D3MIndexFieldName {
-			params = preFilters
-		}
-
-		params.Filters.List = append(params.Filters.List, f)
 	}
 
 	return clone, preFilters

--- a/api/compute/filter.go
+++ b/api/compute/filter.go
@@ -145,7 +145,7 @@ func getPreFiltering(ds *api.Dataset, filterParams *api.FilterParams) (*api.Filt
 
 	// filter if a clustering or outlier detection metadata feature exist
 	// remove pre filters from the rest of the filters since they should not be in the main pipeline
-	preFilters := api.NewFilterParamsFromRaw(nil)
+	preFilters := api.NewFilterParamsFromFilters(nil)
 	clone.Filters = []*model.FilterSet{}
 	for _, fs := range filterParams.Filters {
 		for _, ff := range fs.FeatureFilters {

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -299,7 +299,7 @@ func (s *Storage) buildFilteredQueryWhere(dataset string, wheres []string, param
 	return wheres, params
 }
 
-func (s *Storage) buildSelectionFilter(dataset string, params []interface{}, alias string, filters []api.FilterObject) (string, []interface{}) {
+func (s *Storage) buildSelectionFilter(dataset string, params []interface{}, alias string, filters []model.FilterObject) (string, []interface{}) {
 	// filters acting on the same feature are OR
 	// Filters acting on different features are AND
 	var filtersByFeature []string
@@ -410,7 +410,7 @@ func (s *Storage) buildFilteredResultQueryField(variables []*model.Variable, tar
 	return strings.Join(distincts, ","), fields, nil
 }
 
-func (s *Storage) buildCorrectnessResultWhere(wheres []string, params []interface{}, storageName string, resultURI string, resultFilter api.FilterObject) ([]string, []interface{}, error) {
+func (s *Storage) buildCorrectnessResultWhere(wheres []string, params []interface{}, storageName string, resultURI string, resultFilter model.FilterObject) ([]string, []interface{}, error) {
 	// get the target variable name
 	storageNameResult := s.getResultTable(storageName)
 	targetName, err := s.getResultTargetName(storageNameResult, resultURI)
@@ -441,7 +441,7 @@ func (s *Storage) buildCorrectnessResultWhere(wheres []string, params []interfac
 	return append(wheres, fmt.Sprintf("(%s)", strings.Join(wheresFilter, " OR "))), params, nil
 }
 
-func (s *Storage) buildErrorResultWhere(wheres []string, params []interface{}, residualFilter api.FilterObject) ([]string, []interface{}, error) {
+func (s *Storage) buildErrorResultWhere(wheres []string, params []interface{}, residualFilter model.FilterObject) ([]string, []interface{}, error) {
 	// Add clauses to filter residuals to the existing where
 
 	// Error keys are a string of the form <solutionID>:error.  We need to pull the solution ID out so we can find the name of the target var.
@@ -479,7 +479,7 @@ func (s *Storage) buildErrorResultWhere(wheres []string, params []interface{}, r
 	return append(wheres, fmt.Sprintf("(%s)", strings.Join(wheresFilter, " OR "))), params, nil
 }
 
-func (s *Storage) buildConfidenceResultWhere(wheres []string, params []interface{}, confidenceFilter api.FilterObject, alias string) ([]string, []interface{}) {
+func (s *Storage) buildConfidenceResultWhere(wheres []string, params []interface{}, confidenceFilter model.FilterObject, alias string) ([]string, []interface{}) {
 	// Add a clause to filter confidence to the existing where
 	if alias != "" {
 		alias = alias + "."
@@ -495,7 +495,7 @@ func (s *Storage) buildConfidenceResultWhere(wheres []string, params []interface
 	// Append the clause
 	return append(wheres, fmt.Sprintf("(%s)", strings.Join(wheresFilter, " OR "))), params
 }
-func (s *Storage) buildRankResultWhere(wheres []string, params []interface{}, rankFilter api.FilterObject, alias string) ([]string, []interface{}) {
+func (s *Storage) buildRankResultWhere(wheres []string, params []interface{}, rankFilter model.FilterObject, alias string) ([]string, []interface{}) {
 	// Add a clause to filter confidence to the existing where
 	if alias != "" {
 		alias = alias + "."
@@ -511,11 +511,11 @@ func (s *Storage) buildRankResultWhere(wheres []string, params []interface{}, ra
 	// Append the clause
 	return append(wheres, fmt.Sprintf("(%s)", strings.Join(wheresFilter, " OR "))), params
 }
-func (s *Storage) buildPredictedResultWhere(dataset string, wheres []string, params []interface{}, alias string, resultURI string, resultFilter api.FilterObject) ([]string, []interface{}) {
+func (s *Storage) buildPredictedResultWhere(dataset string, wheres []string, params []interface{}, alias string, resultURI string, resultFilter model.FilterObject) ([]string, []interface{}) {
 	// handle the general category case
 	filterParams := &api.FilterParams{
-		Filters: []*api.FilterSet{{
-			FeatureFilters: []api.FilterObject{resultFilter},
+		Filters: []*model.FilterSet{{
+			FeatureFilters: []model.FilterObject{resultFilter},
 			Mode:           resultFilter.List[0].Mode,
 		}},
 	}
@@ -592,27 +592,27 @@ func combineClauses(mode string, clauses []string, operation string) string {
 }
 
 type filters struct {
-	genericFilters     []api.FilterObject
-	predictedFilters   []api.FilterObject
-	residualFilters    []api.FilterObject
-	correctnessFilters []api.FilterObject
-	confidenceFilters  []api.FilterObject
-	rankFilters        []api.FilterObject
+	genericFilters     []model.FilterObject
+	predictedFilters   []model.FilterObject
+	residualFilters    []model.FilterObject
+	correctnessFilters []model.FilterObject
+	confidenceFilters  []model.FilterObject
+	rankFilters        []model.FilterObject
 }
 
-func splitFilters(filterSet *api.FilterSet) (*filters, error) {
+func splitFilters(filterSet *model.FilterSet) (*filters, error) {
 	if filterSet == nil {
 		return &filters{}, nil
 	}
 
 	// split fitlers into inclusion and exclusion sets
 	output := &filters{
-		genericFilters:     []api.FilterObject{},
-		predictedFilters:   []api.FilterObject{},
-		residualFilters:    []api.FilterObject{},
-		correctnessFilters: []api.FilterObject{},
-		confidenceFilters:  []api.FilterObject{},
-		rankFilters:        []api.FilterObject{},
+		genericFilters:     []model.FilterObject{},
+		predictedFilters:   []model.FilterObject{},
+		residualFilters:    []model.FilterObject{},
+		correctnessFilters: []model.FilterObject{},
+		confidenceFilters:  []model.FilterObject{},
+		rankFilters:        []model.FilterObject{},
 	}
 
 	for _, featureFilters := range filterSet.FeatureFilters {

--- a/api/model/storage/postgres/result.go
+++ b/api/model/storage/postgres/result.go
@@ -528,7 +528,7 @@ func isCorrectnessCategory(categoryName string) bool {
 	return strings.EqualFold(CorrectCategory, categoryName) || strings.EqualFold(categoryName, IncorrectCategory)
 }
 
-func addCorrectnessFilterToWhere(wheres []string, params []interface{}, correctnessFilters api.FilterObject, target *model.Variable) ([]string, []interface{}, error) {
+func addCorrectnessFilterToWhere(wheres []string, params []interface{}, correctnessFilters model.FilterObject, target *model.Variable) ([]string, []interface{}, error) {
 	wheresFilter := []string{}
 	for _, correctnessFilter := range correctnessFilters.List {
 		if len(correctnessFilter.Categories[0]) == 0 {
@@ -555,7 +555,7 @@ func getFullName(alias string, column string) string {
 	return fullName
 }
 
-func addPredictedFilterToWhere(wheres []string, params []interface{}, predictedFilters api.FilterObject, target *model.Variable) ([]string, []interface{}, error) {
+func addPredictedFilterToWhere(wheres []string, params []interface{}, predictedFilters model.FilterObject, target *model.Variable) ([]string, []interface{}, error) {
 	// Handle the predicted column, which is accessed as `value` in the result query
 	wheresFilter := []string{}
 	for _, predictedFilter := range predictedFilters.List {
@@ -616,7 +616,7 @@ func addPredictedFilterToWhere(wheres []string, params []interface{}, predictedF
 	return append(wheres, fmt.Sprintf("(%s)", strings.Join(wheresFilter, " OR "))), params, nil
 }
 
-func addErrorFilterToWhere(wheres []string, params []interface{}, alias string, targetName string, residualFilters api.FilterObject) ([]string, []interface{}, error) {
+func addErrorFilterToWhere(wheres []string, params []interface{}, alias string, targetName string, residualFilters model.FilterObject) ([]string, []interface{}, error) {
 	wheresFilter := []string{}
 	for _, residualFilter := range residualFilters.List {
 		// Add a clause to filter residuals to the existing where

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -597,7 +597,7 @@ func (f *TimeSeriesField) FetchSummaryData(resultURI string, filterParams *api.F
 		Size:      filterParams.Size,
 		Variables: filterParams.Variables,
 		DataMode:  filterParams.DataMode,
-		Filters:   []*api.FilterSet{},
+		Filters:   []*model.FilterSet{},
 	}
 	joins := make([]*joinDefinition, 0)
 	wheres := []string{}

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210427203529-d34eafe13488
+	github.com/uncharted-distil/distil-compute v0.0.0-20210430215027-3b7198c469a9
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210423153809-daca011354e6
+	github.com/uncharted-distil/distil-compute v0.0.0-20210427203529-d34eafe13488
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210427203529-d34eafe13488 h1:X0folbA5VYCT5cJVu53GGxWE/qKjHikk/h4cYMiLH7Y=
-github.com/uncharted-distil/distil-compute v0.0.0-20210427203529-d34eafe13488/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210430215027-3b7198c469a9 h1:Cjc+7f0XDylAtp0hdAjSLHwI/zIWQzw48hvBeMIPgAA=
+github.com/uncharted-distil/distil-compute v0.0.0-20210430215027-3b7198c469a9/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210423153809-daca011354e6 h1:96hmcfmEg6dNJY+f/2u6CowMopfSawWrMho/SxM4DNU=
-github.com/uncharted-distil/distil-compute v0.0.0-20210423153809-daca011354e6/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210427203529-d34eafe13488 h1:X0folbA5VYCT5cJVu53GGxWE/qKjHikk/h4cYMiLH7Y=
+github.com/uncharted-distil/distil-compute v0.0.0-20210427203529-d34eafe13488/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=


### PR DESCRIPTION
Pipeline filtering now uses the filter set approach rather than the previous filtering approach. Translation to the filter set structures now happens at the borders of the client interactions rather than the database interactions.

The filter set and object structures were moved to the compute repo. Consequently, code in this repo was updated to point to the new location.