### PR TITLE
Query Geometry Centroid

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -109,7 +109,6 @@ type DataStorage interface {
 	AddVariable(dataset string, storageName string, varName string, varType string, defaultVal string) error
 	AddField(dataset string, storageName string, varName string, varType string, defaultVal string) error
 	DeleteVariable(dataset string, storageName string, varName string) error
-	UpdateVariable(storageName string, varName string, d3mIndex string, value string) error
 	SetVariableValue(storageName string, varName string, value string) error
 	UpdateVariableBatch(storageName string, varName string, updates map[string]string) error
 	UpdateData(dataset string, storageName string, varName string, updates map[string]string, filterParams *FilterParams) error

--- a/api/model/storage/postgres/bounds.go
+++ b/api/model/storage/postgres/bounds.go
@@ -150,7 +150,7 @@ func (f *BoundsField) fetchHistogram(filterParams *api.FilterParams, numBuckets 
 	//	ST_INTERSECTS WILL OVERCOUNT THOSE THAT CROSS BOUNDARIES
 	query := fmt.Sprintf(`
 		SELECT b.xbuckets, b.xcoord, b.ybuckets, b.ycoord, COUNT(%s)
-		FROM %s AS d inner join %s AS b ON ST_INTERSECTS(d."%s", b.coordinates) %s
+		FROM %s AS d inner join %s AS b ON ST_WITHIN(d."%s", b.coordinates) %s
 		GROUP BY b.xbuckets, b.xcoord, b.ybuckets, b.ycoord
 		ORDER BY b.xbuckets, b.ybuckets;`, f.Count, queryTableName, tmpTableName, f.PolygonCol, where)
 	res, err := tx.Query(context.Background(), query, params...)
@@ -308,7 +308,7 @@ func (f *BoundsField) fetchHistogramByResult(resultURI string, filterParams *api
 	queryTableName := getBaseTableName(f.DatasetStorageName)
 	query := fmt.Sprintf(`
 		SELECT b.xbuckets, b.xcoord, b.ybuckets, b.ycoord, COUNT(%s)
-		FROM %s AS data inner join %s AS b ON ST_INTERSECTS(data."%s", b.coordinates)
+		FROM %s AS data inner join %s AS b ON ST_WITHIN(data."%s", b.coordinates)
 		INNER JOIN %s result ON cast(data."%s" as double precision) = result.index
 		WHERE result.result_id = $%d %s
 		GROUP BY b.xbuckets, b.xcoord, b.ybuckets, b.ycoord

--- a/api/model/storage/postgres/filter.go
+++ b/api/model/storage/postgres/filter.go
@@ -205,7 +205,7 @@ func (s *Storage) buildIncludeFilter(dataset string, wheres []string, params []i
 
 	case model.GeoBoundsFilter:
 		// geo bounds
-		where := fmt.Sprintf("ST_INTERSECTS(%s, $%d)", name, len(params)+1)
+		where := fmt.Sprintf("ST_WITHIN(%s, $%d)", name, len(params)+1)
 		params = append(params, buildBoundsGeometryString(filter.Bounds))
 		wheres = append(wheres, where)
 


### PR DESCRIPTION
Fixes #2545 

Reduced polygons to a centroid in the database, and switched querying to use `WITHIN` semantics rather than `INTERSECTS`. Given where centroids fall, if bucket boundaries dont perfectly match tile boundaries, some patterns will exist but the data will only be counted once.

As part of this work, code that was no longer used was found and promptly removed.