### PR TITLE
Join support for group var

### DIFF
--- a/api/routes/solution_variable_rankings.go
+++ b/api/routes/solution_variable_rankings.go
@@ -72,7 +72,7 @@ func SolutionVariableRankingHandler(metaCtor api.MetadataStorageCtor, solutionCt
 				handleError(w, errors.Wrap(err, "unable to expand grouped variables"))
 				return
 			}
-			rankings, err = targetRank(dataset.ID, request.TargetFeature(), dataset.Folder, summaryVariables, dataset.Source)
+			rankings, err = targetRank(dataset, request.TargetFeature(), summaryVariables, dataset.Source)
 			if err != nil {
 				handleError(w, errors.Wrap(err, "unable get variable ranking"))
 				return

--- a/api/routes/variable_rankings.go
+++ b/api/routes/variable_rankings.go
@@ -56,7 +56,7 @@ func VariableRankingHandler(metaCtor api.MetadataStorageCtor) func(http.Response
 			handleError(w, errors.Wrap(err, "unable to expand grouped variables"))
 			return
 		}
-		rankings, err = targetRank(dataset, target, d.Folder, summaryVariables, d.Source)
+		rankings, err = targetRank(d, target, summaryVariables, d.Source)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable get variable ranking"))
 			return
@@ -81,9 +81,9 @@ func VariableRankingHandler(metaCtor api.MetadataStorageCtor) func(http.Response
 	}
 }
 
-func targetRank(dataset string, target string, folder string, variables []*model.Variable, source metadata.DatasetSource) (map[string]float64, error) {
+func targetRank(dataset *api.Dataset, target string, variables []*model.Variable, source metadata.DatasetSource) (map[string]float64, error) {
 	// compute rankings
-	rankings, err := task.TargetRank(folder, target, variables, source)
+	rankings, err := task.TargetRank(dataset, target, variables, source)
 	if err != nil {
 		return nil, err
 	}

--- a/api/serialization/parquet.go
+++ b/api/serialization/parquet.go
@@ -211,7 +211,7 @@ func (d *Parquet) WriteData(uri string, data [][]string) error {
 		}
 		err = pw.Write(row)
 		if err != nil {
-			return errors.Wrap(err, "error writing data to parquet file")
+			return errors.Wrapf(err, "error writing row %d/%d to parquet file", i, len(data))
 		}
 	}
 	err = pw.WriteStop()

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -127,11 +127,9 @@ func (defaultSubmitter) submit(datasetURIs []string, pipelineDesc *description.F
 }
 
 func createDatasetFromCSV(config *env.Config, csvFile string, datasetName string, storageName string, joinLeft *JoinSpec, joinRight *JoinSpec) ([]*model.Variable, error) {
-
-	datasetStorage := serialization.GetStorage(csvFile)
-	inputData, err := datasetStorage.ReadData(csvFile)
+	inputData, err := serialization.ResultToInputCSV(csvFile)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read data")
+		return nil, err
 	}
 
 	metadata := model.NewMetadata(datasetName, datasetName, datasetName, storageName)

--- a/api/task/solution.go
+++ b/api/task/solution.go
@@ -53,7 +53,7 @@ func SaveFittedSolution(fittedSolutionID string, modelName string, modelDescript
 	// ignore errors in this part because they are secondary to saving the model
 	if len(ranks) == 0 {
 		summaryVariables, _ := api.FetchSummaryVariables(dataset.ID, metadataStorage)
-		ranks, _ = TargetRank(dataset.Folder, request.TargetFeature(), summaryVariables, dataset.Source)
+		ranks, _ = TargetRank(dataset, request.TargetFeature(), summaryVariables, dataset.Source)
 	}
 
 	varMap := make(map[string]*model.Variable)

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210430215027-3b7198c469a9
+	github.com/uncharted-distil/distil-compute v0.0.0-20210503161748-f453e158680e
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Jeffail/gabs/v2 v2.2.0 h1:7touC+WzbQ7LO5+mwgxT44miyTqAVCOlIWLA6PiIB5w=
 github.com/Jeffail/gabs/v2 v2.2.0/go.mod h1:xCn81vdHKxFUuWWAaD5jCTQDNPBMh5pPs9IJ+NcziBI=
@@ -119,7 +118,6 @@ github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.4.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
-github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.10.5/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.0 h1:wJbzvpYMVGG9iTI9VxpnNZfd4DzMPoCWze3GgSqz8yg=
@@ -203,7 +201,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -211,8 +208,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210430215027-3b7198c469a9 h1:Cjc+7f0XDylAtp0hdAjSLHwI/zIWQzw48hvBeMIPgAA=
-github.com/uncharted-distil/distil-compute v0.0.0-20210430215027-3b7198c469a9/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210503161748-f453e158680e h1:nNSQ7PTpEfFRbXfZhOKV/tsmkGPKOda+V1HF1ZlvGzU=
+github.com/uncharted-distil/distil-compute v0.0.0-20210503161748-f453e158680e/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=

--- a/public/components/JoinDatasetsPreview.vue
+++ b/public/components/JoinDatasetsPreview.vue
@@ -26,10 +26,10 @@
     <join-data-preview-slot
       :items="joinDataPreviewItems"
       :fields="emphasizedFields"
-      :numRows="joinDataPreviewNumRows"
-      :hasData="joinDataPreviewHasData"
+      :num-rows="joinDataPreviewNumRows"
+      :has-data="joinDataPreviewHasData"
       instance-name="join-dataset-bottom"
-    ></join-data-preview-slot>
+    />
 
     <div class="row justify-content-center">
       <b-btn
@@ -39,18 +39,18 @@
         :disabled="isPending"
       >
         <div class="row justify-content-center">
-          <i class="fa fa-check-circle fa-2x mr-2"></i>
+          <i class="fa fa-check-circle fa-2x mr-2" />
           <b>Commit join</b>
         </div>
       </b-btn>
       <b-btn
         class="mt-3 join-modal-button"
         variant="outline-danger"
-        @click="onClose"
         :disabled="isPending"
+        @click="onClose"
       >
         <div class="row justify-content-center">
-          <i class="fa fa-times-circle fa-2x mr-2"></i>
+          <i class="fa fa-times-circle fa-2x mr-2" />
           <b>Cancel</b>
         </div>
       </b-btn>
@@ -63,7 +63,7 @@
         variant="outline-secondary"
         striped
         :animated="true"
-      ></b-progress>
+      />
     </div>
   </div>
 </template>
@@ -84,6 +84,7 @@ import {
 } from "../store/dataset/index";
 import { actions as datasetActions } from "../store/dataset/module";
 import { getTableDataItems, getTableDataFields } from "../util/data";
+import { pairs } from "d3-array";
 
 export default Vue.extend({
   name: "JoinDatasetsPreview",
@@ -157,6 +158,15 @@ export default Vue.extend({
   methods: {
     onSave(args: SaveInfo) {
       this.pending = true;
+
+      const leftCols = routeGetters
+        .getJoinPairs(this.$store)
+        .map((p) => p.first);
+
+      const rightCols = routeGetters
+        .getJoinPairs(this.$store)
+        .map((p) => p.second);
+
       const importDatasetArgs = {
         datasetID: args.name,
         terms: this.terms,
@@ -164,6 +174,8 @@ export default Vue.extend({
         provenance: "local",
         originalDataset: this.datasetA,
         joinedDataset: this.datasetB,
+        leftCols: leftCols,
+        rightCols: rightCols,
         searchResultIndex: this.searchResultIndex,
         description: args.description,
         path: this.path,

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -29,7 +29,7 @@ import {
   validateArgs,
 } from "../../util/data";
 import { Dictionary } from "../../util/dict";
-import { EXCLUDE_FILTER, FilterParams } from "../../util/filters";
+import { FilterParams } from "../../util/filters";
 import {
   addHighlightToFilterParams,
   cloneFilters,
@@ -607,6 +607,8 @@ export const actions = {
       description?: string;
       path: string;
       nosample?: boolean;
+      leftCols?: string[];
+      rightCols?: string[];
     }
   ): Promise<any> {
     if (!validateArgs(args, ["datasetID", "source"])) {
@@ -621,11 +623,15 @@ export const actions = {
         originalDataset: args.originalDataset,
         joinedDataset: args.joinedDataset,
         description: args.description,
+        leftCols: args.leftCols,
+        rightCols: args.rightCols,
       };
     } else if (args.originalDataset !== null) {
       postParams = {
         originalDataset: args.originalDataset,
         joinedDataset: args.joinedDataset,
+        leftCols: args.leftCols,
+        rightCols: args.rightCols,
       };
     }
     const response = await axios.post(


### PR DESCRIPTION
Fixes #2546
Fixes #2552

Fixes several issues uncovered when joining satellite image  datasets with external geo datasets:

1. Multi-band image group variables were being left referencing a group ID that was removed due to it being a right-join key.  We now loop over the group structure (which is JSON at that point for some reason?) and update the references to use the left column.
2. In the image-pack route, we were using hard-coded values for multiband image components, which meant any rename of column as a result of the fix from 1. caused the images to fail fetch.
3. MI ranking is now completely skipped  if working with pre-featurized data
4. Only a single geobounds column could be processed during import, leading to data being in partially imported state when a result in 2 bounds columns being present.  We now support multiple bounds columns, although images remain hardcoded at 1, generating a warning on imports if more than one is present.
5. Columns containing geobounds that were converted into ndarrays by the TA2 are serialized by the `DataFrame.to_csv` call as a space separate list.  Trying to re-import this data as part of the join process lead to issues, as the data is not in the accepted D3M vector format.  We now re-format the data on import.  **Note:**  There may be more places this is needed.