### PR TITLE
Exclude sets

### DIFF
--- a/api/compute/query_request.go
+++ b/api/compute/query_request.go
@@ -27,7 +27,7 @@ import (
 type QueryRequest struct {
 	DatasetID string
 	Target    string
-	Filters   *api.FilterParamsRaw
+	Filters   *api.FilterParams
 
 	requestChannel chan QueryStatus
 	finished       chan error

--- a/api/compute/solution_request.go
+++ b/api/compute/solution_request.go
@@ -144,7 +144,7 @@ func NewSolutionRequest(variables []*model.Variable, data []byte) (*SolutionRequ
 		if err != nil {
 			return nil, err
 		}
-		req.Filters = api.NewFilterParamsFromRaw(rawFilters)
+		req.Filters = rawFilters
 	}
 
 	req.CancelFuncs = map[string]context.CancelFunc{}

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -139,11 +139,6 @@ func (f *FilterParams) Clone() *FilterParams {
 	return clone
 }
 
-// AddSet adds a set to the filter params
-func (f *FilterParams) AddSet(filter *model.Filter) {
-
-}
-
 // AddFilter adds a filter to the filter params, inserting it in the proper collection.
 func (f *FilterParams) AddFilter(filter *model.Filter) {
 	// currently assume all include filters are one filter set, and exclude another

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -19,7 +19,6 @@ import (
 	encoding "encoding/json"
 	"fmt"
 	"math"
-	"sort"
 
 	"github.com/pkg/errors"
 
@@ -62,12 +61,27 @@ type FilterParams struct {
 
 // FilterParamsRaw defines the set of numeric range and categorical filters. Variables
 // with no range or category filters are also allowed.
-type FilterParamsRaw struct {
-	Size       int                `json:"size"`
-	Highlights model.FilterObject `json:"highlights"`
-	Filters    model.FilterObject `json:"filters"`
-	Variables  []string           `json:"variables"`
-	DataMode   DataMode           `json:"dataMode"`
+// type FilterParamsRaw struct {
+// 	Size       int          `json:"size"`
+// 	Highlights FilterObject `json:"highlights"`
+// 	Filters    FilterObject `json:"filters"`
+// 	Variables  []string     `json:"variables"`
+// 	DataMode   DataMode     `json:"dataMode"`
+// }
+//type FilterSetRaw struct{
+//	List [][]*model.Filter `json:"list"`
+//	Invert bool 			`json:"invert"`
+//}
+// FilterObject captures a collection of invertable filters.
+type FilterObject struct {
+	List   []*model.Filter `json:"list"`
+	Invert bool            `json:"invert"`
+}
+
+// FilterSet captures a set of filters representing one subset of data.
+type FilterSet struct {
+	FeatureFilters []FilterObject `json:"featureFilters"`
+	Mode           string         `json:"mode"`
 }
 
 // NewFilterParamsFromFilters creates a wrapping container for all filters.
@@ -86,45 +100,45 @@ func NewFilterParamsFromFilters(filters []*model.Filter) *FilterParams {
 }
 
 // NewFilterParamsFromRaw creates a wrapping container from raw filter params.
-func NewFilterParamsFromRaw(raw *FilterParamsRaw) *FilterParams {
-	rawClone := raw.Clone()
-
-	params := &FilterParams{
-		Size:      rawClone.Size,
-		Variables: rawClone.Variables,
-		DataMode:  rawClone.DataMode,
-		Filters:   []*model.FilterSet{},
-	}
-
-	// add filters and highlights to the params
-	for _, f := range rawClone.Filters.List {
-		params.AddFilter(f)
-	}
-	for _, h := range rawClone.Highlights.List {
-		params.AddFilter(h)
-	}
-	// TODO: FIGURE OUT A NICE WAY TO INVERT THINGS!
-	if len(rawClone.Filters.List) > 0 {
-		for _, set := range params.Filters {
-			if set.Mode == rawClone.Filters.List[0].Mode {
-				for i := range set.FeatureFilters {
-					set.FeatureFilters[i].Invert = rawClone.Filters.Invert
-				}
-			}
-		}
-	}
-	if len(rawClone.Highlights.List) > 0 {
-		for _, set := range params.Filters {
-			if set.Mode == rawClone.Highlights.List[0].Mode {
-				for i := range set.FeatureFilters {
-					set.FeatureFilters[i].Invert = rawClone.Highlights.Invert
-				}
-			}
-		}
-	}
-
-	return params
-}
+//func NewFilterParamsFromRaw(raw *FilterParamsRaw) *FilterParams {
+//	rawClone := raw.Clone()
+//
+//	params := &FilterParams{
+//		Size:      rawClone.Size,
+//		Variables: rawClone.Variables,
+//		DataMode:  rawClone.DataMode,
+//		Filters:   []*FilterSet{},
+//	}
+//
+//	// add filters and highlights to the params
+//	for _, f := range rawClone.Filters.List {
+//		params.AddFilter(f)
+//	}
+//	for _, h := range rawClone.Highlights.List {
+//		params.AddFilter(h)
+//	}
+//	// TODO: FIGURE OUT A NICE WAY TO INVERT THINGS!
+//	if len(rawClone.Filters.List) > 0 {
+//		for _, set := range params.Filters {
+//			if set.Mode == rawClone.Filters.List[0].Mode {
+//				for i := range set.FeatureFilters {
+//					set.FeatureFilters[i].Invert = rawClone.Filters.Invert
+//				}
+//			}
+//		}
+//	}
+//	if len(rawClone.Highlights.List) > 0 {
+//		for _, set := range params.Filters {
+//			if set.Mode == rawClone.Highlights.List[0].Mode {
+//				for i := range set.FeatureFilters {
+//					set.FeatureFilters[i].Invert = rawClone.Highlights.Invert
+//				}
+//			}
+//		}
+//	}
+//
+//	return params
+//}
 
 // GetBaselineFilter returns a filter params that only has the baseline filters.
 func GetBaselineFilter(filterParam *FilterParams) *FilterParams {
@@ -188,6 +202,11 @@ func (f *FilterParams) Clone() *FilterParams {
 	clone.Size = f.Size
 	clone.DataMode = f.DataMode
 	return clone
+}
+
+// AddSet adds a set to the filter params
+func (f *FilterParams) AddSet(filter *model.Filter) {
+
 }
 
 // AddFilter adds a filter to the filter params, inserting it in the proper collection.
@@ -257,39 +276,39 @@ func (f *FilterParams) InvertFilters() {
 }
 
 // Empty returns if the filter set is empty.
-func (f *FilterParamsRaw) Empty(ignoreBaselineFilters bool) bool {
-	for _, filter := range f.Filters.List {
-		if !filter.IsBaselineFilter || !ignoreBaselineFilters {
-			return false
-		}
-	}
-	for _, highlight := range f.Highlights.List {
-		if !highlight.IsBaselineFilter || !ignoreBaselineFilters {
-			return false
-		}
-	}
-	return true
-}
+// func (f *FilterParamsRaw) Empty(ignoreBaselineFilters bool) bool {
+// 	for _, filter := range f.Filters.List {
+// 		if !filter.IsBaselineFilter || !ignoreBaselineFilters {
+// 			return false
+// 		}
+// 	}
+// 	for _, highlight := range f.Highlights.List {
+// 		if !highlight.IsBaselineFilter || !ignoreBaselineFilters {
+// 			return false
+// 		}
+// 	}
+// 	return true
+// }
 
 // Clone returns a deep copy of the filter params.
-func (f *FilterParamsRaw) Clone() *FilterParamsRaw {
-	clone := &FilterParamsRaw{}
-
-	for _, h := range f.Highlights.List {
-		c := *h
-		clone.Highlights.List = append(clone.Highlights.List, &c)
-	}
-	for _, f := range f.Filters.List {
-		c := *f
-		clone.Filters.List = append(clone.Filters.List, &c)
-	}
-	clone.Highlights.Invert = f.Highlights.Invert
-	clone.Filters.Invert = f.Filters.Invert
-	clone.Variables = append(clone.Variables, f.Variables...)
-	clone.Size = f.Size
-	clone.DataMode = f.DataMode
-	return clone
-}
+//func (f *FilterParamsRaw) Clone() *FilterParamsRaw {
+//	clone := &FilterParamsRaw{}
+//
+//	for _, h := range f.Highlights.List {
+//		c := *h
+//		clone.Highlights.List = append(clone.Highlights.List, &c)
+//	}
+//	for _, f := range f.Filters.List {
+//		c := *f
+//		clone.Filters.List = append(clone.Filters.List, &c)
+//	}
+//	clone.Highlights.Invert = f.Highlights.Invert
+//	clone.Filters.Invert = f.Filters.Invert
+//	clone.Variables = append(clone.Variables, f.Variables...)
+//	clone.Size = f.Size
+//	clone.DataMode = f.DataMode
+//	return clone
+//}
 
 func filtersEqual(first *model.Filter, second *model.Filter) bool {
 	baseEquals := first.Key == second.Key &&
@@ -308,65 +327,65 @@ func filtersEqual(first *model.Filter, second *model.Filter) bool {
 
 // Merge merges another set of filter params into this set, expanding all
 // properties.
-func (f *FilterParams) Merge(other *FilterParamsRaw) {
-
-	// If the filters has a nil or negative value, we use the value use by default on distil-model
-	// https://github.com/uncharted-distil/distil/blob/master/api/model/storage/postgres/request.go#L239
-	if other.Size >= 0 {
-		f.Size = other.Size
-	}
-
-	for _, highlight := range other.Highlights.List {
-		found := false
-		for _, set := range f.Filters {
-			if set.Mode == highlight.Mode {
-				for _, filters := range set.FeatureFilters {
-					for _, currentFilter := range filters.List {
-						if filtersEqual(highlight, currentFilter) {
-							found = true
-							break
-						}
-					}
-				}
-			}
-		}
-		if !found {
-			f.AddFilter(highlight)
-		}
-	}
-
-	for _, filter := range other.Filters.List {
-		found := false
-		for _, set := range f.Filters {
-			if set.Mode == filter.Mode {
-				for _, filters := range set.FeatureFilters {
-					for _, currentFilter := range filters.List {
-						if filtersEqual(filter, currentFilter) {
-							found = true
-							break
-						}
-					}
-				}
-			}
-		}
-		if !found {
-			f.AddFilter(filter)
-		}
-	}
-
-	for _, variable := range other.Variables {
-		found := false
-		for _, currentVariable := range f.Variables {
-			if variable == currentVariable {
-				found = true
-				break
-			}
-		}
-		if !found {
-			f.Variables = append(f.Variables, variable)
-		}
-	}
-}
+// func (f *FilterParams) Merge(other *FilterParamsRaw) {
+// 
+// 	// If the filters has a nil or negative value, we use the value use by default on distil-model
+// 	// https://github.com/uncharted-distil/distil/blob/master/api/model/storage/postgres/request.go#L239
+// 	if other.Size >= 0 {
+// 		f.Size = other.Size
+// 	}
+// 
+// 	for _, highlight := range other.Highlights.List {
+// 		found := false
+// 		for _, set := range f.Filters {
+// 			if set.Mode == highlight.Mode {
+// 				for _, filters := range set.FeatureFilters {
+// 					for _, currentFilter := range filters.List {
+// 						if filtersEqual(highlight, currentFilter) {
+// 							found = true
+// 							break
+// 						}
+// 					}
+// 				}
+// 			}
+// 		}
+// 		if !found {
+// 			f.AddFilter(highlight)
+// 		}
+// 	}
+// 
+// 	for _, filter := range other.Filters.List {
+// 		found := false
+// 		for _, set := range f.Filters {
+// 			if set.Mode == filter.Mode {
+// 				for _, filters := range set.FeatureFilters {
+// 					for _, currentFilter := range filters.List {
+// 						if filtersEqual(filter, currentFilter) {
+// 							found = true
+// 							break
+// 						}
+// 					}
+// 				}
+// 			}
+// 		}
+// 		if !found {
+// 			f.AddFilter(filter)
+// 		}
+// 	}
+// 
+// 	for _, variable := range other.Variables {
+// 		found := false
+// 		for _, currentVariable := range f.Variables {
+// 			if variable == currentVariable {
+// 				found = true
+// 				break
+// 			}
+// 		}
+// 		if !found {
+// 			f.Variables = append(f.Variables, variable)
+// 		}
+// 	}
+// }
 
 // MergeParams merges another set of filter params into this set, expanding all
 // properties.
@@ -663,7 +682,7 @@ func parseFilter(filter map[string]interface{}) (*model.Filter, error) {
 }
 
 // ParseFilterParamsFromJSONRaw parses filter parameters out of a json.RawMessage
-func ParseFilterParamsFromJSONRaw(raw encoding.RawMessage) (*FilterParamsRaw, error) {
+func ParseFilterParamsFromJSONRaw(raw encoding.RawMessage) (*FilterParams, error) {
 	filterParamsMap, err := json.Unmarshal(raw)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse raw filter params")
@@ -672,14 +691,14 @@ func ParseFilterParamsFromJSONRaw(raw encoding.RawMessage) (*FilterParamsRaw, er
 }
 
 // ParseFilterParamsFromJSON parses filter parameters out of a map[string]interface{}
-func ParseFilterParamsFromJSON(params map[string]interface{}) (*FilterParamsRaw, error) {
+func ParseFilterParamsFromJSON(params map[string]interface{}) (*FilterParams, error) {
 	dataMode := json.StringDefault(params, "default", "dataMode")
 	dataModeParsed, err := DataModeFromString(dataMode)
 	if err != nil {
 		return nil, err
 	}
 
-	filterParams := &FilterParamsRaw{
+	filterParams := &FilterParams{
 		Size:     json.IntDefault(params, model.DefaultFilterSize, "size"),
 		DataMode: dataModeParsed,
 	}
@@ -689,51 +708,59 @@ func ParseFilterParamsFromJSON(params map[string]interface{}) (*FilterParamsRaw,
 	}
 
 	highlights, ok := json.Array(params, "highlights", "list")
+	highlightFilterSet := FilterObject{}
 	if ok {
 		for _, highlight := range highlights {
 			h, err := parseFilter(highlight)
 			if err != nil {
 				return nil, err
 			}
-			filterParams.Highlights.List = append(filterParams.Highlights.List, h)
+			highlightFilterSet.List = append(highlightFilterSet.List, h)
 		}
 	}
+	// highlight invert
 	invertHighlights, ok := json.Bool(params, "highlights", "invert")
 	if ok {
-		filterParams.Highlights.Invert = invertHighlights
+		highlightFilterSet.Invert = invertHighlights
 	} else {
 		return nil, errors.New("Missing required param highlights.Invert")
 	}
-	filters, ok := json.Array(params, "filters", "list")
-	if ok {
-		for _, filter := range filters {
-			f, err := parseFilter(filter)
-			if err != nil {
-				return nil, err
-			}
-			filterParams.Filters.List = append(filterParams.Filters.List, f)
-		}
-	}
-
+	// this invert will apply to all filterObjects
 	invertFilters, ok := json.Bool(params, "filters", "invert")
-	if ok {
-		filterParams.Filters.Invert = invertFilters
-	} else {
+	if !ok {
 		return nil, errors.New("Missing required param filters.Invert")
 	}
-
+	// parse filters which is a double array Filters[][]
+	filterSets, ok := json.Array(params, "filters", "list")
+	if ok {
+		// loop through each filter set
+		for _, set := range filterSets {
+			// pull the set out
+			setArray, ok := json.Array(set)
+			filterSet := FilterSet{}
+			if ok {
+				// put the set in a filter object
+				filterObject := FilterObject{}
+				for _, filter := range setArray {
+					f, err := parseFilter(filter)
+					if err != nil {
+						return nil, err
+					}
+					filterObject.List = append(filterObject.List, f)
+					filterObject.Invert = invertFilters
+				}
+				// put filterObject in a filterSet then append to filterParams
+				filterSet.FeatureFilters = append(filterSet.FeatureFilters, filterObject)
+				filterParams.Filters = append(filterParams.Filters, &filterSet)
+			}
+		}
+	}
+	// We might need to throw an error if no variables are passed?
 	variables, ok := json.StringArray(params, "variables")
+
 	if ok {
 		filterParams.Variables = variables
 	}
-
-	sort.SliceStable(filterParams.Highlights.List, func(i, j int) bool {
-		return filterParams.Highlights.List[i].Key < filterParams.Highlights.List[j].Key
-	})
-
-	sort.SliceStable(filterParams.Filters.List, func(i, j int) bool {
-		return filterParams.Filters.List[i].Key < filterParams.Filters.List[j].Key
-	})
 
 	return filterParams, nil
 }

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -74,7 +74,6 @@ func NewFilterParamsFromFilters(filters []*model.Filter) *FilterParams {
 	return params
 }
 
-
 // GetBaselineFilter returns a filter params that only has the baseline filters.
 func GetBaselineFilter(filterParam *FilterParams) *FilterParams {
 	if filterParam == nil {
@@ -558,10 +557,10 @@ func ParseFilterParamsFromJSON(params map[string]interface{}) (*FilterParams, er
 	} else {
 		return nil, errors.New("Missing required param highlights.Invert")
 	}
-	if highlightFilterSet.List != nil{
-	highlightSet := model.FilterSet{}
-	highlightSet.FeatureFilters = append(highlightSet.FeatureFilters, highlightFilterSet)
-	filterParams.Filters = append(filterParams.Filters, &highlightSet)
+	if highlightFilterSet.List != nil {
+		highlightSet := model.FilterSet{}
+		highlightSet.FeatureFilters = append(highlightSet.FeatureFilters, highlightFilterSet)
+		filterParams.Filters = append(filterParams.Filters, &highlightSet)
 	}
 	// this invert will apply to all filterObjects
 	invertFilters, ok := json.Bool(params, "filters", "invert")
@@ -575,22 +574,22 @@ func ParseFilterParamsFromJSON(params map[string]interface{}) (*FilterParams, er
 		for _, set := range filterSets {
 			// pull the set out
 			filterSet := model.FilterSet{}
-				// put the set in a filter object
-				filterObject := model.FilterObject{}
-				setMode := ""
-				for _, filter := range set {
-					f, err := parseFilter(filter)
-					if err != nil {
-						return nil, err
-					}
-					filterObject.List = append(filterObject.List, f)
-					filterObject.Invert = invertFilters
-					setMode = f.Mode
+			// put the set in a filter object
+			filterObject := model.FilterObject{}
+			setMode := ""
+			for _, filter := range set {
+				f, err := parseFilter(filter)
+				if err != nil {
+					return nil, err
 				}
-				// put filterObject in a filterSet then append to filterParams
-				filterSet.FeatureFilters = append(filterSet.FeatureFilters, filterObject)
-				filterSet.Mode = setMode
-				filterParams.Filters = append(filterParams.Filters, &filterSet)
+				filterObject.List = append(filterObject.List, f)
+				filterObject.Invert = invertFilters
+				setMode = f.Mode
+			}
+			// put filterObject in a filterSet then append to filterParams
+			filterSet.FeatureFilters = append(filterSet.FeatureFilters, filterObject)
+			filterSet.Mode = setMode
+			filterParams.Filters = append(filterParams.Filters, &filterSet)
 		}
 	}
 	// We might need to throw an error if no variables are passed?

--- a/api/routes/confidence.go
+++ b/api/routes/confidence.go
@@ -111,10 +111,10 @@ func ConfidenceSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api
 		if hasBand && isGeobounds {
 			boundsFilter := model.NewCategoricalFilter("band", model.IncludeFilter, []string{"01"})
 			boundsFilter.IsBaselineFilter = true
-			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
+			filterParams.AddFilter(boundsFilter)
 		}
 		// fetch summary histogram
-		summary, err := data.FetchConfidenceSummary(dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), api.SummaryMode(mode))
+		summary, err := data.FetchConfidenceSummary(dataset, storageName, res.ResultURI, filterParams, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/correctness_summary.go
+++ b/api/routes/correctness_summary.go
@@ -119,10 +119,10 @@ func CorrectnessSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor ap
 		if hasBand && isGeobounds {
 			boundsFilter := model.NewCategoricalFilter("band", model.IncludeFilter, []string{"01"})
 			boundsFilter.IsBaselineFilter = true
-			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
+			filterParams.AddFilter(boundsFilter)
 		}
 		// fetch summary histogram
-		summary, err := data.FetchCorrectnessSummary(dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), api.SummaryMode(mode))
+		summary, err := data.FetchCorrectnessSummary(dataset, storageName, res.ResultURI, filterParams, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/data.go
+++ b/api/routes/data.go
@@ -54,7 +54,7 @@ func DataHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataStorageCt
 			return
 		}
 		var data *api.FilteredData
-		if !(len(filterParams.Filters.List) < 1 && filterParams.Filters.Invert) {
+		if !(len(filterParams.Filters) < 1 && filterParams.Invert) {
 			dataset := pat.Param(r, "dataset")
 			includeGroupingCol := pat.Param(r, "include-grouping-col")
 			includeGroupingColBool := parseBoolParam(includeGroupingCol)
@@ -92,7 +92,7 @@ func DataHandler(storageCtor api.DataStorageCtor, metaCtor api.MetadataStorageCt
 			storageName := ds.StorageName
 
 			// replace any grouped variables in filter params with the group's
-			expandedFilterParams, err := api.ExpandFilterParams(dataset, api.NewFilterParamsFromRaw(filterParams), false, metaStore)
+			expandedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, metaStore)
 			if err != nil {
 				handleError(w, errors.Wrap(err, "unable to expand filter params"))
 				return

--- a/api/routes/export.go
+++ b/api/routes/export.go
@@ -140,8 +140,8 @@ func ExportResultHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.Data
 			handleError(w, err)
 			return
 		}
-		if rowCount >=0 {
-		req.Filters.Size = rowCount
+		if rowCount >= 0 {
+			req.Filters.Size = rowCount
 		}
 		filterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
 		if err != nil {

--- a/api/routes/export.go
+++ b/api/routes/export.go
@@ -140,10 +140,9 @@ func ExportResultHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.Data
 			handleError(w, err)
 			return
 		}
-		filterParamsRaw := &api.FilterParamsRaw{
-			Size: rowCount,
+		if rowCount >=0 {
+		req.Filters.Size = rowCount
 		}
-		req.Filters.Merge(filterParamsRaw)
 		filterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
 		if err != nil {
 			handleError(w, err)

--- a/api/routes/extract.go
+++ b/api/routes/extract.go
@@ -58,7 +58,7 @@ func ExtractHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCt
 			return
 		}
 		// replace any grouped variables in filter params with the group's
-		expandedFilterParams, err := api.ExpandFilterParams(dataset, api.NewFilterParamsFromRaw(filterParams), false, metaStorage)
+		expandedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, metaStorage)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable to expand filter params"))
 			return

--- a/api/routes/prediction_result_summary.go
+++ b/api/routes/prediction_result_summary.go
@@ -141,10 +141,10 @@ func PredictionResultSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCt
 		if hasBand && isGeobounds {
 			boundsFilter := model.NewCategoricalFilter("band", model.IncludeFilter, []string{"01"})
 			boundsFilter.IsBaselineFilter = true
-			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
+			filterParams.AddFilter(boundsFilter)
 		}
 		// fetch summary histogram
-		summary, err := data.FetchPredictedSummary(prediction.Dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), extrema, api.SummaryMode(mode))
+		summary, err := data.FetchPredictedSummary(prediction.Dataset, storageName, res.ResultURI, filterParams, extrema, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/prediction_results.go
+++ b/api/routes/prediction_results.go
@@ -95,11 +95,11 @@ func PredictionResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api
 		}
 
 		// merge provided filterParams with those of the request
-		req.Filters.Merge(filterParams)
+		// req.Filters.Merge(filterParams)
 
 		// Expand any grouped variables defined in filters into their subcomponents
 		dataset := predictResult.Dataset
-		updatedFilterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
+		updatedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/prediction_results.go
+++ b/api/routes/prediction_results.go
@@ -95,11 +95,11 @@ func PredictionResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api
 		}
 
 		// merge provided filterParams with those of the request
-		// req.Filters.Merge(filterParams)
+		req.Filters.MergeParams(filterParams)
 
 		// Expand any grouped variables defined in filters into their subcomponents
 		dataset := predictResult.Dataset
-		updatedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, meta)
+		updatedFilterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/residuals_summary.go
+++ b/api/routes/residuals_summary.go
@@ -99,7 +99,7 @@ func ResidualsSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.
 		}
 
 		// fetch summary histogram
-		summary, err := data.FetchResidualsSummary(dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), extrema, api.SummaryMode(mode))
+		summary, err := data.FetchResidualsSummary(dataset, storageName, res.ResultURI, filterParams, extrema, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/results.go
+++ b/api/routes/results.go
@@ -93,10 +93,9 @@ func ResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.DataStora
 		}
 
 		// merge provided filterParams with those of the request
-		// req.Filters.Merge(filterParams)
-
+		req.Filters.MergeParams(filterParams)
 		// Expand any grouped variables defined in filters into their subcomponents
-		updatedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, meta)
+		updatedFilterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/results.go
+++ b/api/routes/results.go
@@ -93,10 +93,10 @@ func ResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.DataStora
 		}
 
 		// merge provided filterParams with those of the request
-		req.Filters.Merge(filterParams)
+		// req.Filters.Merge(filterParams)
 
 		// Expand any grouped variables defined in filters into their subcomponents
-		updatedFilterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
+		updatedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/save_dataset.go
+++ b/api/routes/save_dataset.go
@@ -63,7 +63,7 @@ func SaveDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStora
 			return
 		}
 		// replace any grouped variables in filter params with the group's
-		expandedFilterParams, err := api.ExpandFilterParams(dataset, api.NewFilterParamsFromRaw(filterParams), false, metaStorage)
+		expandedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, metaStorage)
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable to expand filter params"))
 			return

--- a/api/routes/solution_result_summary.go
+++ b/api/routes/solution_result_summary.go
@@ -157,7 +157,7 @@ func SolutionResultSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor
 		if hasBand && isGeobounds {
 			boundsFilter := model.NewCategoricalFilter("band", model.IncludeFilter, []string{"01"})
 			boundsFilter.IsBaselineFilter = true
-			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
+			filterParams.AddFilter(boundsFilter)
 		}
 		// extract extrema for solution
 		extrema, err := fetchSolutionPredictedExtrema(meta, data, solution, request.Dataset, storageName, request.TargetFeature(), "")
@@ -167,7 +167,7 @@ func SolutionResultSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor
 		}
 
 		// fetch summary histogram
-		summary, err := data.FetchPredictedSummary(request.Dataset, storageName, res.ResultURI, api.NewFilterParamsFromRaw(filterParams), extrema, api.SummaryMode(mode))
+		summary, err := data.FetchPredictedSummary(request.Dataset, storageName, res.ResultURI, filterParams, extrema, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/target_summary.go
+++ b/api/routes/target_summary.go
@@ -109,7 +109,7 @@ func TargetSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.Sol
 		if hasBand && isGeobounds {
 			boundsFilter := model.NewCategoricalFilter("band", model.IncludeFilter, []string{"01"})
 			boundsFilter.IsBaselineFilter = true
-			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
+			filterParams.AddFilter(boundsFilter)
 		}
 		// extract extrema for solution
 		extrema, err := fetchSolutionPredictedExtrema(meta, data, solution, dataset, storageName, target, "")
@@ -119,7 +119,7 @@ func TargetSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.Sol
 		}
 
 		// fetch summary histogram
-		summary, err := data.FetchSummaryByResult(dataset, storageName, target, result.ResultURI, api.NewFilterParamsFromRaw(filterParams), extrema, api.SummaryMode(mode))
+		summary, err := data.FetchSummaryByResult(dataset, storageName, target, result.ResultURI, filterParams, extrema, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/timeseries.go
+++ b/api/routes/timeseries.go
@@ -48,7 +48,7 @@ func TimeseriesHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.DataSto
 		}
 
 		// get variable names and ranges out of the params
-		var filterParams *model.FilterParamsRaw
+		var filterParams *model.FilterParams
 		if params.FilterParams != nil {
 			filterParams, err = api.ParseFilterParamsFromJSONRaw(params.FilterParams)
 			if err != nil {
@@ -89,7 +89,7 @@ func TimeseriesHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.DataSto
 
 			// fetch timeseries
 			timeseriesData, err := storage.FetchTimeseries(dataset, storageName, t.VarKey, variable.Grouping.GetIDCol(),
-				xColName, yColName, []string{t.SeriesID}, operation, api.NewFilterParamsFromRaw(filterParams))
+				xColName, yColName, []string{t.SeriesID}, operation, filterParams)
 			if err != nil {
 				handleError(w, err)
 				return

--- a/api/routes/timeseries_forecast.go
+++ b/api/routes/timeseries_forecast.go
@@ -59,9 +59,9 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 		}
 
 		// get variable names and ranges out of the params
-		var filterParamsRaw *model.FilterParamsRaw
+		var filterParams *model.FilterParams
 		if params.FilterParams != nil {
-			filterParamsRaw, err = api.ParseFilterParamsFromJSONRaw(params.FilterParams)
+			filterParams, err = api.ParseFilterParamsFromJSONRaw(params.FilterParams)
 			if err != nil {
 				handleError(w, err)
 				return
@@ -125,7 +125,6 @@ func TimeseriesForecastHandler(metaCtor api.MetadataStorageCtor, dataCtor api.Da
 			}
 
 			// fetch timeseries and forecast
-			filterParams := api.NewFilterParamsFromRaw(filterParamsRaw)
 			timeseriesData, err := data.FetchTimeseries(truthDataset, truthStorageName, t.VarKey, variable.Grouping.GetIDCol(),
 				xColName, yColName, []string{t.SeriesID}, operation, filterParams)
 			if err != nil {

--- a/api/routes/training_summary.go
+++ b/api/routes/training_summary.go
@@ -125,10 +125,10 @@ func TrainingSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor api.S
 		if hasBand && isGeobounds {
 			boundsFilter := model.NewCategoricalFilter("band", model.IncludeFilter, []string{"01"})
 			boundsFilter.IsBaselineFilter = true
-			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
+			filterParams.AddFilter(boundsFilter)
 		}
 		// fetch summary histogram
-		summary, err := data.FetchSummaryByResult(dataset, storageName, variable, result.ResultURI, api.NewFilterParamsFromRaw(filterParams), nil, api.SummaryMode(mode))
+		summary, err := data.FetchSummaryByResult(dataset, storageName, variable, result.ResultURI, filterParams, nil, api.SummaryMode(mode))
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/variable_summaries.go
+++ b/api/routes/variable_summaries.go
@@ -93,16 +93,16 @@ func VariableSummaryHandler(metaCtor api.MetadataStorageCtor, ctorStorage api.Da
 		if hasBand && isGeobounds {
 			// if inverting the filter, then invert the mode
 			mode := model.IncludeFilter
-			if filterParams.Filters.Invert {
+			if filterParams.Invert {
 				mode = model.ExcludeFilter
 			}
 			boundsFilter := model.NewCategoricalFilter("band", mode, []string{"01"})
 			boundsFilter.IsBaselineFilter = true
-			filterParams.Filters.List = append(filterParams.Filters.List, boundsFilter)
+			filterParams.AddFilter(boundsFilter)
 		}
 
 		// fetch summary histogram
-		summary, err := storage.FetchSummary(dataset, storageName, variable, api.NewFilterParamsFromRaw(filterParams), mode)
+		summary, err := storage.FetchSummary(dataset, storageName, variable, filterParams, mode)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/util/json/json.go
+++ b/api/util/json/json.go
@@ -195,14 +195,15 @@ func Array(json map[string]interface{}, path ...string) ([]map[string]interface{
 	}
 	return vals, true
 }
+
 // DoubleArray returns an [][]map[string]interface{} property under the given key.
-func DoubleArray(json map[string]interface{}, path ...string)([][]map[string]interface{}, bool){
+func DoubleArray(json map[string]interface{}, path ...string) ([][]map[string]interface{}, bool) {
 	vs, ok := array(json, path...)
 	if !ok {
 		return nil, false
 	}
 	result := make([][]map[string]interface{}, len(vs))
-	for j, v := range vs{
+	for j, v := range vs {
 		val, ok := v.([]interface{})
 		if !ok {
 			return nil, false
@@ -219,6 +220,7 @@ func DoubleArray(json map[string]interface{}, path ...string)([][]map[string]int
 	}
 	return result, true
 }
+
 // InterfaceArray returns a []interface{} under the given path.
 func InterfaceArray(json map[string]interface{}, path ...string) ([]interface{}, bool) {
 	return array(json, path...)

--- a/api/util/json/json.go
+++ b/api/util/json/json.go
@@ -195,7 +195,30 @@ func Array(json map[string]interface{}, path ...string) ([]map[string]interface{
 	}
 	return vals, true
 }
-
+// DoubleArray returns an [][]map[string]interface{} property under the given key.
+func DoubleArray(json map[string]interface{}, path ...string)([][]map[string]interface{}, bool){
+	vs, ok := array(json, path...)
+	if !ok {
+		return nil, false
+	}
+	result := make([][]map[string]interface{}, len(vs))
+	for j, v := range vs{
+		val, ok := v.([]interface{})
+		if !ok {
+			return nil, false
+		}
+		vals := make([]map[string]interface{}, len(val))
+		for i, v := range val {
+			prop, ok := v.(map[string]interface{})
+			if !ok {
+				return nil, false
+			}
+			vals[i] = prop
+		}
+		result[j] = vals
+	}
+	return result, true
+}
 // InterfaceArray returns a []interface{} under the given path.
 func InterfaceArray(json map[string]interface{}, path ...string) ([]interface{}, bool) {
 	return array(json, path...)

--- a/api/ws/pipeline.go
+++ b/api/ws/pipeline.go
@@ -294,7 +294,7 @@ func handleQuery(conn *Connection, client *compute.Client, metadataCtor apiModel
 		MetaStorage: metaStorage,
 		Dataset:     req.DatasetID,
 		TargetName:  req.Target,
-		Filters:     apiModel.NewFilterParamsFromRaw(req.Filters),
+		Filters:     req.Filters,
 	}
 	_, err = task.Query(params)
 	if err != nil {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "store": "^2.0.12",
     "string-similarity": "^4.0.4",
     "ts-enum-util": "^4.0.1",
+    "uuid": "^8.3.2",
     "vue": "^2.6.6",
     "vue-observe-visibility": "^0.4.4",
     "vue-router": "^3.0.6",

--- a/public/components/CreateSolutionsForm.vue
+++ b/public/components/CreateSolutionsForm.vue
@@ -69,7 +69,11 @@ import { Solution } from "../store/requests/index";
 import { SolutionRequestMsg } from "../store/requests/actions";
 import { Variable, DataMode } from "../store/dataset/index";
 import { DATE_TIME_TYPE } from "../util/types";
-import { FilterParams } from "../util/filters";
+import {
+  FilterParams,
+  FilterSetsParams,
+  groupFiltersBySet,
+} from "../util/filters";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 import Vue from "vue";
 
@@ -160,10 +164,16 @@ export default Vue.extend({
       const routeSplit = routeGetters.getRouteTrainTestSplit(this.$store);
       const defaultSplit = appGetters.getTrainTestSplit(this.$store);
       const timestampSplit = routeGetters.getRouteTimestampSplit(this.$store);
-
+      const filterSet = {
+        ...this.filterParams,
+        filters: {
+          list: groupFiltersBySet(this.filterParams.filters.list),
+          invert: this.filterParams.filters.invert,
+        },
+      } as FilterSetsParams;
       const solutionRequestMsg = {
         dataset: this.dataset,
-        filters: this.filterParams,
+        filters: filterSet,
         target: routeGetters.getRouteTargetVariable(this.$store),
         metrics: this.metrics,
         maxSolutions: routeGetters.getModelLimit(this.$store),

--- a/public/components/PredictionsDataSlot.vue
+++ b/public/components/PredictionsDataSlot.vue
@@ -314,6 +314,7 @@ export default Vue.extend({
         minY: data.bounds[1][0],
         mode: INCLUDE_FILTER,
         type: data.type,
+        set: "",
       };
       // fetch surrounding tiles
       await viewActions.updatePredictionAreaOfInterest(this.$store, filter);

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -73,7 +73,7 @@
         <save-modal
           :solution-id="solutionId"
           :fitted-solution-id="fittedSolutionId"
-          @save="onModelSave"
+          @save="onSaveModel"
         />
         <b-button
           variant="success"

--- a/public/components/ResultsDataSlot.vue
+++ b/public/components/ResultsDataSlot.vue
@@ -359,6 +359,7 @@ export default Vue.extend({
         minY: data.bounds[1][0],
         mode: INCLUDE_FILTER,
         type: data.type,
+        set: "",
       };
       // fetch surrounding tiles
       await viewActions.updateResultAreaOfInterest(this.$store, filter);

--- a/public/components/SelectGeoPlot.vue
+++ b/public/components/SelectGeoPlot.vue
@@ -126,6 +126,7 @@ export default Vue.extend({
         minY: data.bounds[1][0],
         mode: EXCLUDE_FILTER,
         type: data.type,
+        set: "",
       };
       // fetch area of interests
       await viewActions.updateAreaOfInterest(this.$store, filter);

--- a/public/components/labelingComponents/LabelGeoplot.vue
+++ b/public/components/labelingComponents/LabelGeoplot.vue
@@ -158,6 +158,7 @@ export default Vue.extend({
         minY: data.bounds[1][0],
         mode: INCLUDE_FILTER,
         type: data.type,
+        set: "",
       };
       // fetch area of interests
       await viewActions.updateAreaOfInterest(this.$store, filter);

--- a/public/store/predictions/actions.ts
+++ b/public/store/predictions/actions.ts
@@ -153,6 +153,7 @@ export const actions = {
     }
   ) {
     const filterParamsBlank = emptyFilterParamsObject();
+    filterParamsBlank.filters.list.push(args.filter);
     const filterParams = addHighlightToFilterParams(
       filterParamsBlank,
       args.highlights
@@ -161,7 +162,6 @@ export const actions = {
     if (_.isInteger(args.size)) {
       filterParams.size = args.size;
     }
-    filterParams.filters.list.push(args.filter);
     try {
       const response = await axios.post(
         `/distil/prediction-results/${encodeURIComponent(
@@ -189,6 +189,7 @@ export const actions = {
     }
   ) {
     const filterParamsBlank = emptyFilterParamsObject();
+    filterParamsBlank.filters.list.push(args.filter);
     const filterParams = addHighlightToFilterParams(
       filterParamsBlank,
       args.highlights,
@@ -198,7 +199,6 @@ export const actions = {
     if (_.isInteger(args.size)) {
       filterParams.size = args.size;
     }
-    filterParams.filters.list.push(args.filter);
     // if highlight is null there is nothing to invert so return null
     if (
       filterParams.highlights === null &&
@@ -249,16 +249,12 @@ export const actions = {
       return null;
     }
 
-    let filterParams = {
-      highlights: { list: [], invert: false },
-      variables: [],
-      filters: { list: [], invert: false },
-    } as FilterParams;
-    filterParams = addHighlightToFilterParams(filterParams, args.highlights);
+    const filterParams = emptyFilterParamsObject();
+    const filterSet = addHighlightToFilterParams(filterParams, args.highlights);
     try {
       const response = await axios.post(
         `/distil/training-summary/${args.dataset}/${args.variable.key}/${args.resultID}/${args.varMode}`,
-        filterParams
+        filterSet
       );
       const summary = response.data.summary;
       await fetchSummaryExemplars(args.dataset, args.variable.key, summary);
@@ -289,13 +285,13 @@ export const actions = {
     }
   ) {
     let filterParams = emptyFilterParamsObject();
-    filterParams = addHighlightToFilterParams(filterParams, args.highlights);
+    const filterSet = addHighlightToFilterParams(filterParams, args.highlights);
     const mutator = args.isBaseline
       ? mutations.setBaselinePredictionTableData
       : mutations.setIncludedPredictionTableData;
     // Add the size limit to results if provided.
     if (_.isInteger(args.size)) {
-      filterParams.size = args.size;
+      filterSet.size = args.size;
     }
 
     try {
@@ -303,7 +299,7 @@ export const actions = {
         `distil/prediction-results/${encodeURIComponent(
           args.produceRequestId
         )}`,
-        filterParams
+        filterSet
       );
       mutator(context, response.data);
     } catch (error) {
@@ -351,7 +347,7 @@ export const actions = {
     }
 
     let filterParams = emptyFilterParamsObject();
-    filterParams = addHighlightToFilterParams(filterParams, args.highlights);
+    const filterSet = addHighlightToFilterParams(filterParams, args.highlights);
 
     const endpoint = `/distil/prediction-result-summary`;
     const key = predictions.predictedKey;
@@ -364,7 +360,7 @@ export const actions = {
       label,
       predictionGetters.getPredictionSummaries(context),
       mutations.updatePredictedSummary,
-      filterParams,
+      filterSet,
       args.varMode
     );
   },

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -19,7 +19,7 @@ import axios from "axios";
 import _ from "lodash";
 import { ActionContext } from "vuex";
 import { validateArgs } from "../../util/data";
-import { FilterParams } from "../../util/filters";
+import { FilterParams, FilterSetsParams } from "../../util/filters";
 import { getWebSocketConnection, Stream } from "../../util/ws";
 import { SummaryMode, TaskTypes } from "../dataset";
 import { actions as predictActions } from "../predictions/module";
@@ -40,7 +40,7 @@ import {
   SolutionRequestStatus,
   SolutionStatus,
 } from "./index";
-import { setInvert, cloneFilters } from "../../util/highlights";
+import { setInvert, cloneFilters, cloneFilterSet } from "../../util/highlights";
 import { mutations } from "./module";
 
 // Message definitions for the websocket.  These are only for communication with the
@@ -65,7 +65,7 @@ interface StatusMessage {
 // Search request message used in web socket context
 export interface SolutionRequestMsg {
   dataset: string;
-  filters: FilterParams;
+  filters: FilterSetsParams;
   metrics: string[];
   maxSolutions: number;
   maxTime: number;
@@ -530,7 +530,7 @@ export const actions = {
   createSolutionRequest(context: RequestContext, request: SolutionRequestMsg) {
     return new Promise((resolve, reject) => {
       const conn = getWebSocketConnection();
-      const filters = cloneFilters(request.filters);
+      const filters = cloneFilterSet(request.filters);
       request.filters = setInvert(filters, false);
       let receivedFirstSolution = false;
 

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -393,6 +393,7 @@ export const actions = {
     }
 
     const filterParamsBlank = emptyFilterParamsObject();
+    filterParamsBlank.filters.list.push(args.filter);
     const filterParams = addHighlightToFilterParams(
       filterParamsBlank,
       args.highlights
@@ -403,7 +404,7 @@ export const actions = {
     if (_.isInteger(args.size)) {
       filterParams.size = args.size;
     }
-    filterParams.filters.list.push(args.filter);
+
     try {
       const response = await axios.post(
         `/distil/results/${args.dataset}/${encodeURIComponent(
@@ -441,6 +442,7 @@ export const actions = {
     }
 
     const filterParamsBlank = emptyFilterParamsObject();
+    filterParamsBlank.filters.list.push(args.filter);
     const filterParams = addHighlightToFilterParams(
       filterParamsBlank,
       args.highlights,
@@ -453,7 +455,6 @@ export const actions = {
     if (_.isInteger(args.size)) {
       filterParams.size = args.size;
     }
-    filterParams.filters.list.push(args.filter);
     // if highlight is null there is nothing to invert so return null
     if (
       filterParams.highlights === null &&

--- a/public/util/data.ts
+++ b/public/util/data.ts
@@ -89,7 +89,7 @@ import {
   TIMESERIES_TYPE,
 } from "../util/types";
 import { Dictionary } from "./dict";
-import { FilterParams } from "./filters";
+import { FilterParams, FilterSetsParams } from "./filters";
 import { overlayRouteEntry } from "./routes";
 
 // Postfixes for special variable names
@@ -628,7 +628,7 @@ export async function fetchSolutionResultSummary(
   resultProperty: string,
   resultSummaries: VariableSummary[],
   updateFunction: (arg: ResultsContext, summary: VariableSummary) => void,
-  filterParams: FilterParams,
+  filterParams: FilterParams | FilterSetsParams,
   varMode: SummaryMode
 ): Promise<any> {
   const dataset = solution.dataset;
@@ -692,7 +692,7 @@ export async function fetchPredictionResultSummary(
   label: string,
   resultSummaries: VariableSummary[],
   updateFunction: (arg: PredictionContext, summary: VariableSummary) => void,
-  filterParams: FilterParams,
+  filterParams: FilterParams | FilterSetsParams,
   varMode: SummaryMode
 ): Promise<any> {
   const dataset = predictions.dataset;

--- a/public/util/lex.ts
+++ b/public/util/lex.ts
@@ -567,6 +567,7 @@ export function lexQueryToFiltersAndHighlight(
           displayName: displayKey,
           type,
           key,
+          set: "",
         };
 
         if (type === GEOBOUNDS_FILTER || type === GEOCOORDINATE_FILTER) {

--- a/public/util/row.ts
+++ b/public/util/row.ts
@@ -60,6 +60,7 @@ export function createFilterFromRowSelection(
     type: ROW_FILTER,
     mode: mode,
     d3mIndices: selection.d3mIndices.map((num) => _.toString(num)),
+    set: "",
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6414,6 +6414,11 @@ utila@~0.4:
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"


### PR DESCRIPTION
- This branch contains the code required to move the front end filters to align with the back end expectation
- This branch removed: FilterParamsRaw (this is no longer needed it was used as the glue previously), the sorting of filters by key when parsing on the backend (very old code no longer necessary)
- DoubleArray json util was added as the exclude filters are sent from the client in a double array now
- Each array is considered 1 set of exclusion
- The front end keeps track of what filters were excluded together by creating a UUID 
- The UUID is stored in the **set** property in the filters interface
- Added UUID dependency
- closes #2475