### PR TITLE
Semi Supervised Remote Sensing Pretrained

### DIFF
--- a/api/compute/filter.go
+++ b/api/compute/filter.go
@@ -38,7 +38,7 @@ func filterData(client *compute.Client, ds *api.Dataset, filterParams *api.Filte
 	log.Infof("checking if solution search for dataset %s found in '%s' needs prefiltering", ds.ID, inputPath)
 	// determine if filtering is needed
 	updatedParams, preFilters := getPreFiltering(ds, filterParams)
-	if preFilters.Empty(false) {
+	if preFilters.IsEmpty(false) {
 		log.Infof("solution request for dataset %s does not need prefiltering", ds.ID)
 		return inputPath, updatedParams, nil
 	}

--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -170,8 +170,8 @@ func (f *FilterParams) AddFilter(filter *model.Filter) {
 	})
 }
 
-// Empty returns if the filter set is empty.
-func (f *FilterParams) Empty(ignoreBaselineFilters bool) bool {
+// IsEmpty returns true if the filter set is empty.
+func (f *FilterParams) IsEmpty(ignoreBaselineFilters bool) bool {
 	for _, set := range f.Filters {
 		for _, filters := range set.FeatureFilters {
 			for _, filter := range filters.List {

--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -109,7 +109,7 @@ type DataStorage interface {
 	AddVariable(dataset string, storageName string, varName string, varType string, defaultVal string) error
 	AddField(dataset string, storageName string, varName string, varType string, defaultVal string) error
 	DeleteVariable(dataset string, storageName string, varName string) error
-	SetVariableValue(storageName string, varName string, value string) error
+	SetVariableValue(dataset string, storageName string, varName string, value string, filterParams *FilterParams) error
 	UpdateVariableBatch(storageName string, varName string, updates map[string]string) error
 	UpdateData(dataset string, storageName string, varName string, updates map[string]string, filterParams *FilterParams) error
 	DoesVariableExist(dataset string, storageName string, varName string) (bool, error)

--- a/api/model/storage/postgres/bounds.go
+++ b/api/model/storage/postgres/bounds.go
@@ -81,7 +81,7 @@ func (f *BoundsField) FetchSummaryData(resultURI string, filterParams *api.Filte
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams, coordinateBuckets)
 			if err != nil {
 				return nil, err
@@ -92,7 +92,7 @@ func (f *BoundsField) FetchSummaryData(resultURI string, filterParams *api.Filte
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams, coordinateBuckets)
 			if err != nil {
 				return nil, err

--- a/api/model/storage/postgres/categorical.go
+++ b/api/model/storage/postgres/categorical.go
@@ -89,7 +89,7 @@ func (f *CategoricalField) FetchSummaryData(resultURI string, filterParams *api.
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams)
 			if err != nil {
 				return nil, err
@@ -100,7 +100,7 @@ func (f *CategoricalField) FetchSummaryData(resultURI string, filterParams *api.
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams)
 			if err != nil {
 				return nil, err
@@ -288,7 +288,7 @@ func (f *CategoricalField) FetchPredictedSummaryData(resultURI string, datasetRe
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = f.fetchPredictedSummaryData(resultURI, datasetResult, filterParams, extrema)
 		if err != nil {
 			return nil, err

--- a/api/model/storage/postgres/confidence.go
+++ b/api/model/storage/postgres/confidence.go
@@ -53,7 +53,7 @@ func (s *Storage) FetchConfidenceSummary(dataset string, storageName string, res
 		if baseline == nil {
 			continue
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = s.fetchExplainHistogram(dataset, storageName, targetName, explainName, resultURI, filterParams, mode)
 			if err != nil {
 				return nil, err

--- a/api/model/storage/postgres/coordinate.go
+++ b/api/model/storage/postgres/coordinate.go
@@ -71,7 +71,7 @@ func (f *CoordinateField) FetchSummaryData(resultURI string, filterParams *api.F
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams, coordinateBuckets)
 			if err != nil {
 				return nil, err
@@ -82,7 +82,7 @@ func (f *CoordinateField) FetchSummaryData(resultURI string, filterParams *api.F
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams, coordinateBuckets)
 			if err != nil {
 				return nil, err

--- a/api/model/storage/postgres/correctness.go
+++ b/api/model/storage/postgres/correctness.go
@@ -45,7 +45,7 @@ func (s *Storage) FetchCorrectnessSummary(dataset string, storageName string, re
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = s.fetchHistogram(dataset, storageName, variable, targetName, resultURI, filterParams, mode)
 		if err != nil {
 			return nil, err

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -50,12 +50,8 @@ func getVariableTableName(storageName string) string {
 
 // SaveDataset is used for dropping the unused values based on filter param. (Only used in save_dataset route)
 func (s *Storage) SaveDataset(dataset string, storageName string, filterParams *api.FilterParams) error {
-	err := s.deleteRows(dataset, getBaseTableName(storageName), filterParams)
-	if err != nil {
-		return err
-	}
 	// due to values being dropped from base table result table is invalid
-	err = s.deleteRows(dataset, s.getResultTable(storageName), nil)
+	err := s.deleteRows(dataset, s.getResultTable(storageName), nil)
 	if err != nil {
 		return err
 	}
@@ -63,6 +59,13 @@ func (s *Storage) SaveDataset(dataset string, storageName string, filterParams *
 	err = s.deleteRows(dataset, s.getSolutionFeatureWeightTable(storageName), nil)
 	if err != nil {
 		return err
+	}
+
+	if !filterParams.IsEmpty(false) {
+		err = s.deleteRows(dataset, getBaseTableName(storageName), filterParams)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -90,7 +90,7 @@ func (f *DateTimeField) FetchSummaryData(resultURI string, filterParams *api.Fil
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams, api.MaxNumBuckets)
 			if err != nil {
 				return nil, err
@@ -101,7 +101,7 @@ func (f *DateTimeField) FetchSummaryData(resultURI string, filterParams *api.Fil
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams, extrema, api.MaxNumBuckets)
 			if err != nil {
 				return nil, err
@@ -400,7 +400,7 @@ func (f *DateTimeField) FetchPredictedSummaryData(resultURI string, datasetResul
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = f.fetchPredictedSummaryData(resultURI, datasetResult, filterParams, extrema, api.MaxNumBuckets)
 		if err != nil {
 			return nil, err

--- a/api/model/storage/postgres/field.go
+++ b/api/model/storage/postgres/field.go
@@ -110,7 +110,7 @@ func createJoinStatements(joins []*joinDefinition) string {
 // cluster column ID to ensure that it is used in downstream queries.  This is necessary when dealing with the timerseries
 // compound facet, which will display cluster info when available.
 func updateClusterFilters(metadataStorage api.MetadataStorage, dataset string, filterParams *api.FilterParams, mode api.SummaryMode) error {
-	if filterParams != nil && !filterParams.Empty(false) {
+	if filterParams != nil && !filterParams.IsEmpty(false) {
 		for _, s := range filterParams.Filters {
 			for _, f := range s.FeatureFilters {
 				for _, h := range f.List {

--- a/api/model/storage/postgres/image.go
+++ b/api/model/storage/postgres/image.go
@@ -66,7 +66,7 @@ func (f *ImageField) FetchSummaryData(resultURI string, filterParams *api.Filter
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams, mode)
 			if err != nil {
 				return nil, err
@@ -77,7 +77,7 @@ func (f *ImageField) FetchSummaryData(resultURI string, filterParams *api.Filter
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams, mode)
 			if err != nil {
 				return nil, err
@@ -295,7 +295,7 @@ func (f *ImageField) FetchPredictedSummaryData(resultURI string, datasetResult s
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = f.fetchPredictedSummaryData(resultURI, datasetResult, filterParams, extrema, mode)
 		if err != nil {
 			return nil, err

--- a/api/model/storage/postgres/multibandimage.go
+++ b/api/model/storage/postgres/multibandimage.go
@@ -71,7 +71,7 @@ func (f *MultiBandImageField) FetchSummaryData(resultURI string, filterParams *a
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams, mode)
 			if err != nil {
 				return nil, err
@@ -82,7 +82,7 @@ func (f *MultiBandImageField) FetchSummaryData(resultURI string, filterParams *a
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams, mode)
 			if err != nil {
 				return nil, err
@@ -299,7 +299,7 @@ func (f *MultiBandImageField) FetchPredictedSummaryData(resultURI string, datase
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = f.fetchPredictedSummaryData(resultURI, datasetResult, filterParams, extrema, mode)
 		if err != nil {
 			return nil, err

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -97,7 +97,7 @@ func (f *NumericalField) FetchSummaryData(resultURI string, filterParams *api.Fi
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams, api.MaxNumBuckets)
 			if err != nil {
 				return nil, err
@@ -108,7 +108,7 @@ func (f *NumericalField) FetchSummaryData(resultURI string, filterParams *api.Fi
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams, extrema, api.MaxNumBuckets)
 			if err != nil {
 				return nil, err
@@ -442,7 +442,7 @@ func (f *NumericalField) FetchPredictedSummaryData(resultURI string, datasetResu
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = f.fetchPredictedSummaryData(resultURI, datasetResult, filterParams, extrema, api.MaxNumBuckets)
 		if err != nil {
 			return nil, err

--- a/api/model/storage/postgres/residual.go
+++ b/api/model/storage/postgres/residual.go
@@ -61,7 +61,7 @@ func (s *Storage) FetchResidualsSummary(dataset string, storageName string, resu
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = s.fetchResidualsSummary(dataset, storageName, variable, resultURI, filterParams, extrema, api.MaxNumBuckets, mode)
 		if err != nil {
 			return nil, err

--- a/api/model/storage/postgres/text.go
+++ b/api/model/storage/postgres/text.go
@@ -65,7 +65,7 @@ func (f *TextField) FetchSummaryData(resultURI string, filterParams *api.FilterP
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams)
 			if err != nil {
 				return nil, err
@@ -76,7 +76,7 @@ func (f *TextField) FetchSummaryData(resultURI string, filterParams *api.FilterP
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams)
 			if err != nil {
 				return nil, err
@@ -229,7 +229,7 @@ func (f *TextField) FetchPredictedSummaryData(resultURI string, datasetResult st
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = f.fetchPredictedSummaryData(resultURI, datasetResult, filterParams, extrema)
 		if err != nil {
 			return nil, err

--- a/api/model/storage/postgres/timeseries.go
+++ b/api/model/storage/postgres/timeseries.go
@@ -574,7 +574,7 @@ func (f *TimeSeriesField) FetchSummaryData(resultURI string, filterParams *api.F
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogram(filterParams, mode)
 			if err != nil {
 				return nil, err
@@ -585,7 +585,7 @@ func (f *TimeSeriesField) FetchSummaryData(resultURI string, filterParams *api.F
 		if err != nil {
 			return nil, err
 		}
-		if !filterParams.Empty(true) {
+		if !filterParams.IsEmpty(true) {
 			filtered, err = f.fetchHistogramByResult(resultURI, filterParams, mode)
 			if err != nil {
 				return nil, err
@@ -854,7 +854,7 @@ func (f *TimeSeriesField) FetchPredictedSummaryData(resultURI string, datasetRes
 	if err != nil {
 		return nil, err
 	}
-	if !filterParams.Empty(true) {
+	if !filterParams.IsEmpty(true) {
 		filtered, err = f.fetchPredictedSummaryData(resultURI, datasetResult, filterParams, extrema, mode)
 		if err != nil {
 			return nil, err

--- a/api/routes/clear.go
+++ b/api/routes/clear.go
@@ -64,6 +64,10 @@ func ClearHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCtor
 			handleError(w, err)
 			return
 		}
+		if ds.Immutable {
+			handleError(w, errors.New("can not mutate an immutable dataset"))
+			return
+		}
 
 		// replace any grouped variables in filter params with the group's
 		expandedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, metaStorage)

--- a/api/routes/clear.go
+++ b/api/routes/clear.go
@@ -1,0 +1,91 @@
+//
+//   Copyright © 2021 Uncharted Software Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package routes
+
+import (
+	"net/http"
+
+	"github.com/pkg/errors"
+	"goji.io/v3/pat"
+
+	api "github.com/uncharted-distil/distil/api/model"
+)
+
+// ClearHandler generates a route handler that enables the clearing of variable,
+// optionally being able to specify filter params.
+func ClearHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageCtor) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// get dataset name
+		dataset := pat.Param(r, "dataset")
+		// get variable key
+		variableKey := pat.Param(r, "variable")
+
+		// parse update list
+		params, err := getPostParameters(r)
+		if err != nil {
+			handleError(w, errors.Wrap(err, "Unable to parse post parameters"))
+			return
+		}
+		// get variable names and ranges out of the params
+		filterParams, err := api.ParseFilterParamsFromJSON(params)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// get storage clients
+		metaStorage, err := metaCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+		dataStorage, err := dataCtor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// need the storage name
+		ds, err := metaStorage.FetchDataset(dataset, false, false, false)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// replace any grouped variables in filter params with the group's
+		expandedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, metaStorage)
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable to expand filter params"))
+			return
+		}
+
+		// need to change unlabeled to empty string
+		err = dataStorage.SetVariableValue(dataset, ds.StorageName, variableKey, "", expandedFilterParams)
+		if err != nil {
+			handleError(w, err)
+			return
+		}
+
+		// marshal output into JSON
+		err = handleJSON(w, map[string]interface{}{
+			"result": "success",
+		})
+		if err != nil {
+			handleError(w, errors.Wrap(err, "unable marshal clustering result into JSON"))
+			return
+		}
+	}
+}

--- a/api/routes/delete.go
+++ b/api/routes/delete.go
@@ -23,7 +23,7 @@ import (
 	api "github.com/uncharted-distil/distil/api/model"
 )
 
-// DeleteHandler inserts a new field based on existing fields.
+// DeleteHandler deletes a field from the data storage and the metadata storage.
 func DeleteHandler(dataCtor api.DataStorageCtor, esMetaCtor api.MetadataStorageCtor) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		dataset := pat.Param(r, "dataset")

--- a/api/routes/save_dataset.go
+++ b/api/routes/save_dataset.go
@@ -78,17 +78,15 @@ func SaveDatasetHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStora
 			return
 		}
 
-		// export needs to invert the filters
-		expandedFilterParams.InvertFilters()
-		_, _, err = task.ExportDataset(dataset, metaStorage, dataStorage, expandedFilterParams)
+		// delete rows based on filterParams
+		err = dataStorage.SaveDataset(dataset, ds.StorageName, expandedFilterParams)
 		if err != nil {
 			handleError(w, err)
 			return
 		}
-		expandedFilterParams.InvertFilters()
 
-		// delete rows based on filterParams
-		err = dataStorage.SaveDataset(dataset, ds.StorageName, expandedFilterParams)
+		// export the resulting data
+		_, _, err = task.ExportDataset(dataset, metaStorage, dataStorage, nil)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/task/query.go
+++ b/api/task/query.go
@@ -236,7 +236,7 @@ func persistQueryResults(params QueryParams, storageName string, resultData [][]
 		}
 
 	} else {
-		err = params.DataStorage.SetVariableValue(storageName, targetScore, "0.0")
+		err = params.DataStorage.SetVariableValue(params.Dataset, storageName, targetScore, "0.0", nil)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -283,6 +283,7 @@ func main() {
 	registerRoutePost(mux, "/distil/prediction-result-summary/:results-uuid/:mode", routes.PredictionResultSummaryHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/solution-result-summary/:results-uuid/:mode", routes.SolutionResultSummaryHandler(esMetadataStorageCtor, pgSolutionStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/geocode/:dataset/:variable", routes.GeocodingHandler(esMetadataStorageCtor, pgDataStorageCtor))
+	registerRoutePost(mux, "/distil/clear/:dataset/:variable", routes.ClearHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/cluster/:dataset/:variable", routes.ClusteringHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/cluster/:result-id", routes.ClusteringExplainHandler(pgSolutionStorageCtor, esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/upload/:dataset", routes.UploadHandler(&config))

--- a/public/components/labelingComponents/SaveDataset.vue
+++ b/public/components/labelingComponents/SaveDataset.vue
@@ -42,6 +42,9 @@
             :value="datasetName"
             required
           />
+          <b-form-checkbox v-model="retainUnlabeled" class="pt-2">
+            Retain unlabeled rows
+          </b-form-checkbox>
         </b-form-group>
       </form>
     </b-modal>
@@ -87,6 +90,7 @@ export default Vue.extend({
     return {
       saveName: "",
       saveNameState: null,
+      retainUnlabeled: false,
     };
   },
 
@@ -144,7 +148,7 @@ export default Vue.extend({
 
     // save model
     async saveDataset() {
-      this.$emit("save", this.saveName);
+      this.$emit("save", this.saveName, this.retainUnlabeled);
     },
 
     // ensure required fields are filled out

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -692,7 +692,7 @@ export const actions = {
       highlights: Highlight[];
       filterParams: FilterParams;
     }
-  ): Promise<[void[], void[]]> {
+  ): Promise<[void, void]> {
     if (!validateArgs(args, ["dataset", "key"])) {
       return null;
     }
@@ -735,7 +735,7 @@ export const actions = {
   async deleteVariable(
     context: DatasetContext,
     args: { dataset: string; key: string }
-  ): Promise<[void[], void[]]> {
+  ): Promise<[void, void]> {
     if (!validateArgs(args, ["dataset", "key"])) {
       return null;
     }

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -684,6 +684,43 @@ export const actions = {
     }
   },
 
+  async clearVariable(
+    context: DatasetContext,
+    args: { dataset: string; key: string; highlights: Highlight[] }
+  ): Promise<any> {
+    if (!validateArgs(args, ["dataset", "key"])) {
+      return null;
+    }
+    try {
+      await axios.post(
+        `/distil/clear/${args.dataset}/${args.key}`,
+        args.highlights
+      );
+      return Promise.all([
+        actions.fetchVariableSummary(context, {
+          dataset: args.dataset,
+          variable: args.key,
+          filterParams: null,
+          highlights: null,
+          include: true,
+          dataMode: DataMode.Default,
+          mode: SummaryMode.Default,
+        }),
+        actions.fetchVariableSummary(context, {
+          dataset: args.dataset,
+          variable: args.key,
+          filterParams: null,
+          highlights: null,
+          include: false,
+          dataMode: DataMode.Default,
+          mode: SummaryMode.Default,
+        }),
+      ]);
+    } catch (error) {
+      console.error(error);
+    }
+  },
+
   async deleteVariable(
     context: DatasetContext,
     args: { dataset: string; key: string }

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -735,7 +735,7 @@ export const actions = {
   async deleteVariable(
     context: DatasetContext,
     args: { dataset: string; key: string }
-  ): Promise<[void, void]> {
+  ): Promise<[void[], void[]]> {
     if (!validateArgs(args, ["dataset", "key"])) {
       return null;
     }

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -686,22 +686,33 @@ export const actions = {
 
   async clearVariable(
     context: DatasetContext,
-    args: { dataset: string; key: string; highlights: Highlight[] }
+    args: {
+      dataset: string;
+      key: string;
+      highlights: Highlight[];
+      filterParams: FilterParams;
+    }
   ): Promise<any> {
     if (!validateArgs(args, ["dataset", "key"])) {
       return null;
     }
+    let filterParams = addHighlightToFilterParams(
+      args.filterParams,
+      args.highlights
+    );
+    filterParams = setInvert(filterParams, false);
+
     try {
       await axios.post(
         `/distil/clear/${args.dataset}/${args.key}`,
-        args.highlights
+        filterParams
       );
       return Promise.all([
         actions.fetchVariableSummary(context, {
           dataset: args.dataset,
           variable: args.key,
-          filterParams: null,
-          highlights: null,
+          filterParams: args.filterParams,
+          highlights: args.highlights,
           include: true,
           dataMode: DataMode.Default,
           mode: SummaryMode.Default,
@@ -709,8 +720,8 @@ export const actions = {
         actions.fetchVariableSummary(context, {
           dataset: args.dataset,
           variable: args.key,
-          filterParams: null,
-          highlights: null,
+          filterParams: args.filterParams,
+          highlights: args.highlights,
           include: false,
           dataMode: DataMode.Default,
           mode: SummaryMode.Default,

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -692,7 +692,7 @@ export const actions = {
       highlights: Highlight[];
       filterParams: FilterParams;
     }
-  ): Promise<any> {
+  ): Promise<[void[], void[]]> {
     if (!validateArgs(args, ["dataset", "key"])) {
       return null;
     }
@@ -735,7 +735,7 @@ export const actions = {
   async deleteVariable(
     context: DatasetContext,
     args: { dataset: string; key: string }
-  ): Promise<any> {
+  ): Promise<[void[], void[]]> {
     if (!validateArgs(args, ["dataset", "key"])) {
       return null;
     }

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -123,6 +123,7 @@ export const actions = {
   importDataset: dispatch(moduleActions.importDataset),
   importFullDataset: dispatch(moduleActions.importFullDataset),
   importAvailableDataset: dispatch(moduleActions.importAvailableDataset),
+  clearVariable: dispatch(moduleActions.clearVariable),
   deleteVariable: dispatch(moduleActions.deleteVariable),
   setGrouping: dispatch(moduleActions.setGrouping),
   removeGrouping: dispatch(moduleActions.removeGrouping),

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -459,12 +459,14 @@ export default Vue.extend({
         });
       }
       // clear the unlabeled values when saving
-      await datasetActions.clearVariable(this.$store, {
-        dataset: this.dataset,
-        key: this.labelName,
-        highlights: highlightsClear,
-        filterParams: filterParams,
-      });
+      if (retainUnlabeled) {
+        await datasetActions.clearVariable(this.$store, {
+          dataset: this.dataset,
+          key: this.labelName,
+          highlights: highlightsClear,
+          filterParams: filterParams,
+        });
+      }
       const dataMode = routeGetters.getDataMode(this.$store);
       await datasetActions.saveDataset(this.$store, {
         dataset: this.dataset,

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -459,6 +459,12 @@ export default Vue.extend({
           key: this.labelScoreName,
         });
       }
+      // clear the unlabeled values when saving
+      await datasetActions.clearVariable(this.$store, {
+        dataset: this.dataset,
+        key: this.labelName,
+        highlights: null,
+      });
       const dataMode = routeGetters.getDataMode(this.$store);
       await datasetActions.saveDataset(this.$store, {
         dataset: this.dataset,

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -434,16 +434,15 @@ export default Vue.extend({
       this.$bvModal.show("save-model-modal");
     },
     async onSaveValid(saveName: string, retainUnlabeled: boolean) {
-      const highlights = retainUnlabeled
-        ? null
-        : [
-            {
-              context: this.instance,
-              dataset: this.dataset,
-              key: this.labelName,
-              value: LowShotLabels.unlabeled,
-            },
-          ]; // exclude unlabeled from data export
+      const highlightsClear = [
+        {
+          context: this.instance,
+          dataset: this.dataset,
+          key: this.labelName,
+          value: LowShotLabels.unlabeled,
+        },
+      ]; // exclude unlabeled from data export
+      const highlights = retainUnlabeled ? null : highlightsClear;
       let filterParams = routeGetters.getDecodedSolutionRequestFilterParams(
         this.$store
       );
@@ -463,7 +462,8 @@ export default Vue.extend({
       await datasetActions.clearVariable(this.$store, {
         dataset: this.dataset,
         key: this.labelName,
-        highlights: null,
+        highlights: highlightsClear,
+        filterParams: filterParams,
       });
       const dataMode = routeGetters.getDataMode(this.$store);
       await datasetActions.saveDataset(this.$store, {

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -433,15 +433,17 @@ export default Vue.extend({
     onSaveClick() {
       this.$bvModal.show("save-model-modal");
     },
-    async onSaveValid(saveName: string) {
-      const highlights = [
-        {
-          context: this.instance,
-          dataset: this.dataset,
-          key: this.labelName,
-          value: LowShotLabels.unlabeled,
-        },
-      ]; // exclude unlabeled from data export
+    async onSaveValid(saveName: string, retainUnlabeled: boolean) {
+      const highlights = retainUnlabeled
+        ? null
+        : [
+            {
+              context: this.instance,
+              dataset: this.dataset,
+              key: this.labelName,
+              value: LowShotLabels.unlabeled,
+            },
+          ]; // exclude unlabeled from data export
       let filterParams = routeGetters.getDecodedSolutionRequestFilterParams(
         this.$store
       );


### PR DESCRIPTION
The user can now retain unlabeled rows when saving a user labeled dataset. This then allows them to create a semi supervised model on the resulting dataset. 

To support this work, a new route was created that will clear a field's values in the data storage (filter parameters can be provided to limit the scope of the rows cleared). This new route gets called just before the save call. The clear is needed because the semi supervised learning only works if some of the data is empty. Not clearing the field would instead have turned it into a multiclassification task, with possible classes being positive, negative, and unlabeled.