### PR TITLE
FilterParams Merge Removal

### DIFF
--- a/api/routes/prediction_results.go
+++ b/api/routes/prediction_results.go
@@ -95,11 +95,11 @@ func PredictionResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api
 		}
 
 		// merge provided filterParams with those of the request
-		req.Filters.MergeParams(filterParams)
+		filterParams.Variables = req.Filters.Variables
 
 		// Expand any grouped variables defined in filters into their subcomponents
 		dataset := predictResult.Dataset
-		updatedFilterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
+		updatedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/results.go
+++ b/api/routes/results.go
@@ -93,9 +93,9 @@ func ResultsHandler(solutionCtor api.SolutionStorageCtor, dataCtor api.DataStora
 		}
 
 		// merge provided filterParams with those of the request
-		req.Filters.MergeParams(filterParams)
+		filterParams.Variables = req.Filters.Variables
 		// Expand any grouped variables defined in filters into their subcomponents
-		updatedFilterParams, err := api.ExpandFilterParams(dataset, req.Filters, false, meta)
+		updatedFilterParams, err := api.ExpandFilterParams(dataset, filterParams, false, meta)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -345,6 +345,7 @@ export const actions = {
     const filterParams = addHighlightToFilterParams(
       filterParamsBlank,
       args.highlights,
+      EXCLUDE_FILTER,
       EXCLUDE_FILTER
     );
 

--- a/public/util/filters.ts
+++ b/public/util/filters.ts
@@ -138,6 +138,7 @@ export interface FilterSetsParams {
 export interface FilterObject {
   list: Filter[];
   invert?: boolean;
+  mode?: string;
 }
 
 export interface FilterSet {

--- a/public/util/highlights.ts
+++ b/public/util/highlights.ts
@@ -317,12 +317,14 @@ export function setFilterModes(
 export function addHighlightToFilterParams(
   filterParams: FilterParams,
   highlights: Highlight[],
-  mode: string = INCLUDE_FILTER
+  mode: string = INCLUDE_FILTER,
+  highlightMode: string = INCLUDE_FILTER
 ): FilterSetsParams {
   const params = _.cloneDeep(filterParams);
   const highlightFilters = createFiltersFromHighlights(highlights, mode);
   if (highlightFilters.length > 0) {
     params.highlights.list = highlightFilters;
+    params.highlights.mode = highlightMode;
   }
 
   return {


### PR DESCRIPTION
Fixes #2558 

The merge function was not needed as the request filters are embedded in the pipeline anyways so will never appear in the results. The only use of the function was to get the variables from the request, which can be done by setting them specifically.

A mode was added to `FilterObject` on the client to allow the client to specify if the highlight should be inclusive or exclusive.