### PR TITLE
Missing Error Checking

### DIFF
--- a/api/model/filter.go
+++ b/api/model/filter.go
@@ -425,6 +425,9 @@ func parseFilter(filter map[string]interface{}) (*model.Filter, error) {
 		if !ok {
 			return nil, errors.Errorf("no `categories` provided for filter")
 		}
+		if len(categories) == 0 {
+			return nil, errors.Errorf("empty set of categories provided for filter")
+		}
 		return model.NewCategoricalFilter(key, mode, categories), nil
 	}
 

--- a/api/routes/solution_result_summary.go
+++ b/api/routes/solution_result_summary.go
@@ -129,6 +129,10 @@ func SolutionResultSummaryHandler(metaCtor api.MetadataStorageCtor, solutionCtor
 			handleError(w, err)
 			return
 		}
+		if res == nil {
+			handleError(w, errors.Errorf("unrecognized result uuid supplied"))
+			return
+		}
 
 		// Fetch the request so we have access to the original parameters.
 		request, err := solution.FetchRequestBySolutionID(res.SolutionID)


### PR DESCRIPTION
The broken filtering of the result facets led to the identification of some poor error checking in a couple of routes. At least now the server will not panic if bad data is passed in.