### PR TITLE
Check soft delete

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -198,6 +198,7 @@ type MetadataStorage interface {
 	DeleteDataset(dataset string, softDelete bool) error
 	IngestDataset(datasetSource metadata.DatasetSource, meta *model.Metadata) error
 	UpdateDataset(dataset *Dataset) error
+	DatasetExists(dataset string) (bool, error)
 
 	// CloneDataset creates a copy of an existing dataset
 	CloneDataset(dataset string, datasetNew string, storageNameNew string, folderNew string) error

--- a/api/model/storage/datamart/dataset.go
+++ b/api/model/storage/datamart/dataset.go
@@ -78,6 +78,11 @@ func (s *Storage) DeleteDataset(dataset string, softDelete bool) error {
 	return errors.Errorf("Not implemented")
 }
 
+// DatasetExists returns true if a dataset exists.
+func (s *Storage) DatasetExists(dataset string) (bool, error) {
+	return false, errors.Errorf("Not implemented")
+}
+
 // FetchDataset returns a dataset in the provided index.
 func (s *Storage) FetchDataset(datasetName string, includeIndex bool, includeMeta bool, includeSystemData bool) (*api.Dataset, error) {
 	return nil, errors.Errorf("Not implemented")

--- a/api/model/storage/elastic/dataset.go
+++ b/api/model/storage/elastic/dataset.go
@@ -570,11 +570,8 @@ func (s *Storage) DatasetExists(dataset string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if len(datasets) < 1 {
-		return false, nil
-	}
 
-	return true, nil
+	return len(datasets) > 0, nil
 }
 
 // AddGroupedVariable adds a grouping to the metadata.

--- a/api/model/storage/file/dataset.go
+++ b/api/model/storage/file/dataset.go
@@ -59,6 +59,11 @@ func (s *Storage) DeleteDataset(dataset string, softDelete bool) error {
 	return errors.Errorf("Not implemented")
 }
 
+// DatasetExists returns true if a dataset exists.
+func (s *Storage) DatasetExists(dataset string) (bool, error) {
+	return false, errors.Errorf("Not implemented")
+}
+
 // FetchDatasets returns all datasets in the provided index.
 func (s *Storage) FetchDatasets(includeIndex bool, includeMeta bool, includeSystemData bool) ([]*api.Dataset, error) {
 	// use default string in search to get complete list

--- a/api/task/ingest.go
+++ b/api/task/ingest.go
@@ -245,13 +245,13 @@ func IngestDataset(params *IngestParams, config *IngestTaskConfig, steps *Ingest
 	}
 
 	// featurize dataset for downstream efficiencies
-	if config.FeaturizationEnabled && !steps.SkipFeaturization && canFeaturize(params.ID, metaStorage) {
-		_, featurizedDatasetPath, err := FeaturizeDataset(originalSchemaFile, latestSchemaOutput, params.ID, metaStorage, config)
+	if config.FeaturizationEnabled && !steps.SkipFeaturization && canFeaturize(datasetID, metaStorage) {
+		_, featurizedDatasetPath, err := FeaturizeDataset(originalSchemaFile, latestSchemaOutput, datasetID, metaStorage, config)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to featurize dataset")
 		}
 		log.Infof("finished featurizing the dataset")
-		ingestedDataset, err := metaStorage.FetchDataset(params.ID, true, true, false)
+		ingestedDataset, err := metaStorage.FetchDataset(datasetID, true, true, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to load metadata")
 		}


### PR DESCRIPTION
Fixes #2554

Ingest checks to make sure there is no clash with a soft deleted dataset. The dataset id is now what is checked on ingest, with the name being left as is.