### PR TITLE
Satellite + Tabular join fixes

### DIFF
--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -168,6 +168,17 @@ func SetGroups(datasetID string, rawGroupings []map[string]interface{}, data api
 		if err != nil {
 			return err
 		}
+
+		// Make sure we set the role of the multiband image's ID column to grouping as filters need this to run DISTINCT ON
+		idColVariable, err := meta.FetchVariable(datasetID, rsg.GetIDCol())
+		if err != nil {
+			return err
+		}
+		idColVariable.DistilRole = model.VarDistilRoleGrouping
+		err = meta.UpdateVariable(datasetID, rsg.GetIDCol(), idColVariable)
+		if err != nil {
+			return err
+		}
 	}
 
 	geoBoundsGroupings := getGeoBoundsGrouping(rawGroupings)

--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -194,10 +194,20 @@ func SetGroups(datasetID string, rawGroupings []map[string]interface{}, data api
 			return err
 		}
 
+		// confirm that the coordinates col data does exist - it could be that it was removed during the join
+		// process
+		exists, err := data.DoesVariableExist(datasetID, ds.StorageName, grouping.CoordinatesCol)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			continue
+		}
+
 		// confirm the existence of the underlying polygon field, creating it if necessary
 		// (less than ideal because it hides a pretty big side effect)
 		// (other option would be to error here and let calling code worry about it)
-		exists, err := data.DoesVariableExist(datasetID, ds.StorageName, grouping.PolygonCol)
+		exists, err = data.DoesVariableExist(datasetID, ds.StorageName, grouping.PolygonCol)
 		if err != nil {
 			return err
 		}

--- a/api/util/imagery.go
+++ b/api/util/imagery.go
@@ -512,6 +512,10 @@ func SplitMultiBandImage(dataset gdal.Dataset, outputFolder string, bandMapping 
 // CreatePolygonFromCoordinates creates a string that captures the polygon defined
 // by the coordinates.
 func CreatePolygonFromCoordinates(coordinates []float64) string {
+	if len(coordinates) == 0 {
+		return "POLYGON EMPTY"
+	}
+
 	// polygon must be closed, so if it isnt, then add the first point at the end to close it
 	if coordinates[0] != coordinates[len(coordinates)-2] || coordinates[1] != coordinates[len(coordinates)-1] {
 		coordinates = append(coordinates, coordinates[0], coordinates[1])

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210507163154-9a489d9f9b92
+	github.com/uncharted-distil/distil-compute v0.0.0-20210511205534-887b1cbe9cd5
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/uncharted-distil/distil-compute v0.0.0-20210507163154-9a489d9f9b92 h1:urK3JKYP7DvpbV7ykyNaJzbTTRvU4e2ghXuYznG5YBg=
 github.com/uncharted-distil/distil-compute v0.0.0-20210507163154-9a489d9f9b92/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210511205534-887b1cbe9cd5 h1:A9LnMH6HuV9zseRDSmrHDAw2ykYpvNgN+b2ztoSsbgs=
+github.com/uncharted-distil/distil-compute v0.0.0-20210511205534-887b1cbe9cd5/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=


### PR DESCRIPTION
Fixes #2579, #2571

A follow on to #2557 to address further issues uncovered during testing of satellite / tabular joins.

1. Handles cases where a joined row has an empty coordinate value.
2. Sets the group role on multiband image group ID columns when the group is re-created as part of a join.
3. Enforces the condition that there will be only 1 coord column in a dataset post join.