### PR TITLE
Join Pair Accuracy

### DIFF
--- a/api/routes/join.go
+++ b/api/routes/join.go
@@ -178,12 +178,16 @@ func joinDistil(joinLeft *task.JoinSpec, joinRight *task.JoinSpec,
 	if params["joinPairs"] == nil {
 		return "", nil, errors.Errorf("missing parameter 'joinPairs'")
 	}
+
+	accuracy := params["accuracy"].(float64)
+
 	joinPairs, ok := json.Array(params, "joinPairs")
 	if !ok {
 		return "", nil, errors.Errorf("joinPairs not a list of join pairs")
 	}
 	leftCols := make([]string, len(joinPairs))
 	rightCols := make([]string, len(joinPairs))
+	accuracies := make([]float64, len(joinPairs))
 	for i, p := range joinPairs {
 		colName, ok := p["first"].(string)
 		if !ok {
@@ -196,10 +200,10 @@ func joinDistil(joinLeft *task.JoinSpec, joinRight *task.JoinSpec,
 			return "", nil, errors.Errorf("join pair 'second' value is not a string")
 		}
 		rightCols[i] = colName
+
+		accuracies[i] = accuracy
 	}
 
-	tmp := params["accuracy"].(float64)
-	accuracy := float32(tmp)
 	// need to read variables from disk for the variable list
 	metaLeft, err := getDiskMetadata(joinLeft.DatasetID, metaStorage)
 	if err != nil {
@@ -224,7 +228,7 @@ func joinDistil(joinLeft *task.JoinSpec, joinRight *task.JoinSpec,
 	joinLeft.ExistingMetadata = metaLeft
 	joinRight.ExistingMetadata = metaRight
 
-	path, data, err := task.JoinDistil(joinLeft, joinRight, leftCols, rightCols, accuracy)
+	path, data, err := task.JoinDistil(joinLeft, joinRight, leftCols, rightCols, accuracies)
 	if err != nil {
 		return "", nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210512182203-81d1a74ff808
+	github.com/uncharted-distil/distil-compute v0.0.0-20210513131302-301b88e066bd
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210511205534-887b1cbe9cd5
+	github.com/uncharted-distil/distil-compute v0.0.0-20210512182203-81d1a74ff808
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -208,10 +208,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210507163154-9a489d9f9b92 h1:urK3JKYP7DvpbV7ykyNaJzbTTRvU4e2ghXuYznG5YBg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210507163154-9a489d9f9b92/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
-github.com/uncharted-distil/distil-compute v0.0.0-20210511205534-887b1cbe9cd5 h1:A9LnMH6HuV9zseRDSmrHDAw2ykYpvNgN+b2ztoSsbgs=
-github.com/uncharted-distil/distil-compute v0.0.0-20210511205534-887b1cbe9cd5/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210512182203-81d1a74ff808 h1:qzO5i3jXmd9k2pUWylGCjFjoRWYba+0juIeadtMxziQ=
+github.com/uncharted-distil/distil-compute v0.0.0-20210512182203-81d1a74ff808/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210512182203-81d1a74ff808 h1:qzO5i3jXmd9k2pUWylGCjFjoRWYba+0juIeadtMxziQ=
-github.com/uncharted-distil/distil-compute v0.0.0-20210512182203-81d1a74ff808/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210513131302-301b88e066bd h1:DjsvGRl+bis/JNe7Bzxao/w53D2YyU/2i7ncZgw5q1E=
+github.com/uncharted-distil/distil-compute v0.0.0-20210513131302-301b88e066bd/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=


### PR DESCRIPTION
Join accuracy is now tied to a specific join pair rather than being a single value used for all join pairs in a join. Note that once the front end gets updated to capture accuracy as part of a join pair, the server should be updated slightly to tie it all together a bit more nicely and not needlessly go from join pair to split lists for left and right variables, and then back to join pairs.