### PR TITLE
fixed image-transformer fetching images

### DIFF
--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -224,13 +224,13 @@ export default Vue.extend({
         null
       );
     },
-    imageSources(): string[] {
+    imageSources(): HTMLImageElement[] {
       const sources = [];
       if (!!this.image) {
-        sources.push(this.image.src);
+        sources.push(this.image);
       }
       if (!!this.imageAttention && this.isFilteredToggled) {
-        sources.push(this.imageAttention.src);
+        sources.push(this.imageAttention);
       }
       return sources;
     },

--- a/public/components/ImageTransformer.vue
+++ b/public/components/ImageTransformer.vue
@@ -56,13 +56,12 @@ export default Vue.extend({
   props: {
     width: { type: Number as () => number, default: 300 },
     height: { type: Number as () => number, default: 300 },
-    imgSrcs: { type: Array as () => string[], default: [] },
+    imgSrcs: { type: Array as () => HTMLImageElement[], default: [] },
   },
   data() {
     return {
       mouseDown: false,
       start: { x: 0, y: 0 },
-      imgs: [],
       isMouseOnCanvas: false,
     };
   },
@@ -109,21 +108,15 @@ export default Vue.extend({
       if (!this.imgSrcs.length) {
         return;
       }
-      this.imgs = [];
-      this.imgSrcs.forEach((src) => {
-        const image = new Image(this.width, this.height);
-        image.src = src;
-        this.imgs.push(image);
-      });
       const promises = [];
-      this.imgs.forEach((img, i) => {
+      this.imgSrcs.forEach((img, i) => {
         if (!img.complete) {
           promises.push(
             new Promise((res, rej) => {
-              this.imgs[i].onload = () => {
+              this.imgSrcs[i].onload = () => {
                 res(true);
               };
-              this.imgs[i].onerror = () => {
+              this.imgSrcs[i].onerror = () => {
                 rej();
               };
             })
@@ -146,7 +139,7 @@ export default Vue.extend({
       this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
       this.ctx.restore();
       // draws any images
-      this.imgs.forEach((img) => {
+      this.imgSrcs.forEach((img) => {
         this.ctx.drawImage(img, 0, 0, this.width, this.height);
       });
     },


### PR DESCRIPTION
closes #2590
- Image-transformer was being passed the src instead of the imagehtml element so it was doing a fetch again
- The complete check works correctly where if the image is already loaded it wont fetch 