### PR TITLE
Join Variables Unique Key

### DIFF
--- a/api/model/storage.go
+++ b/api/model/storage.go
@@ -126,6 +126,8 @@ type DataStorage interface {
 	// DeleteDataset drops all tables associated to storageName
 	DeleteDataset(storageName string) error
 	CreateIndices(dataset string, indexFields []string) error
+	// IsKey verifies the unique property of the listed variables
+	IsKey(dataset string, storageName string, variables []*model.Variable) (bool, error)
 }
 
 // SolutionStorageCtor represents a client constructor to instantiate a

--- a/main.go
+++ b/main.go
@@ -293,7 +293,7 @@ func main() {
 	registerRoutePost(mux, "/distil/save-dataset/:dataset", routes.SaveDatasetHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
 	registerRoutePost(mux, "/distil/add-field/:dataset", routes.AddFieldHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/extract/:dataset", routes.ExtractHandler(esMetadataStorageCtor, pgDataStorageCtor, config))
-	registerRoutePost(mux, "/distil/join", routes.JoinHandler(esMetadataStorageCtor))
+	registerRoutePost(mux, "/distil/join", routes.JoinHandler(pgDataStorageCtor, esMetadataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries/:dataset/:timeseriesColName/:xColName/:yColName", routes.TimeseriesHandler(esMetadataStorageCtor, pgDataStorageCtor))
 	registerRoutePost(mux, "/distil/timeseries-forecast/:truthDataset/:forecastDataset/:timeseriesColName/:xColName/:yColName/:result-uuid", routes.TimeseriesForecastHandler(esMetadataStorageCtor, pgDataStorageCtor, pgSolutionStorageCtor, config.TrainTestSplitTimeSeries))
 	registerRoutePost(mux, "/distil/event", routes.UserEventHandler(discoveryLogger))


### PR DESCRIPTION
Fixes #2598 

Added a safeguard that checks to make sure the right join variables form a unique key across the dataset to remove row duplication on join.