### PR TITLE
Initial disk management

### DIFF
--- a/api/dataset/d3m.go
+++ b/api/dataset/d3m.go
@@ -128,3 +128,7 @@ func (d *D3M) variableIsTyped(variable *model.Variable) bool {
 func (d *D3M) GetDefinitiveTypes() []*model.Variable {
 	return []*model.Variable{}
 }
+
+// CleanupTempFiles does nothing since this creates no temp files.
+func (d *D3M) CleanupTempFiles() {
+}

--- a/api/dataset/media.go
+++ b/api/dataset/media.go
@@ -289,3 +289,7 @@ func getLabelFolders(folderPath string) ([]string, error) {
 func (m *Media) GetDefinitiveTypes() []*model.Variable {
 	return m.definitiveTypes
 }
+
+// CleanupTempFiles does nothing since this creates no temp files.
+func (m *Media) CleanupTempFiles() {
+}

--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -346,6 +346,11 @@ func (s *Satellite) GetDefinitiveTypes() []*model.Variable {
 	return s.definitiveTypes
 }
 
+// CleanupTempFiles does nothing since this creates no temp files.
+func (s *Satellite) CleanupTempFiles() {
+	util.Delete(s.ExtractedFilePath)
+}
+
 // removeValues removes values not needed based on supplied headernames
 func removeMissingValues(indices []int, values []string) []string {
 	result := []string{}

--- a/api/dataset/table.go
+++ b/api/dataset/table.go
@@ -109,3 +109,7 @@ func (t *Table) CreateDataset(rootDataPath string, datasetName string, config *e
 func (t *Table) GetDefinitiveTypes() []*model.Variable {
 	return []*model.Variable{}
 }
+
+// CleanupTempFiles does nothing since this creates no temp files.
+func (t *Table) CleanupTempFiles() {
+}

--- a/api/env/config.go
+++ b/api/env/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	DatamartNYUEnabled         bool    `env:"DATAMART_NYU_ENABLED" envDefault:"false"`
 	DatamartImportFolder       string  `env:"DATAMART_IMPORT_FOLDER" envDefault:"datamart"`
 	DatasetBatchSize           int     `env:"DATASET_BATCH_SIZE" envDefault:"10000"`
+	DeleteBufferTime           int     `env:"DELETE_BUFFER_TIME" envDefault:"600"`
 	ElasticEndpoint            string  `env:"ES_ENDPOINT" envDefault:"http://localhost:9200"`
 	ESDatasetsIndex            string  `env:"ES_DATASETS_INDEX" envDefault:"datasets"`
 	ESModelsIndex              string  `env:"ES_DATASETS_INDEX" envDefault:"models"`

--- a/api/task/explain.go
+++ b/api/task/explain.go
@@ -94,6 +94,10 @@ func (e explainDataset) GetDefinitiveTypes() []*model.Variable {
 	return []*model.Variable{}
 }
 
+// CleanupTempFiles does nothing since this creates no temp files.
+func (e explainDataset) CleanupTempFiles() {
+}
+
 // ClusterExplainOutput clusters the explained output from a model.
 func ClusterExplainOutput(variable string, resultURI string, explainURI string, config *env.Config) (bool, []*ClusterPoint, error) {
 	// create the SHAP values dataset

--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -130,6 +130,10 @@ func (p *PredictionTimeseriesDataset) GetDefinitiveTypes() []*model.Variable {
 	return []*model.Variable{}
 }
 
+// CleanupTempFiles does nothing.
+func (p *PredictionTimeseriesDataset) CleanupTempFiles() {
+}
+
 func (p *predictionDataset) CreateDataset(rootDataPath string, datasetName string, config *env.Config) (*serialization.RawDataset, error) {
 	// need to do a bit of processing on the usual setup
 	ds, err := p.params.DatasetConstructor.CreateDataset(rootDataPath, datasetName, config)
@@ -166,6 +170,11 @@ func (p *predictionDataset) CreateDataset(rootDataPath string, datasetName strin
 // GetDefinitiveTypes returns an empty list as definitive types.
 func (p *predictionDataset) GetDefinitiveTypes() []*model.Variable {
 	return []*model.Variable{}
+}
+
+// CleanupTempFiles calls the cleanup on the dataset constructor used.
+func (p *predictionDataset) CleanupTempFiles() {
+	p.params.DatasetConstructor.CleanupTempFiles()
 }
 
 // PredictParams contains all parameters passed to the predict function.

--- a/api/util/file.go
+++ b/api/util/file.go
@@ -45,10 +45,12 @@ type deleteBuffer struct {
 }
 
 func (b *deleteBuffer) add(filename string) {
+	log.Infof("buffering delete of '%s'", filename)
 	b.files = append(b.files, filename)
 }
 
 func (b *deleteBuffer) popAll() []string {
+	log.Infof("popping all data to be deleted")
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	copy := append([]string{}, b.files...)
@@ -66,6 +68,8 @@ func InitializeDeleteBuffer(bufferTimeSeconds int) {
 	}
 
 	// start process that will delete in the background
+	log.Infof("starting background process that buffers deletions")
+	go bufferedDelete(deletes, bufferTimeSeconds)
 }
 
 func bufferedDelete(buffer *deleteBuffer, bufferTimeSeconds int) {

--- a/main.go
+++ b/main.go
@@ -120,6 +120,7 @@ func main() {
 	}
 
 	createOutputFolders(&config)
+	util.InitializeDeleteBuffer(config.DeleteBufferTime)
 
 	// initialize the pipeline cache and
 	pipelineCacheFilename := path.Join(env.GetTmpPath(), config.PipelineCacheFilename)


### PR DESCRIPTION
Added a buffered file deletion concept. At startup, a go routine is started that will periodically (10 minutes by default) delete any files and folders flagged for deletion. Currently, temp import files and batches created when prefeaturizing datasets are the only parts that make use of the new capabilities.