### PR TITLE
Aligns prediction dataset with model dataset

### DIFF
--- a/api/model/dataset.go
+++ b/api/model/dataset.go
@@ -201,7 +201,10 @@ func (d *DiskDataset) SaveDataset() error {
 		return err
 	}
 
-	if d.FeaturizedDataset != nil {
+	// Check the schema path here to figure out if this featurized dataset is just a reference to
+	// the baseline datset.  The featurized dataset has the same ID as the baseline, so that comparison
+	// is not sufficient in this case.
+	if d.FeaturizedDataset != nil && d.schemaPath != d.FeaturizedDataset.schemaPath {
 		err = d.FeaturizedDataset.SaveDataset()
 		if err != nil {
 			return err
@@ -276,7 +279,6 @@ func (d *DiskDataset) GetLearningFolder() string {
 	if d.FeaturizedDataset != nil {
 		return d.FeaturizedDataset.GetLearningFolder()
 	}
-
 	return path.Dir(d.schemaPath)
 }
 

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -82,31 +82,6 @@ func (d *RawDataset) AddField(variable *model.Variable) error {
 	return nil
 }
 
-// InsertField inserts a field in the dataset at the specified index, updating both the data
-// and the metadata.
-func (d *RawDataset) InsertField(variable *model.Variable, index int) error {
-	if d.FieldExists(variable) {
-		return errors.Errorf("field '%s' already exists in the raw dataset", variable.Key)
-	}
-	clone := variable.Clone()
-	clone.Index = index
-
-	// insert the variable
-	variables := d.Metadata.GetMainDataResource().Variables
-	variables = append(variables[:index+1], variables[index:]...)
-	variables[index] = clone
-
-	// the first row is the header row
-	d.Data[0] = append(d.Data[0][:index+1], d.Data[0][index:]...)
-	d.Data[0][index] = variable.HeaderName
-	for i, row := range d.Data[1:] {
-		d.Data[i+1] = append(row[:index+1], row[index:]...)
-		d.Data[i+1][index] = ""
-	}
-
-	return nil
-}
-
 // FieldExists returns true if a field is already part of the metadata.
 func (d *RawDataset) FieldExists(variable *model.Variable) bool {
 	for _, v := range d.Metadata.GetMainDataResource().Variables {

--- a/api/serialization/storage.go
+++ b/api/serialization/storage.go
@@ -82,6 +82,31 @@ func (d *RawDataset) AddField(variable *model.Variable) error {
 	return nil
 }
 
+// InsertField inserts a field in the dataset at the specified index, updating both the data
+// and the metadata.
+func (d *RawDataset) InsertField(variable *model.Variable, index int) error {
+	if d.FieldExists(variable) {
+		return errors.Errorf("field '%s' already exists in the raw dataset", variable.Key)
+	}
+	clone := variable.Clone()
+	clone.Index = index
+
+	// insert the variable
+	variables := d.Metadata.GetMainDataResource().Variables
+	variables = append(variables[:index+1], variables[index:]...)
+	variables[index] = clone
+
+	// the first row is the header row
+	d.Data[0] = append(d.Data[0][:index+1], d.Data[0][index:]...)
+	d.Data[0][index] = variable.HeaderName
+	for i, row := range d.Data[1:] {
+		d.Data[i+1] = append(row[:index+1], row[index:]...)
+		d.Data[i+1][index] = ""
+	}
+
+	return nil
+}
+
 // FieldExists returns true if a field is already part of the metadata.
 func (d *RawDataset) FieldExists(variable *model.Variable) bool {
 	for _, v := range d.Metadata.GetMainDataResource().Variables {

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210513131302-301b88e066bd
+	github.com/uncharted-distil/distil-compute v0.0.0-20210521170045-9cbdc31046dc
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/uncharted-distil/distil-compute v0.0.0-20210513131302-301b88e066bd h1:DjsvGRl+bis/JNe7Bzxao/w53D2YyU/2i7ncZgw5q1E=
 github.com/uncharted-distil/distil-compute v0.0.0-20210513131302-301b88e066bd/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210521170045-9cbdc31046dc h1:DCs0Uh4JWM9lMKLWRF4zcANPoCVKQ2cC5jE24z1iYn4=
+github.com/uncharted-distil/distil-compute v0.0.0-20210521170045-9cbdc31046dc/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=


### PR DESCRIPTION
Adds functions to prediction dataset creation to:

1. Determine if the prediction dataset is missing variables used by the model
2. Determine if the prediction dataset has variables that don't match the order of the variables used by the model
3. Update the prediction dataset based on the findings of 1. and 2. 

This needs follow on work to address proper handling of pre-featurized datasets.