### PR TITLE
fixes for label view

### DIFF
--- a/api/routes/image_pack.go
+++ b/api/routes/image_pack.go
@@ -84,10 +84,24 @@ func MultiBandImagePackHandler(ctor api.MetadataStorageCtor, dataCtor api.DataSt
 		result := make(chan chanStruct)
 		// ImageThreadPool is an environment variable defaults to 2 (works great with 6)
 		numOfThreads := config.ImageThreadPool
+		// if no IDs return
+		if len(params.ImageIDs) == 0 {
+			err = handleJSON(w, ImagePackResult{
+				ImagesBuffer: [][]byte{},
+				ImageIDs:     []string{},
+				ErrorIDs:     []string{},
+			})
+			if err != nil {
+				handleError(w, errors.Wrap(err, "unable marshal dataset result into JSON"))
+				return
+			}
+			return
+		}
 		// reduce numOfThreads to the number of ImageIDs if it is lower than 6
 		if numOfThreads > len(params.ImageIDs) {
 			numOfThreads = len(params.ImageIDs)
 		}
+
 		for i := 0; i < numOfThreads; i++ {
 			go funcPointer(params, i, numOfThreads, result, ctor, dataCtor)
 		}

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -686,6 +686,9 @@ export default Vue.extend({
           tileMap.set(i.imageUrl, i);
         }
       });
+      if (!tileMap.size) {
+        return;
+      }
       this.drillDownState.tiles = [...tileMap.values()];
       this.isImageDrilldown = true;
     },
@@ -1267,11 +1270,11 @@ export default Vue.extend({
 
     tileColor(item: any, idx: number) {
       let color = this.isExclude ? BLACK : BLUE; // Default
-      if (this.coloringByVariable) {
-        return this.colorScale(this.colorByVariable(item, idx));
-      }
       if (this.rowSelectionMap.has(item.d3mIndex)) {
         return SELECTION_RED;
+      }
+      if (this.coloringByVariable) {
+        return this.colorScale(this.colorByVariable(item, idx));
       }
       if (item.isExcluded) {
         return GRAY;

--- a/public/components/labelingComponents/LabelGeoplot.vue
+++ b/public/components/labelingComponents/LabelGeoplot.vue
@@ -49,7 +49,7 @@ import {
   LowShotLabels,
 } from "../../util/data";
 import { actions as viewActions } from "../../store/view/module";
-import { INCLUDE_FILTER, Filter } from "../../util/filters";
+import { INCLUDE_FILTER, Filter, EXCLUDE_FILTER } from "../../util/filters";
 import { actions as datasetActions } from "../../store/dataset/module";
 import { bulkRowSelectionUpdate } from "../../util/row";
 
@@ -153,7 +153,7 @@ export default Vue.extend({
         maxY: data.bounds[0][0],
         minX: data.bounds[0][1],
         minY: data.bounds[1][0],
-        mode: INCLUDE_FILTER,
+        mode: EXCLUDE_FILTER,
         type: data.type,
         set: "",
       };

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -312,14 +312,18 @@ export const mutations = {
     Vue.set(state.files, args.url, args.file);
   },
   bulkUpdateFiles(state: DatasetState, args: { urls: string[]; files: any[] }) {
+    const clone = _.cloneDeep(state.files);
     for (let i = 0; i < args.urls.length; ++i) {
-      Vue.set(state.files, args.urls[i], args.files[i]);
+      clone[args.urls[i]] = args.files[i];
     }
+    Vue.set(state, "files", clone);
   },
   bulkRemoveFiles(state: DatasetState, args: { urls: string[] }) {
+    const clone = _.cloneDeep(state.files);
     args.urls.forEach((url) => {
-      Vue.delete(state.files, url);
+      delete clone[url];
     });
+    Vue.set(state, "files", clone);
   },
   removeFile(state: DatasetState, url: string) {
     Vue.delete(state.files, url);

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -588,6 +588,7 @@ export const actions = {
         summary: null,
       });
     }
+
     return Promise.all([
       datasetActions.fetchIncludedVariableSummaries(store, {
         dataset,
@@ -641,11 +642,15 @@ export const actions = {
       .getDecodedSolutionRequestFilterParams as FilterParams;
     const highlights = context.getters.getDecodedHighlights as Highlight[];
     const dataMode = context.getters.getDataMode;
+    const variables = datasetGetters.getAllVariables(store);
     // artificially add filter but dont add it to the url
     // this is a hack to avoid adding an extra field just for the area of interest
     const clonedFilterParams = _.cloneDeep(filterParams);
     clonedFilterParams.filters.list.push(filter);
     clonedFilterParams.filters.invert = true;
+    clonedFilterParams.variables = variables.map((v) => {
+      return v.key;
+    });
     const clonedExcludeFilter = _.cloneDeep(filter);
     // the exclude has to invert all the filters -- the route does a collective NOT() and
     // for areaOfInterest we need compounded ands so therefore we invert client side pass in

--- a/public/views/Labeling.vue
+++ b/public/views/Labeling.vue
@@ -338,8 +338,16 @@ export default Vue.extend({
       }
       return dataset.clone === undefined ? false : dataset.clone;
     },
+    hasConfidence(): boolean {
+      return this.variables.some((v) => {
+        return v.key === this.labelScoreName;
+      });
+    },
   },
   watch: {
+    hasConfidence() {
+      viewActions.updateHighlight(this.$store);
+    },
     geoVarExists() {
       const route = routeGetters.getRoute(this.$store);
       const entry = overlayRouteEntry(route, { hasGeoData: this.geoVarExists });


### PR DESCRIPTION
closes #2642
closes #2643
closes #2644

- The introduction of the color scale in the map and drill down view was causing issues on the label view
- Mainly the confidence variable if coloring by it the data being supplied to the drill down would not contain it causing errors
- The bulkUpdateFiles and bulkRemoveFiles have been updated to only 1 vue.Set
- The row selection now overrides any color scale being applied
- Added a watch to fix the baseline data if a confidence variable is introduced on the label view
- BulkUpdateFiles now takes 0.92ms 
![image](https://user-images.githubusercontent.com/25306965/119710164-0c5a1200-be2c-11eb-8c6b-d8b7cfe1900a.png)
