### PR TITLE
adds the image feature vars to the selected set

### DIFF
--- a/api/compute/featurize.go
+++ b/api/compute/featurize.go
@@ -78,6 +78,14 @@ func (s *SolutionRequest) createPreFeaturizedPipeline(learningDataset string,
 			selectedVariables = append(selectedVariables, v)
 		}
 	}
+
+	// image feature variables are m system data role and should be included in our selected set
+	for _, featurizedVariable := range featurizedVariables {
+		if featurizedVariable.DistilRole == model.VarDistilRoleSystemData {
+			selectedVariables = append(selectedVariables, featurizedVariable.Key)
+		}
+	}
+
 	expandedFilters.Variables = selectedVariables
 
 	prefeaturizedPipeline, err := description.CreatePreFeaturizedDatasetPipeline(name, desc,


### PR DESCRIPTION
Makes the selected feature list for the pre-featurized variables consistent with the updated `IsTA2Field` call, which does consider pre-featurized variables as valid for TA2 processing.
