### PR TITLE
Additional error handling for confidence colouring

### DIFF
--- a/public/components/facets/FacetNumerical.vue
+++ b/public/components/facets/FacetNumerical.vue
@@ -191,7 +191,10 @@ export default Vue.extend({
       // so we can show the latest selection made.
       const highlightAsSelection = buckets.reduce((acc, val, ind) => {
         const key = _.toNumber(val.key);
-        if (highlightValues[0].from === key || highlightValues[0].to === key) {
+        if (
+          highlightValues[0]?.from === key ||
+          highlightValues[0]?.to === key
+        ) {
           acc.push(ind);
         }
         return acc;

--- a/public/util/color.ts
+++ b/public/util/color.ts
@@ -103,8 +103,9 @@ export function colorByFacet(
   // assume range
   else {
     const diff = variable.baseline.extrema.max - variable.baseline.extrema.min;
-    return (item: TableRow, idx: number) => {
-      return (item[key].value - variable.baseline.extrema.min) / diff;
+    return (item: TableRow) => {
+      const itemValue = item[key]?.value ?? 0;
+      return (itemValue - variable.baseline.extrema.min) / diff;
     };
   }
 }


### PR DESCRIPTION
Some exceptions were being thrown when colouring by confidence when the produced model contained confidence, but not ranks.  This update strenghtens error handling s.t. data that is not initially present is handle gracefully.
