### PR TITLE
force multiband image dataset to left of join

### DIFF
--- a/api/routes/join.go
+++ b/api/routes/join.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uncharted-distil/distil/api/serialization"
 	"github.com/uncharted-distil/distil/api/task"
 	"github.com/uncharted-distil/distil/api/util/json"
+	log "github.com/unchartedsoftware/plog"
 )
 
 func missingParamErr(w http.ResponseWriter, paramName string) {
@@ -92,6 +93,7 @@ func JoinHandler(dataCtor api.DataStorageCtor, metaCtor api.MetadataStorageCtor)
 		// data to the area we have imagery for.
 		for _, v := range rightVariables {
 			if model.IsMultiBandImage(v.Type) {
+				log.Warnf("Multiband image set %s used as right join argument and will be forced to the left.", rightJoin.DatasetID)
 				temp := leftJoin
 				leftJoin = rightJoin
 				rightJoin = temp


### PR DESCRIPTION
Checks to see if the right hand dataset in a join is a multiband image and forces it to the right if so.  This is really just a safeguard, and should probably be complemented by similar behaviour on the client side.
