### PR TITLE
skips remove of polygon column from join pipeline

### DIFF
--- a/api/task/join.go
+++ b/api/task/join.go
@@ -310,7 +310,8 @@ func generateRightExcludes(leftVariables []*model.Variable, rightVariables []*mo
 			for _, v := range rightVariables {
 				if v.IsGrouping() && model.IsGeoBounds(v.Type) {
 					gb := v.Grouping.(*model.GeoBoundsGrouping)
-					toRemove[gb.PolygonCol] = true
+					// don't need to remove polygon col here - we force the multiband image data to be the left
+					// part of the join, and that's the only time the polygon col will be present
 					toRemove[gb.CoordinatesCol] = true
 					break
 				}


### PR DESCRIPTION
The polygon column does not exist in the disk version of datasets have geobounds, but are not image sets.  We add a pipeline step to remove the second set of geobounds if we are joining a dataset (we only support one geobound/geocoord per dataset right now), which also includes removing the polygon column.  Since it doesn't exist for non-multiband image sets, the pipeline fails.  Given that we force the image set to the left side of the join, the right side, being the non-multiband image set, will never have the polygon column, so we can just skip the removal completely.
