### PR TITLE
Tag Bounding Polygon

### DIFF
--- a/api/routes/join.go
+++ b/api/routes/join.go
@@ -136,13 +136,21 @@ func parseVariables(variablesRaw []interface{}) ([]*model.Variable, error) {
 		// groups need to be handled separately as they depend on type
 		var groupingParsed model.BaseGrouping
 		if varData["grouping"] != nil {
-			if model.IsTimeSeries(varData["colType"].(string)) {
+			groupingType := varData["colType"].(string)
+			if model.IsTimeSeries(groupingType) {
 				groupingTimeseries := model.TimeseriesGrouping{}
 				err := json.MapToStruct(&groupingTimeseries, varData["grouping"].(map[string]interface{}))
 				if err != nil {
 					return nil, errors.Wrap(err, "Unable to parse timeseries grouping")
 				}
 				groupingParsed = &groupingTimeseries
+			} else if model.IsGeoBounds(groupingType) {
+				groupingGeo := model.GeoBoundsGrouping{}
+				err := json.MapToStruct(&groupingGeo, varData["grouping"].(map[string]interface{}))
+				if err != nil {
+					return nil, errors.Wrap(err, "Unable to parse geobounds grouping")
+				}
+				groupingParsed = &groupingGeo
 			}
 			varData["grouping"] = nil
 		}

--- a/api/task/join.go
+++ b/api/task/join.go
@@ -79,8 +79,9 @@ func JoinDistil(dataStorage apiModel.DataStorage, joinLeft *JoinSpec, joinRight 
 		return "", nil, err
 	}
 
-	varsLeftMapUpdated := apiModel.MapVariables(joinLeft.UpdatedVariables, func(variable *model.Variable) string { return variable.Key })
-	varsRightMapUpdated := apiModel.MapVariables(joinRight.UpdatedVariables, func(variable *model.Variable) string { return variable.Key })
+	isKey := false
+	varsLeftMapUpdated := mapDistilJoinVars(joinLeft.UpdatedVariables)
+	varsRightMapUpdated := mapDistilJoinVars(joinRight.UpdatedVariables)
 	joins := make([]*description.Join, len(joinPairs))
 	rightVars := make([]*model.Variable, len(joinPairs))
 	for i := range joinPairs {
@@ -91,17 +92,32 @@ func JoinDistil(dataStorage apiModel.DataStorage, joinLeft *JoinSpec, joinRight 
 			Absolute: joinPairs[i].AbsoluteAccuracy,
 		}
 		rightVars[i] = varsRightMapUpdated[joinPairs[i].Right]
+
+		// assume groupings are valid keys for the join
+		if joins[i].Right.IsGrouping() {
+			isKey = true
+		}
 	}
-	isKey, err := dataStorage.IsKey(joinRight.DatasetID, joinRight.ExistingMetadata.StorageName, rightVars)
-	if err != nil {
-		return "", nil, err
+	if !isKey {
+		isKey, err = dataStorage.IsKey(joinRight.DatasetID, joinRight.ExistingMetadata.StorageName, rightVars)
+		if err != nil {
+			return "", nil, err
+		}
 	}
 	if !isKey {
 		return "", nil, errors.Errorf("specified right join columns do not specify a unique key")
 	}
 
 	rightExcludes := generateRightExcludes(joinLeft.UpdatedVariables, joinRight.UpdatedVariables)
-	pipelineDesc, err := description.CreateJoinPipeline("Joiner", "Join existing data", joins, []*model.Variable{}, rightExcludes, description.JoinTypeLeft)
+	joinInfo := &description.JoinDescription{
+		Joins:          joins,
+		LeftExcludes:   []*model.Variable{},
+		LeftVariables:  joinLeft.UpdatedVariables,
+		RightExcludes:  rightExcludes,
+		RightVariables: joinRight.UpdatedVariables,
+		Type:           description.JoinTypeLeft,
+	}
+	pipelineDesc, err := description.CreateJoinPipeline("Joiner", "Join existing data", joinInfo)
 	if err != nil {
 		return "", nil, err
 	}
@@ -325,4 +341,18 @@ func generateRightExcludes(leftVariables []*model.Variable, rightVariables []*mo
 		}
 	}
 	return rightExcludes
+}
+
+func mapDistilJoinVars(variables []*model.Variable) map[string]*model.Variable {
+	varsMapped := apiModel.MapVariables(variables, func(variable *model.Variable) string { return variable.Key })
+
+	// geobounds group should map the coordinates field to the grouping columns
+	for _, g := range variables {
+		if g.IsGrouping() && model.IsGeoBounds(g.Type) {
+			geoGrouping := g.Grouping.(*model.GeoBoundsGrouping)
+			varsMapped[geoGrouping.CoordinatesCol] = g
+		}
+	}
+
+	return varsMapped
 }

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210531171521-d0aa9d3db0fd
+	github.com/uncharted-distil/distil-compute v0.0.0-20210601170459-b1560ee56c28
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20210528164133-6a494c827412
+	github.com/uncharted-distil/distil-compute v0.0.0-20210531171521-d0aa9d3db0fd
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210531171521-d0aa9d3db0fd h1:fNv/x9a8ogX0x1qRWyBS9Ub4yLNJxz0W30nQV3HJyfI=
-github.com/uncharted-distil/distil-compute v0.0.0-20210531171521-d0aa9d3db0fd/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210601170459-b1560ee56c28 h1:A9XboBUP/ht3Toy4S6RZnZQ6PqOgXHaCOQDYsGI4zk4=
+github.com/uncharted-distil/distil-compute v0.0.0-20210601170459-b1560ee56c28/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20210528164133-6a494c827412 h1:GM6K2ZIviv1CzYtlTZo2CL9xphbTpKOIspzjCiwalyE=
-github.com/uncharted-distil/distil-compute v0.0.0-20210528164133-6a494c827412/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20210531171521-d0aa9d3db0fd h1:fNv/x9a8ogX0x1qRWyBS9Ub4yLNJxz0W30nQV3HJyfI=
+github.com/uncharted-distil/distil-compute v0.0.0-20210531171521-d0aa9d3db0fd/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6 h1:s0flWfQg2N219KLjBM4cpBKt5Bh9TC2yLhOYCSxUAoM=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210223142454-e2adf2b3dbb6/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=


### PR DESCRIPTION
Geobounds joins will now trigger the proper type of join, using an absolute join accuracy that assumes metres as unit. As part of this work, changes had to be made to make sure columns that are used for joining don't get dropped and that geobounds groups don't get duplicated on import.