### PR TITLE
Empty Timestamp Field

### DIFF
--- a/api/compute/explain.go
+++ b/api/compute/explain.go
@@ -263,6 +263,10 @@ func parseFeatureWeight(resultURI string, outputURI string, d3mIndexLookup map[i
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read feature weight output")
 	}
+	if len(res) == 0 {
+		log.Warnf("empty feature weight file received ('%s')", outputURI)
+		return nil, nil
+	}
 
 	res = addD3MIndex(d3mIndexLookup, res)
 	return &api.SolutionExplainResult{

--- a/api/compute/search.go
+++ b/api/compute/search.go
@@ -116,11 +116,15 @@ func (s *SolutionRequest) dispatchSolutionExplainPipeline(client *compute.Client
 				log.Infof("explaining feature output from URI '%s'", explainURI)
 				explainDatasetURI = compute.BuildSchemaFileURI(explainDatasetURI)
 				parsedExplainResult, err := ExplainFeatureOutput(explainDatasetURI, explainURI)
-				parsedExplainResult.ResultURI = searchResult.resultURI
 				if err != nil {
 					log.Warnf("failed to fetch output explanation - %v", err)
 					continue
 				}
+				if parsedExplainResult == nil {
+					log.Warnf("empty output explanation")
+					continue
+				}
+				parsedExplainResult.ResultURI = searchResult.resultURI
 				parsedExplainResult.ParsingFunction = explain.parsingFunction
 				explainedResults[explain.typ] = parsedExplainResult
 			}

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -767,10 +767,9 @@ func DefaultPostgresValueFromD3MType(typ string) interface{} {
 	}
 }
 
-// IsDatabaseFloatingPoint indicates whether or not a database type is a floating point
-// value.
-func IsDatabaseFloatingPoint(typ string) bool {
-	return typ == dataTypeFloat
+// IsNullable indicates whether or not a database type can be empty.
+func IsNullable(typ string) bool {
+	return typ == dataTypeFloat || typ == dataTypeDate
 }
 
 // ValueForFieldType generates the select field value for a given variable type.
@@ -880,7 +879,7 @@ func IsColumnType(client DatabaseDriver, tableName string, variable *model.Varia
 		viewSelect = fmt.Sprintf("%s::%s", viewSelect, colType)
 	}
 	// generate view query
-	viewQuery := fmt.Sprintf("CREATE TEMPORARY VIEW temp_view_%[1]s AS SELECT %[3]s AS \"%[1]s\" FROM %[2]s", variable.Key, tableName, viewSelect)
+	viewQuery := fmt.Sprintf("CREATE TEMPORARY VIEW temp_view_%[1]s AS SELECT %[3]s AS \"%[1]s\" FROM %[2]s WHERE \"%[1]s\" != ''", variable.Key, tableName, viewSelect)
 	// test query
 	testQuery := fmt.Sprintf("SELECT COUNT(\"%[1]s\") FROM temp_view_%[1]s %[2]s", variable.Key, where)
 


### PR DESCRIPTION
Fixes #2681 

DateTime fields are now defaulted to `0001-01-01 00:00:00` and get ignored in summary queries. This allows retyping to DateTime even in cases where empty values are present.

More generally, type checking now excludes empty values. If the type is valid when empty values are ignored, then that will be treated as a valid retyping and will use the relevant default value when building the view. A major side effect is that default values will now make it through to the client when querying for data. Follow on work should probably be done to remap default values to blanks.

Minor tweaks were made in how SHAP output is handled to account for getting empty explanations back. This may occur when limited features are selected.