### PR TITLE
Default Data Handling

### DIFF
--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -238,8 +238,7 @@ func (s *Storage) createView(storageName string, fields map[string]*model.Variab
 	// Build the select statement of the query.
 	fieldList := make([]string, 0)
 	for _, v := range fields {
-		fieldList = append(fieldList, postgres.GetViewField(v.Key, postgres.ValueForFieldType(v.Type, v.Key),
-			postgres.MapD3MTypeToPostgresType(v.Type), postgres.DefaultPostgresValueFromD3MType(v.Type)))
+		fieldList = append(fieldList, postgres.GetViewField(v))
 	}
 	sql = fmt.Sprintf(sql, storageName, strings.Join(fieldList, ","), storageName)
 

--- a/api/model/storage/postgres/dataset.go
+++ b/api/model/storage/postgres/dataset.go
@@ -189,16 +189,6 @@ func (s *Storage) cloneTable(existingTable string, newTable string, copyData boo
 	return nil
 }
 
-func (s *Storage) getViewField(fieldName string, fieldSelect string, displayName string, typ string, defaultValue interface{}) string {
-	viewField := fmt.Sprintf("COALESCE(CAST(%s AS %s), %v)", fieldSelect, typ, defaultValue)
-	if postgres.IsNullable(typ) {
-		// handle missing values
-		viewField = fmt.Sprintf("CASE WHEN \"%s\" = '' THEN %v ELSE %s END", fieldName, defaultValue, viewField)
-	}
-	viewField = fmt.Sprintf("%s AS \"%s\"", viewField, displayName)
-	return viewField
-}
-
 func (s *Storage) getDatabaseFields(tableName string) ([]string, error) {
 	sql := "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1;"
 
@@ -248,8 +238,8 @@ func (s *Storage) createView(storageName string, fields map[string]*model.Variab
 	// Build the select statement of the query.
 	fieldList := make([]string, 0)
 	for _, v := range fields {
-		fieldList = append(fieldList, s.getViewField(v.Key, postgres.ValueForFieldType(v.Type, v.Key),
-			v.Key, postgres.MapD3MTypeToPostgresType(v.Type), postgres.DefaultPostgresValueFromD3MType(v.Type)))
+		fieldList = append(fieldList, postgres.GetViewField(v.Key, postgres.ValueForFieldType(v.Type, v.Key),
+			postgres.MapD3MTypeToPostgresType(v.Type), postgres.DefaultPostgresValueFromD3MType(v.Type)))
 	}
 	sql = fmt.Sprintf(sql, storageName, strings.Join(fieldList, ","), storageName)
 

--- a/api/model/storage/postgres/datetime.go
+++ b/api/model/storage/postgres/datetime.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/uncharted-distil/distil-compute/model"
 	api "github.com/uncharted-distil/distil/api/model"
-	"github.com/uncharted-distil/distil/api/postgres"
 )
 
 // DateTimeField defines behaviour for the numerical field type.
@@ -129,7 +128,7 @@ func (f *DateTimeField) fetchHistogramWithJoins(filterParams *api.FilterParams, 
 
 	// create the filter for the query.
 	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams)
-	wheres = append(wheres, f.getDefaultFilter())
+	wheres = append(wheres, f.getDefaultFilter(true))
 
 	// need the extrema to calculate the histogram interval
 	extrema, err := f.fetchExtrema()
@@ -172,7 +171,7 @@ func (f *DateTimeField) fetchHistogramByResult(resultURI string, filterParams *a
 	if err != nil {
 		return nil, err
 	}
-	wheres = append(wheres, f.getDefaultFilter())
+	wheres = append(wheres, f.getDefaultFilter(true))
 
 	params = append(params, resultURI)
 
@@ -224,7 +223,7 @@ func (f *DateTimeField) fetchExtrema() (*api.Extrema, error) {
 	aggQuery := f.getMinMaxAggsQuery()
 
 	// create a query that does min and max aggregations for each variable
-	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE %s;", aggQuery, fromClause, f.getDefaultFilter())
+	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE %s;", aggQuery, fromClause, f.getDefaultFilter(true))
 
 	// execute the postgres query
 	// NOTE: We may want to use the regular Query operation since QueryRow
@@ -371,7 +370,7 @@ func (f *DateTimeField) fetchExtremaByURI(resultURI string) (*api.Extrema, error
 
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s INNER JOIN %s result ON %s.\"%s\" = result.index WHERE result.result_id = $1 AND %s;",
-		aggQuery, fromClause, f.Storage.getResultTable(f.DatasetStorageName), baseTableAlias, model.D3MIndexFieldName, f.getDefaultFilter())
+		aggQuery, fromClause, f.Storage.getResultTable(f.DatasetStorageName), baseTableAlias, model.D3MIndexFieldName, f.getDefaultFilter(true))
 
 	// execute the postgres query
 	// NOTE: We may want to use the regular Query operation since QueryRow
@@ -557,8 +556,4 @@ func (f *DateTimeField) fetchExtremaStorage() (*api.Extrema, error) {
 	}
 
 	return f.parseExtrema(res)
-}
-
-func (f *DateTimeField) getDefaultFilter() string {
-	return fmt.Sprintf("\"%s\" != %v", f.Key, postgres.DefaultPostgresValueFromD3MType(model.DateTimeType))
 }

--- a/api/model/storage/postgres/numerical.go
+++ b/api/model/storage/postgres/numerical.go
@@ -134,7 +134,7 @@ func (f *NumericalField) fetchHistogramWithJoins(filterParams *api.FilterParams,
 
 	// create the filter for the query.
 	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams)
-	wheres = append(wheres, f.getNaNFilter())
+	wheres = append(wheres, f.getDefaultFilter(true))
 
 	// need the extrema to calculate the histogram interval
 	extrema, err := f.fetchExtrema()
@@ -192,7 +192,7 @@ func (f *NumericalField) fetchHistogramByResult(resultURI string, filterParams *
 	if err != nil {
 		return nil, err
 	}
-	wheres = append(wheres, f.getNaNFilter())
+	wheres = append(wheres, f.getDefaultFilter(true))
 
 	params = append(params, resultURI)
 
@@ -260,7 +260,7 @@ func (f *NumericalField) fetchExtrema() (*api.Extrema, error) {
 
 	// create a query that does min and max aggregations for each variable
 	// need to ignore the NaN values
-	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE %s;", aggQuery, fromClause, f.getNaNFilter())
+	queryString := fmt.Sprintf("SELECT %s FROM %s WHERE %s;", aggQuery, fromClause, f.getDefaultFilter(true))
 
 	// execute the postgres query
 	// NOTE: We may want to use the regular Query operation since QueryRow
@@ -409,7 +409,7 @@ func (f *NumericalField) fetchExtremaByURI(resultURI string) (*api.Extrema, erro
 
 	// create a query that does min and max aggregations for each variable
 	queryString := fmt.Sprintf("SELECT %s FROM %s INNER JOIN %s result ON %s.\"%s\" = result.index WHERE result.result_id = $1 AND %s;",
-		aggQuery, fromClause, f.Storage.getResultTable(f.DatasetStorageName), baseTableAlias, model.D3MIndexFieldName, f.getNaNFilter())
+		aggQuery, fromClause, f.Storage.getResultTable(f.DatasetStorageName), baseTableAlias, model.D3MIndexFieldName, f.getDefaultFilter(true))
 
 	// execute the postgres query
 	// NOTE: We may want to use the regular Query operation since QueryRow
@@ -573,7 +573,7 @@ func (f *NumericalField) FetchNumericalStats(filterParams *api.FilterParams) (*N
 	wheres := make([]string, 0)
 	params := make([]interface{}, 0)
 	wheres, params = f.Storage.buildFilteredQueryWhere(f.GetDatasetName(), wheres, params, "", filterParams)
-	wheres = append(wheres, f.getNaNFilter())
+	wheres = append(wheres, f.getDefaultFilter(true))
 
 	where := ""
 	if len(wheres) > 0 {
@@ -604,7 +604,7 @@ func (f *NumericalField) FetchNumericalStatsByResult(resultURI string, filterPar
 	if err != nil {
 		return nil, err
 	}
-	wheres = append(wheres, f.getNaNFilter())
+	wheres = append(wheres, f.getDefaultFilter(true))
 
 	params = append(params, resultURI)
 
@@ -676,10 +676,6 @@ func (f *NumericalField) getFromClause(alias bool) string {
 	}
 
 	return fromClause
-}
-
-func (f *NumericalField) getNaNFilter() string {
-	return fmt.Sprintf("\"%s\" != 'NaN'", f.Key)
 }
 
 func (f *NumericalField) fetchExtremaStorage() (*api.Extrema, error) {

--- a/api/model/storage/postgres/storage.go
+++ b/api/model/storage/postgres/storage.go
@@ -120,6 +120,7 @@ func (s *Storage) updateStats(storageName string) {
 
 // VerifyData checks each column in the table against every supported type, then updates what types are valid in the SuggestedType
 func (s *Storage) VerifyData(datasetID string, tableName string) error {
+	tableName = getBaseTableName(tableName)
 	validTypes := postgres.GetValidTypes()
 	ds, err := s.metadata.FetchDataset(datasetID, true, true, false)
 	if err != nil {

--- a/api/model/storage/postgres/variable.go
+++ b/api/model/storage/postgres/variable.go
@@ -129,6 +129,12 @@ func (s *Storage) fetchSummaryData(dataset string, storageName string, varName s
 		return nil, errors.Wrap(err, "failed to fetch summary data")
 	}
 
+	// add the default buckets
+	err = addDefaultBuckets(summary, field)
+	if err != nil {
+		return nil, err
+	}
+
 	// add dataset
 	summary.Dataset = dataset
 
@@ -302,4 +308,23 @@ func (s *Storage) createField(dataset string, storageName string, variable *mode
 	}
 
 	return field, nil
+}
+
+func addDefaultBuckets(summary *api.VariableSummary, field Field) error {
+	var err error
+	if summary.Baseline != nil {
+		summary.Baseline.DefaultBucket, err = field.fetchDefaultBucket()
+		if err != nil {
+			return err
+		}
+	}
+
+	if summary.Filtered != nil {
+		summary.Filtered.DefaultBucket, err = field.fetchDefaultBucket()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/api/model/variable_summary.go
+++ b/api/model/variable_summary.go
@@ -42,6 +42,7 @@ type Bucket struct {
 // Histogram represents a single variable histogram.
 type Histogram struct {
 	Extrema         *Extrema             `json:"extrema,omitempty"`
+	DefaultBucket   *Bucket              `json:"defaultBucket"`
 	Buckets         []*Bucket            `json:"buckets"`
 	CategoryBuckets map[string][]*Bucket `json:"categoryBuckets"`
 	Exemplars       []string             `json:"exemplars"`

--- a/api/postgres/postgres.go
+++ b/api/postgres/postgres.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/unchartedsoftware/plog"
@@ -43,7 +42,6 @@ const (
 	dataTypeLat      = "LATITUDE"
 	dataTypeLon      = "LONGITUDE"
 	dataTypeCoord    = "SPECIAL_COORD"
-	dateFormat       = "2006-01-02T15:04:05Z"
 
 	metadataTableCreationSQL = `CREATE TABLE %s (
 			name	text	NOT NULL,
@@ -753,10 +751,8 @@ func DefaultPostgresValueFromD3MType(typ string) interface{} {
 		return float64(0)
 	case model.LongitudeType, model.LatitudeType, model.RealType:
 		return "'NaN'::double precision"
-	case model.IntegerType, model.TimestampType:
-		return int(0)
-	case model.DateTimeType:
-		return fmt.Sprintf("'%s'", time.Time{}.Format(dateFormat))
+	case model.IntegerType, model.TimestampType, model.DateTimeType:
+		return "NULL"
 	case model.GeoBoundsType:
 		return "'POLYGON EMPTY'"
 	case model.RealVectorType, model.RealListType:

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -344,6 +344,10 @@ export function formatValue(colValue: any, colType: string): any {
 
   // If the schema type is an integer, round.
   if (isIntegerType(colType)) {
+    // missing integer values will be null
+    if (!colValue) {
+      return colValue;
+    }
     return Math.round(colValue).toFixed(0);
   }
 


### PR DESCRIPTION
Fixes #2690 

The initial view built during ingest is now built the same way as the view built when types get changed or fields get added (ex: clustering). It was not handling missing or default values before this change.

Checking for supported types during ingest queries the base table rather than the typed view to account for cases where the typed data may not handle missing values as expected or the type being checked may require different handling for default data.

Added a default value bucket and a default value filter when fetching summaries.