### PR TITLE
fix for table not appearing

### DIFF
--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -573,6 +573,11 @@ export const actions = {
           // close streampredict
           conn.close();
           requestStreams.delete(response.requestId);
+          // fetch solutions after completed to update resultUUID for confidence and error keys
+          actions.fetchSolutions(context, {
+            dataset: request.dataset,
+            target: request.target,
+          });
         }
       });
 


### PR DESCRIPTION
closes #2693
- We need to fetch the solutions once the results have come back in order to get the correct key for errorKey and ConfidenceKey
`				if len(sol.Results) > 0 {
					// result
					solution.ResultID = sol.Results[0].ResultUUID
					solution.FittedSolutionID = sol.Results[0].FittedSolutionID
					solution.PredictedKey = api.GetPredictedKey(sol.Results[0].ResultUUID)
					solution.ErrorKey = api.GetErrorKey(sol.Results[0].ResultUUID)
					solution.ConfidenceKey = api.GetConfidenceKey(sol.Results[0].ResultUUID)
				}
				solutions = append(solutions, solution)`