### PR TITLE
Remote Sensing Filtered Model Application

### DIFF
--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -285,7 +285,7 @@ func (s *Satellite) CreateDataset(rootDataPath string, datasetName string, confi
 	dr.Variables = append(dr.Variables,
 		model.NewVariable(varCounter, "__geo_coordinates", "coordinates", "geo_coordinates", "__geo_coordinates", model.GeoBoundsType,
 			model.GeoBoundsType, "postgis structure for the bounding box coordinates of the tile", []string{},
-			model.VarDistilRoleMetadata, nil, dr.Variables, false))
+			model.VarDistilRoleData, nil, dr.Variables, false))
 	varCounter++
 	if len(expectedHeaders) == len(headerNames) {
 		dr.Variables = append(dr.Variables,


### PR DESCRIPTION
Fixes #2705 

Remote sensing dataset polygon column switched to be data and not metadata. Because it was set to data, prefiltering was not using it in the data sent to the server, which meant it was not part of the dataset used for modelling. Consequently, when applying the model to the prediction dataset, the columns were not aligned properly because the prediction dataset was using the source dataset fields and not the filtered dataset fields.

A more general solution to this potential source of problems should probably be considered. The only time this problem should occur is if there are non data (or system data) fields in the disk dataset. Perhaps some kind of check for that should be added during prefiltering?