### PR TITLE
State wrapper

### DIFF
--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -1343,7 +1343,9 @@ export default Vue.extend({
   color: #000;
   cursor: pointer;
 }
-
+.selection-mode {
+  cursor: cell;
+}
 .geo-close-button:hover {
   background-color: #f4f4f4;
 }

--- a/public/components/layout/ActionColumn.vue
+++ b/public/components/layout/ActionColumn.vue
@@ -43,9 +43,9 @@
         <b-button
           role="tab"
           data-toggle="tab"
-          variant="light"
+          :variant="toggleColor(action.toggle)"
           class="box-shadow-none"
-          @click.stop.prevent="toggle($event, action.paneId)"
+          @click.stop.prevent="toggle(action.paneId)"
         >
           <i :class="action.icon" />
         </b-button>
@@ -56,14 +56,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-
-export interface Action {
-  name: string;
-  icon: string;
-  paneId: string;
-  count?: number;
-  toggle?: boolean;
-}
+import { Action } from "../../util/dataExplorer";
 
 export default Vue.extend({
   name: "ActionColumn",
@@ -80,16 +73,20 @@ export default Vue.extend({
     },
     baseActions(): Action[] {
       return this.actions.filter((a) => {
-        return !a.toggle;
+        return a.toggle === undefined;
       });
     },
   },
   methods: {
-    toggle(event: MouseEvent, actionName: string): void {
-      const button = event.currentTarget as HTMLElement;
-      button.classList.toggle("btn-light");
-      button.classList.toggle("btn-primary");
-      this.$emit("toggle-action", actionName);
+    toggleColor(toggle: boolean): string {
+      return toggle ? "primary" : "light";
+    },
+    toggle(paneId: string): void {
+      const action = this.toggleActions.find((ta) => {
+        return ta.paneId === paneId;
+      });
+      action.toggle = !action.toggle;
+      this.$emit("toggle-action", action.paneId);
     },
     setActive(actionName: string): void {
       // If the action is currently selected, pass ''

--- a/public/components/panel/FacetListPane.vue
+++ b/public/components/panel/FacetListPane.vue
@@ -83,6 +83,7 @@ export default Vue.extend({
     },
     enableColorScales: { type: Boolean as () => boolean, default: false },
     include: { type: Boolean as () => boolean, default: true },
+    enableFooter: { type: Boolean as () => boolean, default: false },
   },
 
   data() {
@@ -94,31 +95,33 @@ export default Vue.extend({
   },
 
   computed: {
-    buttons(): (group: Group) => HTMLElement {
-      return (group: Group) => {
-        const variable = group.key;
+    buttons(): (group: Group) => HTMLElement | null {
+      return !this.enableFooter
+        ? null
+        : (group: Group) => {
+            const variable = group.key;
 
-        // Display and Hide variables in the Data Explorer.
-        const exploreButton = this.displayButton(variable);
+            // Display and Hide variables in the Data Explorer.
+            const exploreButton = this.displayButton(variable);
 
-        // Add/Remove a variable as training.
-        const trainingButton = this.trainingButton(variable);
+            // Add/Remove a variable as training.
+            const trainingButton = this.trainingButton(variable);
 
-        // Add/Remove a variable as target.
-        const targetButton = this.targetButton(variable);
+            // Add/Remove a variable as target.
+            const targetButton = this.targetButton(variable);
 
-        // List of model creation buttons to be added.
-        const buttons = [targetButton, trainingButton].filter((b) => !!b);
-        const modelButtons = document.createElement("div");
-        modelButtons.className = "btn-group ml-auto";
-        modelButtons.append(...buttons);
+            // List of model creation buttons to be added.
+            const buttons = [targetButton, trainingButton].filter((b) => !!b);
+            const modelButtons = document.createElement("div");
+            modelButtons.className = "btn-group ml-auto";
+            modelButtons.append(...buttons);
 
-        // Container to display the buttons with flex.
-        const container = document.createElement("div");
-        container.className = "d-flex";
-        container.append(exploreButton, modelButtons);
-        return container;
-      };
+            // Container to display the buttons with flex.
+            const container = document.createElement("div");
+            container.className = "d-flex";
+            container.append(exploreButton, modelButtons);
+            return container;
+          };
     },
     dataset(): string {
       return routeGetters.getRouteDataset(this.$store);

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1131,6 +1131,9 @@ export const actions = {
     });
     const values = await Promise.all(promises);
     values.map((v) => {
+      if (!v) {
+        return;
+      }
       if (v.context) mutator(v.context, v.summary);
     });
   },

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -26,7 +26,6 @@ import {
   fetchSolutionResultSummary,
   fetchSummaryExemplars,
   minimumRouteKey,
-  updateSummaries,
   validateArgs,
   VARIABLE_SUMMARY_BASE,
   VARIABLE_SUMMARY_CONFIDENCE,
@@ -849,6 +848,9 @@ export const actions = {
       })
     );
     values.map((v) => {
+      if (!v) {
+        return;
+      }
       const val = v as VariableSummaryResp<ResultsContext>;
       mutations.updateCorrectnessSummaries(val.context, val.summary);
     });

--- a/public/util/dataExplorer.ts
+++ b/public/util/dataExplorer.ts
@@ -1,0 +1,126 @@
+export interface Action {
+  name: string;
+  icon: string;
+  paneId: string;
+  count?: number;
+  toggle?: boolean;
+}
+
+export default interface ExplorerConfig {
+  // whether the footer is enabled
+  readonly facetFooterEnabled: boolean;
+  // whether include/exclude in needed on this state
+  readonly includeExcludeEnabled: boolean;
+  // required actions in current state
+  readonly actionList: Action[];
+}
+export class SelectViewConfig implements ExplorerConfig {
+  facetFooterEnabled = true;
+  includeExcludeEnabled = true;
+  get actionList(): Action[] {
+    const actions = [
+      ActionNames.CREATE_NEW_VARIABLE,
+      ActionNames.ALL_VARIABLES,
+      ActionNames.TEXT_VARIABLES,
+      ActionNames.CATEGORICAL_VARIABLES,
+      ActionNames.NUMBER_VARIABLES,
+      ActionNames.LOCATION_VARIABLES,
+      ActionNames.IMAGE_VARIABLES,
+      ActionNames.UNKNOWN_VARIABLES,
+      ActionNames.TARGET_VARIABLE,
+      ActionNames.TRAINING_VARIABLE,
+    ];
+    return actions.map((a) => {
+      return ACTION_MAP.get(a);
+    });
+  }
+}
+export class ResultViewConfig implements ExplorerConfig {
+  facetFooterEnabled = false;
+  includeExcludeEnabled = false;
+  get actionList(): Action[] {
+    const actions = [
+      ActionNames.ALL_VARIABLES,
+      ActionNames.TEXT_VARIABLES,
+      ActionNames.CATEGORICAL_VARIABLES,
+      ActionNames.NUMBER_VARIABLES,
+      ActionNames.LOCATION_VARIABLES,
+      ActionNames.IMAGE_VARIABLES,
+      ActionNames.UNKNOWN_VARIABLES,
+      ActionNames.TARGET_VARIABLE,
+      ActionNames.TRAINING_VARIABLE,
+      ActionNames.OUTCOME_VARIABLES,
+    ];
+    return actions.map((a) => {
+      return ACTION_MAP.get(a);
+    });
+  }
+}
+export enum ActionNames {
+  CREATE_NEW_VARIABLE = "Create New Variable",
+  ALL_VARIABLES = "All Variables",
+  TEXT_VARIABLES = "Text Variables",
+  CATEGORICAL_VARIABLES = "Categorical Variables",
+  NUMBER_VARIABLES = "Number Variables",
+  TIME_VARIABLES = "Time Variables",
+  LOCATION_VARIABLES = "Location Variables",
+  IMAGE_VARIABLES = "Image Variables",
+  UNKNOWN_VARIABLES = "Unknown Variables",
+  TARGET_VARIABLE = "Target Variable",
+  TRAINING_VARIABLE = "Training Variables",
+  OUTCOME_VARIABLES = "Outcome Variables",
+}
+
+export const ACTIONS = [
+  { name: ActionNames.CREATE_NEW_VARIABLE, icon: "fa fa-plus", paneId: "add" },
+  {
+    name: ActionNames.ALL_VARIABLES,
+    icon: "fa fa-database",
+    paneId: "available",
+  },
+  { name: ActionNames.TEXT_VARIABLES, icon: "fa fa-font", paneId: "text" },
+  {
+    name: ActionNames.CATEGORICAL_VARIABLES,
+    icon: "fa fa-align-left",
+    paneId: "categorical",
+  },
+  {
+    name: ActionNames.NUMBER_VARIABLES,
+    icon: "fa fa-bar-chart",
+    paneId: "number",
+  },
+  { name: ActionNames.TIME_VARIABLES, icon: "fa fa-clock-o", paneId: "time" },
+  {
+    name: ActionNames.LOCATION_VARIABLES,
+    icon: "fa fa-map-o",
+    paneId: "location",
+  },
+  { name: ActionNames.IMAGE_VARIABLES, icon: "fa fa-image", paneId: "image" },
+  {
+    name: ActionNames.UNKNOWN_VARIABLES,
+    icon: "fa fa-question",
+    paneId: "unknown",
+  },
+  {
+    name: ActionNames.TARGET_VARIABLE,
+    icon: "fa fa-crosshairs",
+    paneId: "target",
+  },
+  {
+    name: ActionNames.TRAINING_VARIABLE,
+    icon: "fa fa-asterisk",
+    paneId: "training",
+  },
+  {
+    name: ActionNames.OUTCOME_VARIABLES,
+    icon: "fas fa-poll",
+    paneId: "outcome",
+    toggle: true,
+  },
+] as Action[];
+
+export const ACTION_MAP = new Map(
+  ACTIONS.map((a) => {
+    return [a.name, a];
+  })
+);

--- a/public/util/state/AppStateWrapper.ts
+++ b/public/util/state/AppStateWrapper.ts
@@ -51,6 +51,7 @@ export interface BaseState {
   // gets table data fields
   getFields(include?: boolean): Dictionary<TableColumn>;
   /******Fetch Functions**********/
+  init(): Promise<void>;
   fetchVariables(): Promise<unknown>;
   fetchData(): Promise<unknown>;
   fetchVariableSummaries(): Promise<unknown>;
@@ -59,6 +60,11 @@ export interface BaseState {
 }
 
 export class SelectViewState implements BaseState {
+  async init(): Promise<void> {
+    await this.fetchVariables();
+    await this.fetchMapBaseline();
+    return;
+  }
   getSecondaryVariables(): Variable[] {
     return routeGetters.getAvailableVariables(store);
   }
@@ -140,6 +146,11 @@ export class SelectViewState implements BaseState {
 }
 
 export class ResultViewState implements BaseState {
+  async init(): Promise<void> {
+    await this.fetchVariables();
+    await this.fetchMapBaseline();
+    return;
+  }
   getSecondaryVariables(): Variable[] {
     const solutionID = routeGetters.getRouteSolutionId(store);
     const solution = getSolutionById(

--- a/public/util/state/AppStateWrapper.ts
+++ b/public/util/state/AppStateWrapper.ts
@@ -201,7 +201,9 @@ export class ResultViewState implements BaseState {
     return viewActions.updateResultAreaOfInterest(store, filter);
   }
   getVariables(): Variable[] {
-    return requestGetters.getActiveSolutionTrainingVariables(store);
+    return requestGetters
+      .getActiveSolutionTrainingVariables(store)
+      .concat([routeGetters.getTargetVariable(store)]);
   }
   getData(): TableRow[] {
     return resultGetters.getIncludedResultTableDataItems(store);

--- a/public/util/state/AppStateWrapper.ts
+++ b/public/util/state/AppStateWrapper.ts
@@ -152,10 +152,13 @@ export class ResultViewState implements BaseState {
     return;
   }
   getSecondaryVariables(): Variable[] {
-    const solutionID = routeGetters.getRouteSolutionId(store);
+    const solutionId = routeGetters.getRouteSolutionId(store);
+    if (!solutionId) {
+      return [];
+    }
     const solution = getSolutionById(
       requestGetters.getRelevantSolutions(store),
-      solutionID
+      solutionId
     );
     return resultSummariesToVariables(solution?.resultId);
   }
@@ -175,6 +178,9 @@ export class ResultViewState implements BaseState {
   getSecondaryVariableSummaries(): VariableSummary[] {
     const currentSummaries = [];
     const solution = requestGetters.getActiveSolution(store);
+    if (!solution?.resultId) {
+      return [];
+    }
     const predictedSummary = getSolutionResultSummary(solution.resultId);
     if (predictedSummary) {
       currentSummaries.push(predictedSummary);
@@ -201,9 +207,7 @@ export class ResultViewState implements BaseState {
     return viewActions.updateResultAreaOfInterest(store, filter);
   }
   getVariables(): Variable[] {
-    return requestGetters
-      .getActiveSolutionTrainingVariables(store)
-      .concat([routeGetters.getTargetVariable(store)]);
+    return requestGetters.getActiveSolutionTrainingVariables(store);
   }
   getData(): TableRow[] {
     return resultGetters.getIncludedResultTableDataItems(store);
@@ -213,14 +217,14 @@ export class ResultViewState implements BaseState {
       store
     );
     const variables = this.getVariables();
-    const trainingSummaries = getVariableSummariesByState(
-      0,
-      variables.length,
+    const trainingSummaries = getAllVariablesSummaries(
       variables,
-      summaryDictionary,
-      true
+      summaryDictionary
     );
-
+    const target = routeGetters.getTargetVariableSummaries(store)(true);
+    if (target) {
+      return trainingSummaries.concat(target);
+    }
     return trainingSummaries;
   }
   getMapBaseline(): TableRow[] {
@@ -233,11 +237,17 @@ export class ResultViewState implements BaseState {
     return resultGetters.getAreaOfInterestOuterDataItems(store);
   }
   getLexBarVariables(): Variable[] {
-    const solutionID = routeGetters.getRouteSolutionId(store);
+    const solutionId = routeGetters.getRouteSolutionId(store);
+    if (!solutionId) {
+      return [];
+    }
     const solution = getSolutionById(
       requestGetters.getRelevantSolutions(store),
-      solutionID
+      solutionId
     );
+    if (solution?.resultId) {
+      return [];
+    }
     const resultVariables = resultSummariesToVariables(solution?.resultId);
     return datasetGetters.getAllVariables(store).concat(resultVariables);
   }

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -143,22 +143,21 @@
         </b-button-toolbar>
         <create-solutions-form
           v-if="isCreateModelPossible"
+          ref="model-creation-form"
           class="ml-2"
           @create-model="onModelCreation"
         />
       </footer>
     </main>
-    <left-side-panel v-if="toggleAction.outcome" :panel-title="currentAction">
+    <left-side-panel
+      v-if="toggleAction.outcome"
+      panel-title="Outcome Variables"
+      class="overflow-auto"
+    >
       <template v-if="hasNoVariables">
         <p>No Outcome Variables available.</p>
       </template>
-      <facet-list-pane
-        v-else
-        :variables="secondaryVariables"
-        :summaries="secondarySummaries"
-        :enable-color-scales="geoVarExists"
-        :include="include"
-      />
+      <result-facets v-else />
     </left-side-panel>
     <status-sidebar />
     <status-panel />
@@ -184,6 +183,7 @@ import SelectGraphView from "../components/SelectGraphView.vue";
 import SelectTimeseriesView from "../components/SelectTimeseriesView.vue";
 import StatusPanel from "../components/StatusPanel.vue";
 import StatusSidebar from "../components/StatusSidebar.vue";
+import ResultFacets from "../components/ResultFacets.vue";
 
 // Store
 import {
@@ -285,6 +285,7 @@ export default Vue.extend({
     SearchBar,
     SelectDataTable,
     GeoPlot,
+    ResultFacets,
     SelectGraphView,
     SelectTimeseriesView,
     StatusPanel,
@@ -584,7 +585,11 @@ export default Vue.extend({
           });
           this.$router.push(entry).catch((err) => console.warn(err));
           this.setState(new ResultViewState());
-          await this.state.fetchVariables();
+          await this.state.init();
+          const modelCreationRef = this.$refs[
+            "model-creation-form"
+          ] as InstanceType<typeof CreateSolutionsForm>;
+          modelCreationRef.pending = false;
         })
         .catch((err) => {
           console.error(err);


### PR DESCRIPTION
- Added a dataExplorer util file to hold all of the state related things
- Added ExplorerConfig interface which allows us to toggle different things in the data explorer based on state (include/exclude, createModel button, different actions, facet footers).
- results seem to be stable next is to add a way back to the select screen.