### PR TITLE
State wrapper

### DIFF
--- a/api/routes/solutions.go
+++ b/api/routes/solutions.go
@@ -43,7 +43,7 @@ type SolutionResponse struct {
 	PredictedKey     string               `json:"predictedKey"`
 	ErrorKey         string               `json:"errorKey"`
 	ConfidenceKey    string               `json:"confidenceKey"`
-	HasPredictions	 bool					`json:"hasPredictions"`
+	HasPredictions   bool                 `json:"hasPredictions"`
 }
 
 // SolutionsHandler fetches solutions associated with a given dataset and target.

--- a/public/components/JoinDatasetsPreview.vue
+++ b/public/components/JoinDatasetsPreview.vue
@@ -72,8 +72,6 @@
 import _ from "lodash";
 import Vue from "vue";
 import JoinDataPreviewSlot from "../components/JoinDataPreviewSlot.vue";
-import { SaveInfo } from "./SaveModal.vue";
-import { createRouteEntry } from "../util/routes";
 import { Dictionary } from "../util/dict";
 import { getters as routeGetters } from "../store/route/module";
 import {
@@ -84,7 +82,7 @@ import {
 } from "../store/dataset/index";
 import { actions as datasetActions } from "../store/dataset/module";
 import { getTableDataItems, getTableDataFields } from "../util/data";
-import { EventList } from "../util/events";
+import { EventList, EI } from "../util/events";
 
 export default Vue.extend({
   name: "JoinDatasetsPreview",
@@ -156,7 +154,7 @@ export default Vue.extend({
   },
 
   methods: {
-    onSave(args: SaveInfo) {
+    onSave(args: EI.RESULT.SaveInfo) {
       this.pending = true;
 
       const leftCols = routeGetters

--- a/public/components/NavBar.vue
+++ b/public/components/NavBar.vue
@@ -95,6 +95,13 @@
           >
             <i class="fa fa-check-circle nav-icon" /> Check Models
           </b-nav-item>
+          <b-nav-item
+            :active="explorerPredictionState"
+            :disabled="hasNoDatasetAndTarget"
+            @click="explorerNav('prediction')"
+          >
+            <i class="fa fa-line-chart nav-icon" /> View Predictions
+          </b-nav-item>
         </template>
       </b-navbar-nav>
     </b-collapse>
@@ -206,6 +213,9 @@ export default Vue.extend({
     },
     explorerResultState(): boolean {
       return this.dataExplorerState === ExplorerStateNames.RESULT_VIEW;
+    },
+    explorerPredictionState(): boolean {
+      return this.dataExplorerState === ExplorerStateNames.PREDICTION_VIEW;
     },
     hasDataset(): boolean {
       return !!this.dataset;

--- a/public/components/PredictionSummaries.vue
+++ b/public/components/PredictionSummaries.vue
@@ -17,7 +17,9 @@
 
 <template>
   <div class="prediction-summaries mh-100">
-    <p class="nav-link font-weight-bold">Predictions for Dataset</p>
+    <p v-if="includeTitle" class="nav-link font-weight-bold">
+      Predictions for Dataset
+    </p>
     <div class="prediction-group-container overflow-auto">
       <div v-for="meta in metaSummaries" :key="meta.summary.key">
         <div
@@ -55,7 +57,9 @@
         </div>
       </div>
     </div>
-    <b-button v-b-modal.save class="mt-3"> Create Dataset </b-button>
+    <b-button v-if="includeFooter" v-b-modal.save class="mt-3">
+      Create Dataset
+    </b-button>
 
     <b-modal id="save" title="Create Dataset" @ok="createDataset">
       <div class="check-message-container d-flex justify-content-around">
@@ -72,7 +76,12 @@
       </div>
     </b-modal>
 
-    <b-button variant="primary" class="float-right mt-3" v-b-modal.export>
+    <b-button
+      v-if="includeFooter"
+      variant="primary"
+      class="float-right mt-3"
+      v-b-modal.export
+    >
       Export Predictions
     </b-button>
 
@@ -147,7 +156,10 @@ export default Vue.extend({
     FileUploader,
     PredictionGroup,
   },
-
+  props: {
+    includeFooter: { type: Boolean as () => boolean, default: false },
+    includeTitle: { type: Boolean as () => boolean, default: false },
+  },
   data() {
     return {
       saveFileName: "",

--- a/public/components/PredictionsDataUploader.vue
+++ b/public/components/PredictionsDataUploader.vue
@@ -94,6 +94,7 @@ import { getPredictionsById } from "../util/predictions";
 import { varModesToString, createRouteEntry } from "../util/routes";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 import { PREDICTION_ROUTE } from "../store/route";
+import { EventList } from "../util/events";
 
 export default Vue.extend({
   name: "PredictionsUploader",
@@ -102,6 +103,7 @@ export default Vue.extend({
     fittedSolutionId: String as () => string,
     target: String as () => string,
     targetType: String as () => string,
+    handleModelCreation: { type: Boolean as () => boolean, default: false },
   },
 
   data() {
@@ -164,7 +166,7 @@ export default Vue.extend({
     },
 
     async makeRequest() {
-      var deconflictedName = generateUniqueDatasetName(
+      const deconflictedName = generateUniqueDatasetName(
         removeExtension(this.file.name)
       );
 
@@ -262,8 +264,12 @@ export default Vue.extend({
           applyModel: true.toString(),
           solutionId: routeGetters.getRouteSolutionId(this.$store),
         };
-        const entry = createRouteEntry(PREDICTION_ROUTE, routeArgs);
-        this.$router.push(entry).catch((err) => console.warn(err));
+        if (this.handleModelCreation) {
+          const entry = createRouteEntry(PREDICTION_ROUTE, routeArgs);
+          this.$router.push(entry).catch((err) => console.warn(err));
+          return;
+        }
+        this.$emit(EventList.MODEL.APPLY_EVENT, routeArgs);
       }
     },
   },

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -95,7 +95,7 @@ import ResultFacets from "../components/ResultFacets.vue";
 import PredictionsDataUploader from "../components/PredictionsDataUploader.vue";
 import ForecastHorizon from "../components/ForecastHorizon.vue";
 import ErrorThresholdSlider from "../components/ErrorThresholdSlider.vue";
-import SaveModal, { SaveInfo } from "./SaveModal.vue";
+import SaveModal from "./SaveModal.vue";
 import ResultTargetVariable from "../components/ResultTargetVariable.vue";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as routeGetters } from "../store/route/module";
@@ -106,6 +106,7 @@ import { Solution, SolutionStatus } from "../store/requests/index";
 import { isFittedSolutionIdSavedAsModel } from "../util/models";
 import { Feature, Activity, SubActivity } from "../util/userEvents";
 import { actions as appActions } from "../store/app/module";
+import { EI } from "../util/events";
 
 export default Vue.extend({
   name: "ResultSummaries",
@@ -214,7 +215,7 @@ export default Vue.extend({
 
   methods: {
     isFittedSolutionIdSavedAsModel,
-    async onSaveModel(args: SaveInfo) {
+    async onSaveModel(args: EI.RESULT.SaveInfo) {
       appActions.logUserEvent(this.$store, {
         feature: Feature.EXPORT_MODEL,
         activity: Activity.MODEL_SELECTION,

--- a/public/components/ResultSummaries.vue
+++ b/public/components/ResultSummaries.vue
@@ -50,6 +50,7 @@
         :fitted-solution-id="fittedSolutionId"
         :target="target"
         :target-type="targetType"
+        handle-model-creation
       />
       <template v-if="isSingleSolution || isActiveSolutionSaved">
         <b-button

--- a/public/components/SaveModal.vue
+++ b/public/components/SaveModal.vue
@@ -84,14 +84,7 @@ import { SEARCH_ROUTE } from "../store/route";
 import { getters as routeGetters } from "../store/route/module";
 import { createRouteEntry } from "../util/routes";
 import router from "../router/router";
-import { EventList } from "../util/events";
-
-export interface SaveInfo {
-  solutionId: string;
-  fittedSolution: string;
-  name: string;
-  description: string;
-}
+import { EventList, EI } from "../util/events";
 
 export default Vue.extend({
   name: "SaveModal",
@@ -202,7 +195,7 @@ export default Vue.extend({
         fittedSolution: this.fittedSolutionId,
         name: this.saveName,
         description: this.saveDescription,
-      } as SaveInfo);
+      } as EI.RESULT.SaveInfo);
     },
     showSuccessModel() {
       this.isSaving = false;

--- a/public/components/panel/AddVariablePane.vue
+++ b/public/components/panel/AddVariablePane.vue
@@ -17,12 +17,53 @@
 
 <template>
   <div>
-    <b-button @click="onTimeseriesClick" variant="dark">
+    <b-button variant="dark" @click="onTimeseriesClick">
       <i class="fa fa-area-chart" /> Timeseries
     </b-button>
-    <b-button @click="onMapClick" variant="dark">
+    <b-button variant="dark" @click="onMapClick">
       <i class="fa fa-globe" /> Map
     </b-button>
+    <b-button variant="dark" @click="onLabelClick">
+      <i class="fa fa-tag" /> Label
+    </b-button>
+    <b-modal
+      :id="modalId"
+      @hide="onLabelSubmit"
+      no-close-on-backdrop
+      ok-only
+      no-close-on-esc
+    >
+      <template #modal-header>
+        {{ labelModalTitle }}
+      </template>
+      <b-form-group
+        v-if="!isClone"
+        id="input-group-1"
+        label="Label name:"
+        label-for="label-input-field"
+        description="Enter the name of label."
+      >
+        <b-form-input
+          id="label-input-field"
+          v-model="labelName"
+          type="text"
+          required
+          :placeholder="labelName"
+        />
+      </b-form-group>
+      <b-form-group
+        v-else
+        label="Label name:"
+        label-for="label-select-field"
+        description="Select the label field."
+      >
+        <b-form-select
+          id="label-select-field"
+          v-model="labelName"
+          :options="options"
+        />
+      </b-form-group>
+    </b-modal>
   </div>
 </template>
 
@@ -52,6 +93,9 @@ export default Vue.extend({
 
     onTimeseriesClick() {
       this.groupingClick(TIMESERIES_TYPE);
+    },
+    onLabelClick() {
+      return;
     },
   },
 });

--- a/public/store/requests/index.ts
+++ b/public/store/requests/index.ts
@@ -75,6 +75,7 @@ export interface Solution extends SolutionRequest {
   confidenceKey: string;
   isBad: boolean;
   featureLabel: string;
+  hasPredictions: boolean;
 }
 
 export interface Predictions extends Request {

--- a/public/util/componentTypes.ts
+++ b/public/util/componentTypes.ts
@@ -1,0 +1,71 @@
+/**
+ *
+ *    Copyright © 2021 Uncharted Software Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import Vue from "vue";
+import VueRouter from "vue-router";
+import { Highlight, RowSelection, Variable } from "../store/dataset";
+import { Solution } from "../store/requests";
+import { ExplorerStateNames } from "./dataExplorer";
+import { RouteArgs } from "./routes";
+import { BaseState } from "./state/AppStateWrapper";
+
+/**
+ * Add any component types needed for typescript
+ * Add a path above the interface
+ */
+
+// public/views/DataExplorer.vue
+export interface DataExplorerRef {
+  // computes
+  dataset: string;
+  isClone: boolean | null;
+  highlights: Highlight[];
+  isFilteringHighlights: boolean;
+  isFilteringSelection: boolean;
+  target: Variable;
+  training: string[];
+  solution: Solution;
+  fittedSolutionId: string;
+  rowSelection: RowSelection;
+  variables: Variable[];
+  // data
+  labelName: string;
+  state: BaseState;
+  // methods
+  isFittedSolutionIdSavedAsModel: (id: string) => boolean;
+  updateRoute: (args: RouteArgs) => void;
+  changeStatesByName: (name: ExplorerStateNames) => Promise<void>;
+  resetHighlightsOrRow: () => void;
+  // globals
+  $refs: {
+    [key: string]: Vue | Element | Vue[] | Element[];
+  };
+  $router: VueRouter;
+}
+
+// public/components/layout/ActionColumn.vue
+export interface ActionColumnRef extends Vue {
+  toggle: (paneId: string) => void;
+}
+// public/components/CreateSolutionsForm.vue
+export interface CreateSolutionsFormRef extends Vue {
+  pending: boolean;
+}
+// public/components/SaveModal.vue
+export interface SaveModalRef extends Vue {
+  showSuccessModel: () => void;
+}

--- a/public/util/dataExplorer.ts
+++ b/public/util/dataExplorer.ts
@@ -1,5 +1,6 @@
 import {
   BaseState,
+  PredictViewState,
   ResultViewState,
   SelectViewState,
 } from "./state/AppStateWrapper";
@@ -35,7 +36,7 @@ export function getConfigFromName(state: ExplorerStateNames): ExplorerConfig {
     case ExplorerStateNames.RESULT_VIEW:
       return new ResultViewConfig();
     case ExplorerStateNames.PREDICTION_VIEW:
-      throw Error("Prediction config not implemented");
+      return new PredictViewConfig();
     default:
       throw Error("Config State not supported");
   }
@@ -48,7 +49,7 @@ export function getStateFromName(state: ExplorerStateNames): BaseState {
     case ExplorerStateNames.RESULT_VIEW:
       return new ResultViewState();
     case ExplorerStateNames.PREDICTION_VIEW:
-      throw Error("Prediction config not implemented");
+      return new PredictViewState();
     default:
       throw Error("Config State not supported");
   }
@@ -76,6 +77,27 @@ export class SelectViewConfig implements ExplorerConfig {
   }
 }
 export class ResultViewConfig implements ExplorerConfig {
+  facetFooterEnabled = false;
+  includeExcludeEnabled = false;
+  get actionList(): Action[] {
+    const actions = [
+      ActionNames.ALL_VARIABLES,
+      ActionNames.TEXT_VARIABLES,
+      ActionNames.CATEGORICAL_VARIABLES,
+      ActionNames.NUMBER_VARIABLES,
+      ActionNames.LOCATION_VARIABLES,
+      ActionNames.IMAGE_VARIABLES,
+      ActionNames.UNKNOWN_VARIABLES,
+      ActionNames.TARGET_VARIABLE,
+      ActionNames.TRAINING_VARIABLE,
+      ActionNames.OUTCOME_VARIABLES,
+    ];
+    return actions.map((a) => {
+      return ACTION_MAP.get(a);
+    });
+  }
+}
+export class PredictViewConfig implements ExplorerConfig {
   facetFooterEnabled = false;
   includeExcludeEnabled = false;
   get actionList(): Action[] {

--- a/public/util/dataExplorer.ts
+++ b/public/util/dataExplorer.ts
@@ -1,9 +1,12 @@
+import { datasetGetters } from "../store";
 import {
   BaseState,
   PredictViewState,
   ResultViewState,
   SelectViewState,
 } from "./state/AppStateWrapper";
+import DataExplorer from "../views/DataExplorer.vue";
+import store from "../store/store";
 
 export interface Action {
   name: string;
@@ -14,10 +17,6 @@ export interface Action {
 }
 
 export default interface ExplorerConfig {
-  // whether the footer is enabled
-  readonly facetFooterEnabled: boolean;
-  // whether include/exclude in needed on this state
-  readonly includeExcludeEnabled: boolean;
   // required actions in current state
   actionList: Action[];
 }
@@ -56,8 +55,6 @@ export function getStateFromName(state: ExplorerStateNames): BaseState {
 }
 
 export class SelectViewConfig implements ExplorerConfig {
-  facetFooterEnabled = true;
-  includeExcludeEnabled = true;
   get actionList(): Action[] {
     const actions = [
       ActionNames.CREATE_NEW_VARIABLE,
@@ -77,8 +74,6 @@ export class SelectViewConfig implements ExplorerConfig {
   }
 }
 export class ResultViewConfig implements ExplorerConfig {
-  facetFooterEnabled = false;
-  includeExcludeEnabled = false;
   get actionList(): Action[] {
     const actions = [
       ActionNames.ALL_VARIABLES,
@@ -98,8 +93,6 @@ export class ResultViewConfig implements ExplorerConfig {
   }
 }
 export class PredictViewConfig implements ExplorerConfig {
-  facetFooterEnabled = false;
-  includeExcludeEnabled = false;
   get actionList(): Action[] {
     const actions = [
       ActionNames.ALL_VARIABLES,
@@ -186,3 +179,16 @@ export const ACTION_MAP = new Map(
     return [a.name, a];
   })
 );
+/**************MIXINS********************/
+export const SELECT_VIEW_COMPUTED = {};
+export const SELECT_VIEW_METHODS = {};
+export const LABEL_VIEW_COMPUTED = {
+  isClone(datasetName: string): boolean | null {
+    const datasets = datasetGetters.getDatasets(store);
+    const dataset = datasets.find((d) => d.id === datasetName);
+    if (!dataset) {
+      return null;
+    }
+    return dataset.clone === undefined ? false : dataset.clone;
+  },
+};

--- a/public/util/events.ts
+++ b/public/util/events.ts
@@ -140,5 +140,12 @@ export declare namespace EI {
       timeseriesIds: TableRow[];
     }
   }
-  namespace Explorer {}
+  namespace RESULT {
+    interface SaveInfo {
+      solutionId: string;
+      fittedSolution: string;
+      name: string;
+      description: string;
+    }
+  }
 }

--- a/public/util/events.ts
+++ b/public/util/events.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { Variable, TableRow } from "../store/dataset/index";
+import { TableRow, Variable } from "../store/dataset/index";
 /**
  * ALL EVENT RELATED CODE SHOULD BE HERE
  */
@@ -101,6 +101,8 @@ export class EventList {
     SAVE_EVENT: "save",
     // delete the model
     DELETE_EVENT: "model-delete",
+    // apply model
+    APPLY_EVENT: "model-apply",
   };
   static readonly EXPLORER = {
     NAV_EVENT: "nav-event",

--- a/public/util/state/AppStateWrapper.ts
+++ b/public/util/state/AppStateWrapper.ts
@@ -36,6 +36,7 @@ import {
   resultSummariesToVariables,
   summaryToVariable,
 } from "../summaries";
+import { DISTIL_ROLES } from "../types";
 
 export interface BaseState {
   name: ExplorerStateNames;
@@ -466,5 +467,65 @@ export class PredictViewState implements BaseState {
   }
   fetchMapDrillDown(filter: Filter): Promise<void[]> {
     return viewActions.updatePredictionAreaOfInterest(store, filter);
+  }
+}
+
+export class LabelViewState implements BaseState {
+  name: ExplorerStateNames.LABEL_VIEW;
+  getVariables(): Variable[] {
+    return datasetGetters.getVariables(store).filter((v) => {
+      return v.distilRole !== DISTIL_ROLES.SystemData;
+    });
+  }
+  getSecondaryVariables(): Variable[] {
+    throw new Error("Method not implemented.");
+  }
+  getData(include?: boolean): TableRow[] {
+    throw new Error("Method not implemented.");
+  }
+  getBaseVariableSummaries(include?: boolean): VariableSummary[] {
+    throw new Error("Method not implemented.");
+  }
+  getSecondaryVariableSummaries(include?: boolean): VariableSummary[] {
+    throw new Error("Method not implemented.");
+  }
+  getAllVariableSummaries(include?: boolean): VariableSummary[] {
+    throw new Error("Method not implemented.");
+  }
+  getTargetVariable(): Variable {
+    throw new Error("Method not implemented.");
+  }
+  getMapBaseline(): TableRow[] {
+    throw new Error("Method not implemented.");
+  }
+  getMapDrillDownBaseline(include?: boolean): TableRow[] {
+    throw new Error("Method not implemented.");
+  }
+  getMapDrillDownFiltered(include?: boolean): TableRow[] {
+    throw new Error("Method not implemented.");
+  }
+  getLexBarVariables(): Variable[] {
+    throw new Error("Method not implemented.");
+  }
+  getFields(include?: boolean): Dictionary<TableColumn> {
+    throw new Error("Method not implemented.");
+  }
+  init(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  fetchVariables(): Promise<unknown> {
+    throw new Error("Method not implemented.");
+  }
+  fetchData(): Promise<unknown> {
+    throw new Error("Method not implemented.");
+  }
+  fetchVariableSummaries(): Promise<unknown> {
+    throw new Error("Method not implemented.");
+  }
+  fetchMapBaseline(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  fetchMapDrillDown(filter: Filter): Promise<void[]> {
+    throw new Error("Method not implemented.");
   }
 }

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -159,6 +159,7 @@
           :fitted-solution-id="fittedSolutionId"
           :target="targetName"
           :target-type="targetType"
+          @apply-model="onApplyModel"
         />
         <save-modal
           ref="saveModel"
@@ -208,7 +209,8 @@
       <template v-if="hasNoVariables">
         <p>No Outcome Variables available.</p>
       </template>
-      <result-facets v-else />
+      <result-facets v-else-if="state.name === 'result'" />
+      <prediction-summaries v-else />
     </left-side-panel>
     <status-sidebar />
     <status-panel />
@@ -238,6 +240,7 @@ import ResultFacets from "../components/ResultFacets.vue";
 import LegendWeight from "../components/LegendWeight.vue";
 import SaveModal, { SaveInfo } from "../components/SaveModal.vue";
 import PredictionsDataUploader from "../components/PredictionsDataUploader.vue";
+import PredictionSummaries from "../components/PredictionSummaries.vue";
 import { isFittedSolutionIdSavedAsModel } from "../util/models";
 
 // Store
@@ -323,6 +326,7 @@ export default Vue.extend({
     LegendWeight,
     ImageMosaic,
     PredictionsDataUploader,
+    PredictionSummaries,
     SearchBar,
     SelectDataTable,
     GeoPlot,
@@ -667,7 +671,7 @@ export default Vue.extend({
           const dataMode = routeGetters.getDataMode(this.$store);
           const dataModeDefault = dataMode ? dataMode : DataMode.Default;
           // transition to result screen
-          const entry = overlayRouteEntry(this.$route, {
+          this.updateRoute({
             dataset: routeGetters.getRouteDataset(this.$store),
             target: routeGetters.getRouteTargetVariable(this.$store),
             solutionId: res.solutionId,
@@ -680,7 +684,6 @@ export default Vue.extend({
             modelTimeLimit: routeGetters.getModelTimeLimit(this.$store),
             modelQuality: routeGetters.getModelQuality(this.$store),
           });
-          this.$router.push(entry).catch((err) => console.warn(err));
           const modelCreationRef = this.$refs[
             "model-creation-form"
           ] as InstanceType<typeof CreateSolutionsForm>;
@@ -697,6 +700,10 @@ export default Vue.extend({
           console.error(err);
         });
       return;
+    },
+    async onApplyModel(args: RouteArgs) {
+      this.updateRoute(args);
+      await this.changeStatesByName(ExplorerStateNames.PREDICTION_VIEW);
     },
     onExcludeClick() {
       let filter = null;

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -174,7 +174,7 @@
         >
           <b-button
             v-if="isTimeseries"
-            variant="primary"
+            variant="success"
             class="apply-button"
             @click="$bvModal.show('forecast-horizon-modal')"
           >
@@ -182,7 +182,7 @@
           </b-button>
           <b-button
             v-else
-            variant="primary"
+            variant="success"
             class="apply-button"
             @click="$bvModal.show('predictions-data-upload-modal')"
           >
@@ -415,7 +415,9 @@ export default Vue.extend({
     hasNoVariables(): boolean {
       return isEmpty(this.activeVariables);
     },
-
+    isTimeseries(): boolean {
+      return routeGetters.isTimeseries(this.$store);
+    },
     highlights(): Highlight[] {
       return routeGetters.getDecodedHighlights(this.$store);
     },

--- a/public/views/Predictions.vue
+++ b/public/views/Predictions.vue
@@ -52,6 +52,8 @@
 
         <prediction-summaries
           class="col-12 col-md-3 border-gray-left predictions-predictions-summaries"
+          include-footer
+          include-title
         ></prediction-summaries>
       </div>
     </div>


### PR DESCRIPTION
- Moved the view computes and methods to dataExplorer.ts
- This allows us to define and keep related state utilities together
- Added a componentType.ts this is where we can type vue components that need to be referenced in a typescript file
- Predictions is working (still a few issue with remote_sensing and immediately jumping to prediction screen)
- Started integrating the labeling view