### PR TITLE
fixes for sparkline state and data explorer

### DIFF
--- a/public/components/SparklinePreview.vue
+++ b/public/components/SparklinePreview.vue
@@ -65,11 +65,15 @@ import * as d3 from "d3";
 import Vue from "vue";
 import SparklineChart from "../components/SparklineChart.vue";
 import SparklineSvg from "../components/SparklineSvg.vue";
-import { TimeseriesExtrema, TimeSeriesValue } from "../store/dataset/index";
+import {
+  TimeSeries,
+  TimeseriesExtrema,
+  TimeSeriesValue,
+} from "../store/dataset/index";
 import { getters as datasetGetters } from "../store/dataset/module";
 import { getters as resultsGetters } from "../store/results/module";
 import { getters as predictionsGetters } from "../store/predictions/module";
-
+import { Dictionary } from "../util/dict";
 export default Vue.extend({
   name: "SparklinePreview",
 
@@ -90,6 +94,10 @@ export default Vue.extend({
     predictionsId: String as () => string,
     includeForecast: Boolean as () => boolean,
     uniqueTrail: { type: String as () => string, default: "" },
+    getTimeseries: {
+      type: Function,
+      default: null,
+    },
   },
   data() {
     return {
@@ -108,6 +116,13 @@ export default Vue.extend({
       return this.variableKey + this.timeseriesId + this.uniqueTrail;
     },
     timeseries(): TimeSeriesValue[] {
+      if (this.getTimeseries != null) {
+        const timeseries = this.getTimeseries() as TimeSeries;
+        if (!timeseries) {
+          return null;
+        }
+        return timeseries.timeseriesData[this.timeseriesUniqueId];
+      }
       if (this.predictionsId) {
         const timeseries = predictionsGetters.getPredictedTimeseries(
           this.$store

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -16,7 +16,6 @@
  */
 
 import axios, { AxiosResponse } from "axios";
-import { BIconLayoutThreeColumns } from "bootstrap-vue";
 import _ from "lodash";
 import { ActionContext } from "vuex";
 import {
@@ -75,7 +74,6 @@ import {
   Task,
   Variable,
   VariableRankingPendingRequest,
-  VariableSummary,
   VariableSummaryKey,
   VariableSummaryResp,
 } from "./index";
@@ -1843,5 +1841,8 @@ export const actions = {
       console.error(error);
       return null;
     }
+  },
+  resetState(context: DatasetContext): void {
+    mutations.resetState(context);
   },
 };

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -460,56 +460,59 @@ export interface MetricDropdownItem {
   };
   text: string;
 }
+export const defaultState = (): DatasetState => {
+  return {
+    // datasets and filtered datasets
+    datasets: [],
+    filteredDatasets: [],
 
-export const state: DatasetState = {
-  // datasets and filtered datasets
-  datasets: [],
-  filteredDatasets: [],
+    // variable list and rankings for the active dataset
+    variables: [],
+    variableRankings: {},
 
-  // variable list and rankings for the active dataset
-  variables: [],
-  variableRankings: {},
+    // working set of data
+    includedSet: {
+      tableData: null,
+      variableSummariesByKey: {},
+      rowSelectionData: [],
+    },
+    excludedSet: {
+      tableData: null,
+      variableSummariesByKey: {},
+      rowSelectionData: [],
+    },
+    // highlight set
+    baselineIncludeSet: null,
+    baselineExcludeSet: null,
+    // tiles surrounding tile that was clicked
+    // include area of interest
+    areaOfInterestIncludeInner: null,
+    areaOfInterestIncludeOuter: null,
+    // exclude area of interest
+    areaOfInterestExcludeInner: null,
+    areaOfInterestExcludeOuter: null,
+    // linked files / representation data
+    files: {},
+    timeseries: {},
+    timeseriesExtrema: {},
 
-  // working set of data
-  includedSet: {
-    tableData: null,
-    variableSummariesByKey: {},
-    rowSelectionData: [],
-  },
-  excludedSet: {
-    tableData: null,
-    variableSummariesByKey: {},
-    rowSelectionData: [],
-  },
-  // highlight set
-  baselineIncludeSet: null,
-  baselineExcludeSet: null,
-  // tiles surrounding tile that was clicked
-  // include area of interest
-  areaOfInterestIncludeInner: null,
-  areaOfInterestIncludeOuter: null,
-  // exclude area of interest
-  areaOfInterestExcludeInner: null,
-  areaOfInterestExcludeOuter: null,
-  // linked files / representation data
-  files: {},
-  timeseries: {},
-  timeseriesExtrema: {},
+    // joined data table data
+    joinTableData: {},
 
-  // joined data table data
-  joinTableData: {},
+    // pending requests for the active dataset
+    pendingRequests: [],
 
-  // pending requests for the active dataset
-  pendingRequests: [],
+    // task information
+    task: {
+      task: [TaskTypes.CLASSIFICATION, TaskTypes.MULTICLASS],
+    },
 
-  // task information
-  task: {
-    task: [TaskTypes.CLASSIFICATION, TaskTypes.MULTICLASS],
-  },
+    // bands
+    bands: [],
 
-  // bands
-  bands: [],
-
-  // metrics
-  metrics: [],
+    // metrics
+    metrics: [],
+  };
 };
+
+export const state: DatasetState = defaultState();

--- a/public/store/dataset/module.ts
+++ b/public/store/dataset/module.ts
@@ -198,6 +198,7 @@ export const actions = {
   updateDataset: dispatch(moduleActions.updateDataset),
   extractDataset: dispatch(moduleActions.extractDataset),
   saveDataset: dispatch(moduleActions.saveDataset),
+  resetState: dispatch(moduleActions.resetState),
 };
 
 // Typed mutations
@@ -273,4 +274,5 @@ export const mutations = {
   updateBands: commit(moduleMutations.updateBands),
   updateRowSelectionData: commit(moduleMutations.updateRowSelectionData),
   updateMetrics: commit(moduleMutations.updateMetrics),
+  resetState: commit(moduleMutations.resetState),
 };

--- a/public/store/dataset/mutations.ts
+++ b/public/store/dataset/mutations.ts
@@ -34,6 +34,7 @@ import {
   Dataset,
   DatasetPendingRequest,
   DatasetState,
+  defaultState,
   Metric,
   TableData,
   Task,
@@ -508,5 +509,8 @@ export const mutations = {
 
   updateMetrics(state: DatasetState, metrics: Metric[]) {
     state.metrics = metrics;
+  },
+  resetState(state: DatasetState) {
+    Object.assign(state, defaultState());
   },
 };

--- a/public/store/model/index.ts
+++ b/public/store/model/index.ts
@@ -44,7 +44,11 @@ export interface VariableDetail {
   varType: string;
 }
 
-export const state: ModelState = {
-  models: {},
-  filteredModelIds: [],
+export const defaultState = (): ModelState => {
+  return {
+    models: {},
+    filteredModelIds: [],
+  };
 };
+
+export const state: ModelState = defaultState();

--- a/public/store/predictions/actions.ts
+++ b/public/store/predictions/actions.ts
@@ -589,4 +589,7 @@ export const actions = {
     }
     return null;
   },
+  resetState(context: PredictionContext): void {
+    mutations.resetState(context);
+  },
 };

--- a/public/store/predictions/index.ts
+++ b/public/store/predictions/index.ts
@@ -41,26 +41,29 @@ export interface PredictionState {
   fittedSolutionId: string;
   produceRequestId: string;
 }
-
-export const state: PredictionState = {
-  // table data
-  includedPredictionTableData: null,
-  excludedPredictionTableData: null,
-  // baseline table data
-  baselinePredictionTableData: null,
-  // training / target
-  trainingSummaries: {},
-  targetSummary: null,
-  // predicted
-  predictedSummaries: [],
-  confidenceSummaries: [],
-  rankSummaries: [],
-  // forecasts
-  timeseries: {},
-  forecasts: {},
-  // areaOfInterest
-  areaOfInterestInner: null,
-  areaOfInterestOuter: null,
-  fittedSolutionId: null,
-  produceRequestId: null,
+export const defaultState = (): PredictionState => {
+  return {
+    // table data
+    includedPredictionTableData: null,
+    excludedPredictionTableData: null,
+    // baseline table data
+    baselinePredictionTableData: null,
+    // training / target
+    trainingSummaries: {},
+    targetSummary: null,
+    // predicted
+    predictedSummaries: [],
+    confidenceSummaries: [],
+    rankSummaries: [],
+    // forecasts
+    timeseries: {},
+    forecasts: {},
+    // areaOfInterest
+    areaOfInterestInner: null,
+    areaOfInterestOuter: null,
+    fittedSolutionId: null,
+    produceRequestId: null,
+  };
 };
+
+export const state: PredictionState = defaultState();

--- a/public/store/predictions/module.ts
+++ b/public/store/predictions/module.ts
@@ -107,6 +107,7 @@ export const actions = {
   fetchExportData: dispatch(moduleActions.fetchExportData),
   // cloning results of a prediction to a new dataset
   createDataset: dispatch(moduleActions.createDataset),
+  resetState: dispatch(moduleActions.resetState),
 };
 
 // Typed mutations
@@ -141,4 +142,5 @@ export const mutations = {
     moduleMutations.bulkUpdatePredictedForecast
   ),
   removeTimeseries: commit(moduleMutations.removeTimeseries),
+  resetState: commit(moduleMutations.resetState),
 };

--- a/public/store/predictions/mutations.ts
+++ b/public/store/predictions/mutations.ts
@@ -16,7 +16,7 @@
  */
 
 import Vue from "vue";
-import { PredictionState } from "./index";
+import { defaultState, PredictionState } from "./index";
 import { VariableSummary, TableData } from "../dataset/index";
 import { updateSummaries, updateSummariesPerVariable } from "../../util/data";
 
@@ -218,5 +218,8 @@ export const mutations = {
       args.id,
       args.isDateTime
     );
+  },
+  resetState(state: PredictionState): void {
+    Object.assign(state, defaultState());
   },
 };

--- a/public/store/requests/index.ts
+++ b/public/store/requests/index.ts
@@ -109,8 +109,8 @@ export interface RequestState {
   predictions: Predictions[];
 }
 
-export const state: RequestState = {
-  solutionRequests: [],
-  solutions: [],
-  predictions: [],
+export const defaultState = (): RequestState => {
+  return { solutionRequests: [], solutions: [], predictions: [] };
 };
+
+export const state: RequestState = defaultState();

--- a/public/store/results/actions.ts
+++ b/public/store/results/actions.ts
@@ -1133,4 +1133,7 @@ export const actions = {
       rankings: _.pickBy(rankings, (ranking) => ranking !== null),
     });
   },
+  resetState(context: ResultsContext) {
+    mutations.resetState(context);
+  },
 };

--- a/public/store/results/index.ts
+++ b/public/store/results/index.ts
@@ -68,35 +68,38 @@ export interface ResultsState {
   // variable rankings - maps {solutionID, {featureName: rank value}}
   featureImportanceRanking: Dictionary<Dictionary<number>>;
 }
-
-export const state: ResultsState = {
-  // table data
-  includedResultTableData: null,
-  excludedResultTableData: null,
-  fullIncludedResultTableData: null,
-  // area of interest for tiles clicks in geo map
-  areaOfInterestInner: null,
-  areaOfInterestOuter: null,
-  // training / target
-  trainingSummaries: {},
-  targetSummary: null,
-  // predicted
-  predictedSummaries: [],
-  // residuals
-  residualSummaries: [],
-  residualsExtrema: { min: null, max: null },
-  // correctness summary (correct vs. incorrect) for predicted categorical data
-  correctnessSummaries: [],
-  // confidence summary (how sure the system is of it's predictions) for any predicted data
-  confidenceSummaries: [],
-  // ranking summary (used in tandem with confidence)
-  rankingSummaries: [],
-  // forecasts
-  timeseries: {},
-  forecasts: {},
-  // result IDs
-  fittedSolutionId: null,
-  produceRequestId: null,
-  // variable rankings
-  featureImportanceRanking: {},
+export const defaultState = (): ResultsState => {
+  return {
+    // table data
+    includedResultTableData: null,
+    excludedResultTableData: null,
+    fullIncludedResultTableData: null,
+    // area of interest for tiles clicks in geo map
+    areaOfInterestInner: null,
+    areaOfInterestOuter: null,
+    // training / target
+    trainingSummaries: {},
+    targetSummary: null,
+    // predicted
+    predictedSummaries: [],
+    // residuals
+    residualSummaries: [],
+    residualsExtrema: { min: null, max: null },
+    // correctness summary (correct vs. incorrect) for predicted categorical data
+    correctnessSummaries: [],
+    // confidence summary (how sure the system is of it's predictions) for any predicted data
+    confidenceSummaries: [],
+    // ranking summary (used in tandem with confidence)
+    rankingSummaries: [],
+    // forecasts
+    timeseries: {},
+    forecasts: {},
+    // result IDs
+    fittedSolutionId: null,
+    produceRequestId: null,
+    // variable rankings
+    featureImportanceRanking: {},
+  };
 };
+
+export const state: ResultsState = defaultState();

--- a/public/store/results/module.ts
+++ b/public/store/results/module.ts
@@ -140,6 +140,8 @@ export const actions = {
   // area of interest for tile clicks
   fetchAreaOfInterestInner: dispatch(moduleActions.fetchAreaOfInterestInner),
   fetchAreaOfInterestOuter: dispatch(moduleActions.fetchAreaOfInterestOuter),
+
+  resetState: dispatch(moduleActions.resetState),
 };
 
 // Typed mutations
@@ -190,4 +192,5 @@ export const mutations = {
     moduleMutations.setFeatureImportanceRanking
   ),
   removeTimeseries: commit(moduleMutations.removeTimeseries),
+  resetState: commit(moduleMutations.resetState),
 };

--- a/public/store/results/mutations.ts
+++ b/public/store/results/mutations.ts
@@ -24,7 +24,7 @@ import {
 } from "../../util/data";
 import { Extrema, TableData, VariableSummary } from "../dataset/index";
 import { TimeSeriesForecastUpdate } from "../dataset/mutations";
-import { ResultsState } from "./index";
+import { defaultState, ResultsState } from "./index";
 
 export const mutations = {
   // training / target
@@ -271,5 +271,8 @@ export const mutations = {
     args: { solutionID: string; rankings: Dictionary<number> }
   ) {
     Vue.set(state.featureImportanceRanking, args.solutionID, args.rankings);
+  },
+  resetState(state: ResultsState): void {
+    Object.assign(state, defaultState());
   },
 };

--- a/public/util/state/AppStateWrapper.ts
+++ b/public/util/state/AppStateWrapper.ts
@@ -48,6 +48,8 @@ import { DISTIL_ROLES } from "../types";
 
 export interface BaseState {
   name: ExplorerStateNames;
+  // resets the state, note this sets the store's module back to defaultState
+  resetState(): void;
   // gets basic variables
   getVariables(): Variable[];
   // gets secondary variables related to secondary variableSummaries
@@ -74,7 +76,7 @@ export interface BaseState {
   // gets table data fields
   getFields(include?: boolean): Dictionary<TableColumn>;
   // getTimeseries dictionary
-  getTimeseries(include?: boolean): Dictionary<TimeSeries>;
+  getTimeseries(): TimeSeries;
   /******Fetch Functions**********/
   init(): Promise<void>;
   fetchVariables(): Promise<unknown>;
@@ -87,8 +89,12 @@ export interface BaseState {
 
 export class SelectViewState implements BaseState {
   name = ExplorerStateNames.SELECT_VIEW;
-  getTimeseries(): Dictionary<TimeSeries> {
-    return datasetGetters.getTimeseries(store);
+  resetState(): void {
+    datasetActions.resetState(store);
+  }
+  getTimeseries(): TimeSeries {
+    const datasetId = routeGetters.getRouteDataset(store);
+    return datasetGetters.getTimeseries(store)[datasetId];
   }
   fetchTimeseries(args: EI.TIMESERIES.FetchTimeseriesEvent) {
     args.variables.forEach((tsv) => {
@@ -208,8 +214,12 @@ export class SelectViewState implements BaseState {
 
 export class ResultViewState implements BaseState {
   name = ExplorerStateNames.RESULT_VIEW;
-  getTimeseries(): Dictionary<TimeSeries> {
-    return resultGetters.getPredictedTimeseries(store);
+  resetState(): void {
+    resultActions.resetState(store);
+  }
+  getTimeseries(): TimeSeries {
+    const solutionId = routeGetters.getRouteSolutionId(store);
+    return resultGetters.getPredictedTimeseries(store)[solutionId];
   }
   fetchTimeseries(args: EI.TIMESERIES.FetchTimeseriesEvent) {
     args.variables.forEach((tsv) => {
@@ -381,8 +391,12 @@ export class ResultViewState implements BaseState {
 
 export class PredictViewState implements BaseState {
   name = ExplorerStateNames.PREDICTION_VIEW;
-  getTimeseries(): Dictionary<TimeSeries> {
-    return predictionGetters.getPredictedTimeseries(store);
+  resetState(): void {
+    predictionActions.resetState(store);
+  }
+  getTimeseries(): TimeSeries {
+    const predictionId = routeGetters.getRouteProduceRequestId(store);
+    return predictionGetters.getPredictedTimeseries(store)[predictionId];
   }
   fetchTimeseries(args: EI.TIMESERIES.FetchTimeseriesEvent) {
     const activePredictions = requestGetters.getActivePredictions(store);
@@ -554,8 +568,11 @@ export class PredictViewState implements BaseState {
 
 export class LabelViewState implements BaseState {
   name = ExplorerStateNames.LABEL_VIEW;
-  getTimeseries(include?: boolean): Dictionary<TimeSeries> {
-    return {};
+  resetState(): void {
+    predictionActions.resetState(store);
+  }
+  getTimeseries(): TimeSeries {
+    return {} as TimeSeries;
   }
   fetchTimeseries(args: EI.TIMESERIES.FetchTimeseriesEvent) {
     console.error("timeseries is not supported in label view");

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -128,6 +128,7 @@
             inner: drillDownBaseline,
             outer: drillDownFiltered,
           }"
+          :get-timeseries="state.getTimeseries"
           @tile-clicked="onTileClick"
           @selection-tool-event="onToolSelection"
           @fetch-timeseries="fetchTimeseries"
@@ -532,7 +533,7 @@ const DataExplorer = Vue.extend({
     isSingleSolution(): boolean {
       return routeGetters.isSingleSolution(this.$store);
     },
-    timeseries(): Dictionary<TimeSeries> {
+    timeseries(): TimeSeries {
       return this.state.getTimeseries();
     },
     routeHighlight(): string {
@@ -802,8 +803,13 @@ const DataExplorer = Vue.extend({
   methods: {
     capitalize,
     async changeStatesByName(state: ExplorerStateNames) {
+      // reset state
+      this.state.resetState();
+      // get the new state object
       this.setState(getStateFromName(state));
+      // set the config used for action bar, could be used for other configs
       this.setConfig(getConfigFromName(state));
+      // init this is the basic fetches needed to get the information for the state
       await this.state.init();
     },
     /* When the user request to fetch a different size of data. */


### PR DESCRIPTION
closes #2772 

- Added function for each store module that returns the default state
- Added action for reseting the store module to the default state while maintaining observers
- Note: at some point when data explorer is the main UI for the application we should refactor the sparkline there is logic in there that is not necessary (but needed with the older UI)