### PR TITLE
Skip clean up of expanded dataset dir when it is the public dir

### DIFF
--- a/api/dataset/satellite.go
+++ b/api/dataset/satellite.go
@@ -348,7 +348,9 @@ func (s *Satellite) GetDefinitiveTypes() []*model.Variable {
 
 // CleanupTempFiles does nothing since this creates no temp files.
 func (s *Satellite) CleanupTempFiles() {
-	util.Delete(s.ExtractedFilePath)
+	if !env.IsPublicPath(s.ExtractedFilePath) {
+		util.Delete(s.ExtractedFilePath)
+	}
 }
 
 // removeValues removes values not needed based on supplied headernames

--- a/api/env/path.go
+++ b/api/env/path.go
@@ -17,6 +17,7 @@ package env
 
 import (
 	"path"
+	"strings"
 
 	"github.com/uncharted-distil/distil-compute/metadata"
 	log "github.com/unchartedsoftware/plog"
@@ -152,6 +153,12 @@ func GetBatchPath() string {
 // GetPublicPath returns the batch path as initialized.
 func GetPublicPath() string {
 	return publicPath
+}
+
+// IsPublicPath indicates whether or not the supplied path is the current
+// public path.
+func IsPublicPath(filename string) bool {
+	return strings.HasPrefix(filename, GetPublicPath())
 }
 
 // ResolvePath returns an absolute path based on the dataset source.

--- a/api/routes/import.go
+++ b/api/routes/import.go
@@ -21,7 +21,6 @@ import (
 	"math"
 	"net/http"
 	"path"
-	"strings"
 
 	"github.com/pkg/errors"
 	log "github.com/unchartedsoftware/plog"
@@ -265,7 +264,7 @@ func ImportHandler(dataCtor api.DataStorageCtor, datamartCtors map[string]api.Me
 			return
 		}
 
-		if !isPublicPath(datasetPathRaw) {
+		if !env.IsPublicPath(datasetPathRaw) {
 			util.Delete(datasetPathRaw)
 		}
 		// marshal data and sent the response back
@@ -573,8 +572,4 @@ func syncPrefeaturizedDataset(datasetID string, updateDatasetID string, sourceLe
 	log.Infof("done syncing prefeaturized dataset '%s' on disk", datasetID)
 
 	return nil
-}
-
-func isPublicPath(filename string) bool {
-	return strings.HasPrefix(filename, env.GetPublicPath())
 }


### PR DESCRIPTION
fixes #2904

This error was restricted to satellite image imports only, and only when it is a dataset folder, rather than a zip archive.