### PR TITLE
Fixed route nav having intermittent data problems

### DIFF
--- a/public/App.vue
+++ b/public/App.vue
@@ -59,9 +59,9 @@ export default Vue.extend({
     NavBar,
   },
   methods: {
-    onExplorerNav(state: ExplorerStateNames) {
+    async onExplorerNav(state: ExplorerStateNames) {
       const dataExplorer = (this.$refs.view as unknown) as DataExplorerRef;
-      dataExplorer.changeStatesByName(state);
+      await dataExplorer.changeStatesByName(state);
     },
   },
   beforeMount() {

--- a/public/store/view/actions.ts
+++ b/public/store/view/actions.ts
@@ -720,9 +720,8 @@ export const actions = {
     const solutionID = routeGetters.getRouteSolutionId(store);
 
     // fetch new state
-    await fetchVariables(context, {
-      dataset: dataset,
-    });
+    await datasetActions.fetchVariables(store, { dataset });
+
     await modelActions.fetchModels(store); // Fetch saved models.
 
     // These are long running processes we won't wait on

--- a/public/util/explorer/functions/generic.ts
+++ b/public/util/explorer/functions/generic.ts
@@ -86,14 +86,14 @@ export const GENERIC_METHODS = {
     const self = (this as unknown) as DataExplorerRef;
     // reset state
     self.state.resetState();
-    // reset config state
-    self.config.resetConfig(self);
     // get the new state object
     self.setState(getStateFromName(state));
-    // set the config used for action bar, could be used for other configs
-    self.setConfig(getConfigFromName(state));
     // init this is the basic fetches needed to get the information for the state
     await self.state.init();
+    // reset config state
+    self.config.resetConfig(self);
+    // set the config used for action bar, could be used for other configs
+    self.setConfig(getConfigFromName(state));
   },
   /**
    * setBusyState changes the data view from spinner if true to data view components

--- a/public/util/state/AppStateWrapper.ts
+++ b/public/util/state/AppStateWrapper.ts
@@ -135,8 +135,9 @@ export class SelectViewState implements BaseState {
   async init(): Promise<void> {
     await this.fetchVariables();
     await this.fetchMapBaseline();
-    this.fetchVariableSummaries();
-    datasetActions.fetchMultiBandCombinations(store, {
+    // await this.fetchVariableSummaries();
+    await this.fetchData();
+    await datasetActions.fetchMultiBandCombinations(store, {
       dataset: routeGetters.getRouteDataset(store),
     });
     return;
@@ -218,7 +219,7 @@ export class SelectViewState implements BaseState {
   fetchVariableSummaries(): Promise<unknown> {
     const fetchArgs = {
       dataset: routeGetters.getRouteDataset(store),
-      variables: sortVariablesByImportance(this.getSecondaryVariables()),
+      variables: sortVariablesByImportance(this.getVariables()),
       filterParams: routeGetters.getDecodedSolutionRequestFilterParams(store),
       highlights: routeGetters.getDecodedHighlights(store),
       dataMode: routeGetters.getDataMode(store),
@@ -280,6 +281,7 @@ export class ResultViewState implements BaseState {
         target: routeGetters.getRouteTargetVariable(store),
       });
       const solutions = requestGetters.getSolutions(store);
+
       if (solutions && solutions.length) {
         // dont mutate store array
         const sorted = [...solutions].sort((a, b) => {

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -481,10 +481,6 @@ const DataExplorer = Vue.extend({
       const route = routeGetters.getRoute(this.$store);
       const entry = overlayRouteEntry(route, { hasGeoData: self.geoVarExists });
       this.$router.push(entry).catch((err) => console.warn(err));
-      this.dataLoading = true;
-      await this.state.fetchMapBaseline();
-      await this.state.fetchData();
-      this.dataLoading = false;
     },
     targetName() {
       const self = (this as unknown) as DataExplorerRef; // because the computes/methods are added in beforeCreate typescript does not work so we cast it to a type here


### PR DESCRIPTION
Some times when flipping between select and result state through the nav bar would result in incomplete fetching. It was fixed through the use of await and removing redundant fetch calls that was causing reactivity.
closes #2858