### PR TITLE
Button state needs updating - make include/exclude buttons more obvious

### DIFF
--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -172,15 +172,13 @@
           <b-button-toolbar v-if="isSelectState">
             <b-button-group class="ml-2 mt-1">
               <b-button
-                variant="primary"
-                :disabled="include"
+                :variant="include ? 'primary' : 'secondary'"
                 @click="setIncludedActive"
               >
                 Included
               </b-button>
               <b-button
-                variant="secondary"
-                :disabled="!include"
+                :variant="!include ? 'primary' : 'secondary'"
                 @click="setExcludedActive"
               >
                 Excluded


### PR DESCRIPTION
Fixes: #2979 

Makes the include and exclude buttons more obvious as to which one is selected

<img width="163" alt="Screen Shot 2021-10-08 at 1 25 19 PM" src="https://user-images.githubusercontent.com/25292393/136598028-69d229c3-d057-486f-8d5d-9a82e9a8a13e.png">
<img width="184" alt="Screen Shot 2021-10-08 at 1 25 14 PM" src="https://user-images.githubusercontent.com/25292393/136598140-9fcef4fd-0754-4fdd-8ee7-c7801ac5a287.png">

 