### PR TITLE
Added check to keep from infinite looping

### DIFF
--- a/api/model/storage/postgres/bounds.go
+++ b/api/model/storage/postgres/bounds.go
@@ -431,8 +431,10 @@ func getGeoBoundsBuckets(xExtrema *api.Extrema, yExtrema *api.Extrema,
 	// build a list of bounds representing the buckets
 	xInterval := xExtrema.GetBucketInterval(xNumBuckets)
 	yInterval := yExtrema.GetBucketInterval(yNumBuckets)
-
 	buckets := []*geometryBucket{}
+	if xInterval == 0 || yInterval == 0 {
+		return buckets
+	} 
 	xLeft := xExtrema.Min
 	xRight := xLeft + xInterval
 	for xCount := 0; xLeft <= xExtrema.Max; xLeft, xRight = xLeft+xInterval, xRight+xInterval {


### PR DESCRIPTION
This is a partial fix the real problem is here https://github.com/uncharted-distil/distil/blame/main/api/model/storage/postgres/dataset.go#L858

when the ingest happens we are storing geobounds as a centroid and the extrema is calculated from it. When you only have 1 geobounds the max and min extrema are the same. Resulting in the interval for the getGeoBound buckets to be 0. When the interval is 0 it infinite loops.