### PR TITLE
Refactored status panel to assimilate to the data explorer approach

### DIFF
--- a/public/util/componentTypes.ts
+++ b/public/util/componentTypes.ts
@@ -87,9 +87,11 @@ export interface DataExplorerRef {
   state: BaseState;
 
   // methods
+  bindEventHandlers: (eventHandlers: Record<string, Function>) => void;
   changeStatesByName: (name: ExplorerStateNames) => Promise<void>;
   isFittedSolutionIdSavedAsModel: (id: string) => boolean;
   preSelectTopVariables: (num?: number) => void;
+  removeEventHandlers: (eventHandlers: Record<string, Function>) => void;
   resetHighlightsOrRow: () => void;
   setConfig: (config: ExplorerConfig) => void;
   setState: (state: BaseState) => void;

--- a/public/util/events.ts
+++ b/public/util/events.ts
@@ -60,6 +60,10 @@ export class EventList {
     SEARCH_EVENT: "search",
   };
   static readonly VARIABLES = {
+    // event is fired when outlier needs to be applied to ds
+    APPLY_OUTLIER_EVENT: "apply-outlier-event",
+    // event is fired when cluster needs to be applied to grouped variable
+    APPLY_CLUSTER_EVENT: "apply-cluster-event",
     // fetch variable rankings
     FETCH_RANK_EVENT: "fetch-variable-rankings",
     // occurs when a variable is removed or added to the training set

--- a/public/util/explorer/functions/generic.ts
+++ b/public/util/explorer/functions/generic.ts
@@ -149,6 +149,7 @@ export const GENERIC_METHODS = {
         return [t, true];
       })
     );
+    self.bindEventHandlers(self.config.eventHandlers);
     // the switch to the new config will trigger a render of new elements
     // if the defaultActions is one of the new elements it will not exist in the dom yet
     // so we toggle the default actions after the next DOM cycle

--- a/public/util/explorer/functions/prediction.ts
+++ b/public/util/explorer/functions/prediction.ts
@@ -1,6 +1,16 @@
-import { requestGetters, viewActions } from "../../../store";
+import {
+  datasetActions,
+  datasetGetters,
+  requestGetters,
+  viewActions,
+} from "../../../store";
+import { DataMode, SummaryMode } from "../../../store/dataset";
 import { getters as routeGetters } from "../../../store/route/module";
 import store from "../../../store/store";
+import { DataExplorerRef } from "../../componentTypes";
+import { EventList } from "../../events";
+import { overlayRouteEntry, varModesToString } from "../../routes";
+import { IMAGE_TYPE, isClusterType } from "../../types";
 
 /**
  * PREDICTION_COMPUTES contains all of the computes for the prediction state in the data explorer
@@ -26,5 +36,71 @@ export const PREDICTION_METHODS = {
     viewActions.updatePredictionSummaries(store, {
       predictions: predictions,
     });
+  },
+};
+
+export const PREDICTION_EVENT_HANDLERS = {
+  /**
+   * This function handles the apply cluster event
+   * It updates the variable with a cluster column
+   * then updates the variable summary with the new cluster datamode
+   */
+  [EventList.VARIABLES.APPLY_CLUSTER_EVENT]: function () {
+    const self = (this as unknown) as DataExplorerRef;
+    // fetch the var modes map
+    const varModesMap = routeGetters.getDecodedVarModes(store);
+    const clusterVars = new Set<string>();
+    // find any grouped vars that are using this cluster data and update their
+    // mode to cluster now that data is available
+    datasetGetters
+      .getGroupings(store)
+      .filter((v) => isClusterType(v.colType))
+      .forEach((v) => {
+        varModesMap.set(v.key, SummaryMode.Cluster);
+        clusterVars.add(v.grouping.clusterCol);
+      });
+
+    // find any image variables using this cluster data and update their mode
+    datasetGetters
+      .getVariables(store)
+      .filter((v) => v.colType === IMAGE_TYPE)
+      .forEach((v) => {
+        varModesMap.set(v.key, SummaryMode.Cluster);
+      });
+
+    // serialize the modes map into a string and add to the route
+    // and update to know that the clustering has been applied.
+    const varModesStr = varModesToString(varModesMap);
+    const entry = overlayRouteEntry(self.$route, {
+      varModes: varModesStr,
+      dataMode: DataMode.Cluster,
+      clustering: "1",
+    });
+    self.$router.push(entry).catch((err) => console.warn(err));
+    // fetch the new summaries with the clustering applied
+    viewActions.updateResultsSummaries(store);
+    return;
+  },
+  /**
+   * This handles outlier events for the select state
+   * All it does is apply the outlier to the ds
+   * then update the variables / variable summaries
+   * **/
+  [EventList.VARIABLES.APPLY_OUTLIER_EVENT]: async function () {
+    const self = (this as unknown) as DataExplorerRef;
+    const dataset = self.dataset;
+    const success = await datasetActions.applyOutliers(store, dataset);
+    if (!success) return;
+
+    // Update the variables, which should now include the outlier variable.
+    await datasetActions.fetchVariables(store, {
+      dataset,
+    });
+    await viewActions.updatePredictionTrainingSummaries(store);
+
+    // Update the route to know that the outlier has been applied.
+    const entry = overlayRouteEntry(self.$route, { outlier: "1" });
+    self.$router.push(entry).catch((err) => console.warn(err));
+    return;
   },
 };

--- a/public/util/explorer/functions/select.ts
+++ b/public/util/explorer/functions/select.ts
@@ -1,12 +1,18 @@
 import { CreateSolutionsFormRef, DataExplorerRef } from "../../componentTypes";
 import { isEmpty, isNil } from "lodash";
-import { appActions, datasetActions, requestActions } from "../../../store";
+import {
+  appActions,
+  datasetActions,
+  datasetGetters,
+  requestActions,
+  viewActions,
+} from "../../../store";
 import { getters as routeGetters } from "../../../store/route/module";
 import store from "../../../store/store";
 import { SolutionRequestMsg } from "../../../store/requests/actions";
 import { Solution } from "../../../store/requests";
-import { DataMode } from "../../../store/dataset";
-import { varModesToString } from "../../routes";
+import { DataMode, SummaryMode } from "../../../store/dataset";
+import { overlayRouteEntry, varModesToString } from "../../routes";
 import { ExplorerStateNames } from "..";
 import { createFiltersFromHighlights } from "../../highlights";
 import {
@@ -15,6 +21,10 @@ import {
   INCLUDE_FILTER,
 } from "../../filters";
 import { Activity, Feature, SubActivity } from "../../userEvents";
+import { EventList } from "../../events";
+import { IMAGE_TYPE, isClusterType } from "../../types";
+import { $enum } from "ts-enum-util";
+
 /**
  * SELECT_COMPUTES contains all of the computes for the select state in the data explorer
  **/
@@ -146,6 +156,90 @@ export const SELECT_METHODS = {
       subActivity: SubActivity.DATA_TRANSFORMATION,
       details: { filter: filter },
     });
+    return;
+  },
+};
+
+export const SELECT_EVENT_HANDLERS = {
+  /**
+   * This function handles the apply cluster event
+   * It updates the variable with a cluster column
+   * then updates the variable summary with the new cluster datamode
+   */
+  [EventList.VARIABLES.APPLY_CLUSTER_EVENT]: function () {
+    const self = (this as unknown) as DataExplorerRef;
+    // fetch the var modes map
+    const varModesMap = routeGetters.getDecodedVarModes(store);
+    const clusterVars = new Set<string>();
+    // find any grouped vars that are using this cluster data and update their
+    // mode to cluster now that data is available
+    datasetGetters
+      .getGroupings(store)
+      .filter((v) => isClusterType(v.colType))
+      .forEach((v) => {
+        varModesMap.set(v.key, SummaryMode.Cluster);
+        clusterVars.add(v.grouping.clusterCol);
+      });
+
+    // find any image variables using this cluster data and update their mode
+    datasetGetters
+      .getVariables(store)
+      .filter((v) => v.colType === IMAGE_TYPE)
+      .forEach((v) => {
+        varModesMap.set(v.key, SummaryMode.Cluster);
+      });
+
+    // serialize the modes map into a string and add to the route
+    // and update to know that the clustering has been applied.
+    const varModesStr = varModesToString(varModesMap);
+    const entry = overlayRouteEntry(self.$route, {
+      varModes: varModesStr,
+      dataMode: DataMode.Cluster,
+      clustering: "1",
+    });
+    self.$router.push(entry).catch((err) => console.warn(err));
+
+    // update variables
+    // pull the updated dataset, vars, and summaries
+    const filterParams = routeGetters.getDecodedSolutionRequestFilterParams(
+      store
+    );
+    const highlights = routeGetters.getDecodedHighlights(store);
+    for (const [k, v] of varModesMap) {
+      datasetActions.fetchVariableSummary(store, {
+        dataset: self.dataset,
+        variable: k,
+        highlights: highlights,
+        filterParams: filterParams,
+        include: true,
+        dataMode: DataMode.Cluster,
+        mode: $enum(SummaryMode).asValueOrDefault(v, SummaryMode.Default),
+        handleMutation: true,
+      });
+    }
+
+    return;
+  },
+  /**
+   * This handles outlier events for the select state
+   * All it does is apply the outlier to the ds
+   * then update the variables / variable summaries
+   * **/
+  [EventList.VARIABLES.APPLY_OUTLIER_EVENT]: async function () {
+    const self = (this as unknown) as DataExplorerRef;
+    const dataset = self.dataset;
+    const success = await datasetActions.applyOutliers(store, dataset);
+    if (!success) return;
+
+    // Update the variables, which should now include the outlier variable.
+    await datasetActions.fetchVariables(store, {
+      dataset,
+    });
+    await viewActions.updateVariableSummaries(store);
+
+    // Update the route to know that the outlier has been applied.
+    const entry = overlayRouteEntry(self.$route, { outlier: "1" });
+    self.$router.push(entry).catch((err) => console.warn(err));
     return;
   },
 };

--- a/public/util/state/AppStateWrapper.ts
+++ b/public/util/state/AppStateWrapper.ts
@@ -314,6 +314,9 @@ export class ResultViewState implements BaseState {
     });
     await this.fetchVariables();
     await this.fetchMapBaseline();
+    if (routeGetters.isOutlierApplied(store)) {
+      await datasetActions.applyOutliers(store, dataset);
+    }
     return;
   }
   getSecondaryVariables(): Variable[] {
@@ -372,7 +375,17 @@ export class ResultViewState implements BaseState {
     return viewActions.updateResultAreaOfInterest(store, filter);
   }
   getVariables(): Variable[] {
-    return requestGetters.getActiveSolutionTrainingVariables(store);
+    return requestGetters
+      .getActiveSolutionTrainingVariables(store)
+      .concat(
+        datasetGetters
+          .getVariables(store)
+          .filter(
+            (variable) =>
+              variable.distilRole === DISTIL_ROLES.Augmented &&
+              variable.key === "_outlier"
+          )
+      );
   }
   getData(): TableRow[] {
     return resultGetters.getIncludedResultTableDataItems(store) ?? [];
@@ -611,7 +624,6 @@ export class PredictViewState implements BaseState {
     });
     await viewActions.fetchPredictionsData(store);
     datasetActions.fetchClusters(store, { dataset });
-    datasetActions.fetchOutliers(store, dataset);
     viewActions.updateBaselinePredictions(store);
   }
   fetchVariables(): Promise<unknown> {


### PR DESCRIPTION
There is not a cluster and outlier event each state can listen for and handle in whatever way is needed
This is for:
https://github.com/uncharted-distil/distil/issues/2975

Ran into another problem which is a blocker for the prediction screen.
Will revisit and test after fixing the other bug.
Select and result view is working correctly.