### PR TITLE
Fixed error handling on model creation

### DIFF
--- a/public/components/ErrorModal.vue
+++ b/public/components/ErrorModal.vue
@@ -17,7 +17,7 @@
 
 <template>
   <div>
-    <b-modal v-model="show" cancel-disabled hide-header hide-footer>
+    <b-modal v-model="show" cancel-disabled hide-header hide-footer size="lg">
       <div class="row justify-content-center">
         <i class="fa fa-exclamation-triangle fa-3x fail-icon"></i>
         <div>

--- a/public/store/requests/actions.ts
+++ b/public/store/requests/actions.ts
@@ -547,6 +547,7 @@ export const actions = {
         // log any error
         if (!_.isEmpty(response.error)) {
           console.error(response.error);
+          reject(new Error(response.error));
         }
 
         // handle request / solution progress


### PR DESCRIPTION
When the error occurred it was logged instead of logged and rejected
closes #3010
![Peek 2021-10-19 14-15](https://user-images.githubusercontent.com/25306965/137968983-a45f4ed9-69f0-46ed-b823-88db3637a9ef.gif)
