### PR TITLE
added unique trail for image fetch

### DIFF
--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -474,6 +474,7 @@ export default Vue.extend({
           dataset: this.dataset,
           url: this.selectedImageUrl,
           scale: imageOptions.scale,
+          uniqueTrail: this.uniqueTrail,
         });
       }
       // save as data so when we fetch next image we retain the UI size

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1311,6 +1311,7 @@ export const actions = {
       url: string;
       isThumbnail?: boolean;
       scale?: boolean;
+      uniqueTrail?: string;
     }
   ) {
     if (!validateArgs(args, ["dataset", "url"])) return;
@@ -1319,7 +1320,10 @@ export const actions = {
       const thumbnail = args.isThumbnail ? "true" : "false";
       const urlRequest = `distil/image/${args.dataset}/${args.url}/${thumbnail}/${imgScale}`;
       const response = await loadImage(urlRequest);
-      mutations.updateFile(context, { url: args.url, file: response });
+      const url = args.uniqueTrail
+        ? args.url + `-${args.uniqueTrail}`
+        : args.url;
+      mutations.updateFile(context, { url, file: response });
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
The drill down was updated to use a unique trail but the regular image route was not updated to use it.
closes #3015
![Peek 2021-10-20 11-17](https://user-images.githubusercontent.com/25306965/138122018-ece66d8a-7219-4f63-b65d-b6a06992e3d4.gif)

