### PR TITLE
Fix no label in image mosaic drilldown

### DIFF
--- a/public/components/ImageMosaic.vue
+++ b/public/components/ImageMosaic.vue
@@ -40,6 +40,7 @@
                 :summaries="summaries"
                 :index="imageIndex(idx)"
                 :items="dataItems"
+                :label-feature-name="labelFeatureName"
                 @click="onImageClick"
                 @shift-click="onImageShiftClick"
                 @cycle-images="onImageCycle"


### PR DESCRIPTION
<img width="1436" alt="Screen Shot 2021-10-29 at 2 47 15 PM" src="https://user-images.githubusercontent.com/14062458/139486764-18b8d661-38d7-4896-a602-187bebbab1f8.png">
