### PR TITLE
Optram

### DIFF
--- a/api/routes/image_pack.go
+++ b/api/routes/image_pack.go
@@ -260,7 +260,7 @@ func getMultiBandImages(multiBandPackRequest *ImagePackRequest, optramMap map[st
 		if val, ok := optramMap[geoHash]; ok {
 			edge = val
 		}
-		img, err := imagery.ImageFromCombination(sourcePath, bandMapping[imageID], multiBandPackRequest.Band, imageScale, &edge, options)
+		img, err := imagery.ImageFromCombination(sourcePath, bandMapping[imageID], multiBandPackRequest.Band, imageScale, &edge, multiBandPackRequest.Ramp, options)
 		if err != nil {
 			handleThreadError(&errorIDs, &imageID, &err)
 			continue

--- a/api/routes/image_pack.go
+++ b/api/routes/image_pack.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/nfnt/resize"
 	"github.com/pkg/errors"
@@ -76,9 +77,18 @@ func MultiBandImagePackHandler(ctor api.MetadataStorageCtor, dataCtor api.DataSt
 		}
 		// default to getImages
 		funcPointer := getImages
+		optramMap := map[string]imagery.OptramEdges{}
+		precision := 0
 		if params.Band != "" {
 			// if band is not empty then get multiBandImages
 			funcPointer = getMultiBandImages
+			if params.Band == imagery.OPTRAM {
+				optramMap, precision, err = fetchOptramVariables(params, ctor)
+				if err != nil {
+					handleError(w, err)
+					return
+				}
+			}
 		}
 		// channel for threads to communicate
 		result := make(chan chanStruct)
@@ -103,7 +113,7 @@ func MultiBandImagePackHandler(ctor api.MetadataStorageCtor, dataCtor api.DataSt
 		}
 
 		for i := 0; i < numOfThreads; i++ {
-			go funcPointer(params, i, numOfThreads, result, ctor, dataCtor)
+			go funcPointer(params, optramMap, precision, i, numOfThreads, result, ctor, dataCtor)
 		}
 		imagesBuffer := [][]byte{}
 		IDs := []string{}
@@ -132,7 +142,7 @@ func MultiBandImagePackHandler(ctor api.MetadataStorageCtor, dataCtor api.DataSt
 		}
 	}
 }
-func getImages(imagePackRequest *ImagePackRequest, threadID int, numThreads int, result chan chanStruct, ctor api.MetadataStorageCtor, dataCtor api.DataStorageCtor) {
+func getImages(imagePackRequest *ImagePackRequest, _ map[string]imagery.OptramEdges, _ int, threadID int, numThreads int, result chan chanStruct, ctor api.MetadataStorageCtor, dataCtor api.DataStorageCtor) {
 	temp := [][]byte{}
 	IDs := []string{}
 	errorIDs := []string{}
@@ -149,7 +159,6 @@ func getImages(imagePackRequest *ImagePackRequest, threadID int, numThreads int,
 		log.Error(err)
 		return
 	}
-
 	sourcePath := env.ResolvePath(res.Source, res.Folder)
 	metaDisk, err := metadata.LoadMetadataFromOriginalSchema(path.Join(sourcePath, compute.D3MDataSchema), false)
 	if err != nil {
@@ -190,7 +199,7 @@ func getImages(imagePackRequest *ImagePackRequest, threadID int, numThreads int,
 	}
 	result <- chanStruct{data: temp, IDs: IDs, errorIDs: errorIDs}
 }
-func getMultiBandImages(multiBandPackRequest *ImagePackRequest, threadID int, numThreads int, result chan chanStruct, ctor api.MetadataStorageCtor, dataCtor api.DataStorageCtor) {
+func getMultiBandImages(multiBandPackRequest *ImagePackRequest, optramMap map[string]imagery.OptramEdges, precision int, threadID int, numThreads int, result chan chanStruct, ctor api.MetadataStorageCtor, dataCtor api.DataStorageCtor) {
 	temp := [][]byte{}
 	IDs := []string{}
 	errorIDs := []string{}
@@ -211,6 +220,7 @@ func getMultiBandImages(multiBandPackRequest *ImagePackRequest, threadID int, nu
 		log.Error(err)
 		return
 	}
+
 	sourcePath := env.ResolvePath(res.Source, res.Folder)
 	metaDisk, err := metadata.LoadMetadataFromOriginalSchema(path.Join(sourcePath, compute.D3MDataSchema), false)
 	if err != nil {
@@ -244,8 +254,12 @@ func getMultiBandImages(multiBandPackRequest *ImagePackRequest, threadID int, nu
 	// loop through image info
 	for i := threadID; i < len(multiBandPackRequest.ImageIDs); i += numThreads {
 		imageID := multiBandPackRequest.ImageIDs[i]
-
-		img, err := imagery.ImageFromCombination(sourcePath, bandMapping[imageID], multiBandPackRequest.Band, imageScale, options)
+		geoHash := imagery.ParseGeoHashFromID(imageID, precision)
+		edge := imagery.OptramEdges{}
+		if val, ok := optramMap[geoHash]; ok {
+			edge = val
+		}
+		img, err := imagery.ImageFromCombination(sourcePath, bandMapping[imageID], multiBandPackRequest.Band, imageScale, &edge, options)
 		if err != nil {
 			handleThreadError(&errorIDs, &imageID, &err)
 			continue
@@ -266,4 +280,28 @@ func getMultiBandImages(multiBandPackRequest *ImagePackRequest, threadID int, nu
 func handleThreadError(errorIDs *[]string, imageID *string, err *error) {
 	*errorIDs = append(*errorIDs, *imageID)
 	log.Error(*err)
+}
+
+func fetchOptramVariables(imagePackRequest *ImagePackRequest, ctor api.MetadataStorageCtor) (map[string]imagery.OptramEdges, int, error) {
+	storage, err := ctor()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	res, err := storage.FetchDataset(imagePackRequest.Dataset, false, false, false)
+	if err != nil {
+		return nil, 0, err
+	}
+	var optramMap map[string]imagery.OptramEdges
+	// load optram file
+	// parse optram variables
+	precision := 0
+	optramPath := strings.Join([]string{env.ResolvePath(res.Source, res.Folder), imagery.OPTRAMJSONFile}, "/")
+	edgeMap, mapPrecision, err := imagery.ReadOptramFile(optramPath)
+	if err != nil {
+		return nil, 0, err
+	}
+	optramMap = edgeMap
+	precision = mapPrecision
+	return optramMap, precision, nil
 }

--- a/api/routes/index.go
+++ b/api/routes/index.go
@@ -17,12 +17,14 @@ package routes
 
 import (
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
 	"goji.io/v3/pat"
 
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
+	"github.com/uncharted-distil/distil/api/env"
 	api "github.com/uncharted-distil/distil/api/model"
 	"github.com/uncharted-distil/distil/api/util"
 	"github.com/uncharted-distil/distil/api/util/imagery"
@@ -59,17 +61,29 @@ func IndexDataHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter, *h
 			handleError(w, errors.Wrap(err, "Unable to parse post parameters"))
 			return
 		}
-
+		meta, err := ctor()
+		if err != nil {
+			handleError(w, err)
+			return
+		}
 		var combinations *Combinations
 		switch typ {
 		case "metrics":
 			task := params["task"].(string)
 			combinations = getModelMetrics(task)
 		case "bands":
-			combinations = getBandCombinations()
+			datasetName := params["dataset"].(string)
+			ds, err := meta.FetchDataset(datasetName, false, false, false)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+			
+			combinations = getBandCombinations(env.ResolvePath(ds.Source, ds.Folder))
 		default:
 			err = errors.Errorf("unrecognized index data type '%s'", typ)
 		}
+
 		if err != nil {
 			handleError(w, errors.Wrap(err, "unable marshal result histogram into JSON"))
 			return
@@ -83,10 +97,24 @@ func IndexDataHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter, *h
 	}
 }
 
-func getBandCombinations() *Combinations {
-	combinationsList := make([]interface{}, len(imagery.SentinelBandCombinations))
+func getBandCombinations(augmentFolder string) *Combinations {
+	optramSupported:=true
+	// check augmented folder for optram variables
+	_, err := os.Stat(strings.Join([]string{augmentFolder, imagery.OPTRAMJSONFile}, "/"))
+	size:= len(imagery.SentinelBandCombinations)
+	if err != nil {
+		// file does not exist remove optram
+		optramSupported=false
+		// decrease size of result array
+		size-=1
+	}
+	combinationsList := make([]interface{}, size)
 	idx := 0
 	for _, value := range imagery.SentinelBandCombinations {
+		// if not supported make sure not to add band combination to results
+		if !optramSupported && value.ID == imagery.OPTRAM {
+			continue
+		}
 		combinationsList[idx] = &MultiBandCombinationDesc{value.ID, value.DisplayName}
 		idx++
 	}

--- a/api/routes/index.go
+++ b/api/routes/index.go
@@ -78,7 +78,7 @@ func IndexDataHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter, *h
 				handleError(w, err)
 				return
 			}
-			
+
 			combinations = getBandCombinations(env.ResolvePath(ds.Source, ds.Folder))
 		default:
 			err = errors.Errorf("unrecognized index data type '%s'", typ)
@@ -98,15 +98,15 @@ func IndexDataHandler(ctor api.MetadataStorageCtor) func(http.ResponseWriter, *h
 }
 
 func getBandCombinations(augmentFolder string) *Combinations {
-	optramSupported:=true
+	optramSupported := true
 	// check augmented folder for optram variables
 	_, err := os.Stat(strings.Join([]string{augmentFolder, imagery.OPTRAMJSONFile}, "/"))
-	size:= len(imagery.SentinelBandCombinations)
+	size := len(imagery.SentinelBandCombinations)
 	if err != nil {
 		// file does not exist remove optram
-		optramSupported=false
+		optramSupported = false
 		// decrease size of result array
-		size-=1
+		size -= 1
 	}
 	combinationsList := make([]interface{}, size)
 	idx := 0

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -108,8 +108,22 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, dataCtor api.DataStorag
 			handleError(w, err)
 			return
 		}
+		var optramMap map[string]imagery.OptramEdges
+		optramPath := ""
+		edge := imagery.OptramEdges{}
+		precision := 0
+		if bandCombo == imagery.OPTRAM {
+			optramPath = strings.Join([]string{env.ResolvePath(res.Source, res.Folder), imagery.OPTRAMJSONFile}, "/")
+			optramMap, precision, err = imagery.ReadOptramFile(optramPath)
+			if err != nil {
+				handleError(w, err)
+				return
+			}
+			geoHash := imagery.ParseGeoHashFromID(imageID, precision)
+			edge = optramMap[geoHash]
+		}
 
-		img, err := imagery.ImageFromCombination(sourcePath, bandMapping[imageID], bandCombo, imageScale, options)
+		img, err := imagery.ImageFromCombination(sourcePath, bandMapping[imageID], bandCombo, imageScale, &edge, options)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/routes/multiband_image.go
+++ b/api/routes/multiband_image.go
@@ -124,7 +124,7 @@ func MultiBandImageHandler(ctor api.MetadataStorageCtor, dataCtor api.DataStorag
 			edge = optramMap[geoHash]
 		}
 
-		img, err := imagery.ImageFromCombination(sourcePath, bandMapping[imageID], bandCombo, imageScale, &edge, options)
+		img, err := imagery.ImageFromCombination(sourcePath, bandMapping[imageID], bandCombo, imageScale, &edge, ramp, options)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/util/imagery/imagery.go
+++ b/api/util/imagery/imagery.go
@@ -221,7 +221,7 @@ type ImageCacheKey struct {
 
 // ImageFromCombination takes a base dataset directory, fileID and a band combination label and
 // returns a composed image.  NOTE: Currently a bit hardcoded for sentinel-2 data.
-func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, bandCombo string, imageScale ImageScale, edges *OptramEdges, options ...Options) (*image.RGBA, error) {
+func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, bandCombo string, imageScale ImageScale, edges *OptramEdges, ramp string, options ...Options) (*image.RGBA, error) {
 	// attempt to get the folder file type for the supplied dataset dir from the cache, if
 	// not do the look up
 	bandCombination := strings.ToLower(string(BandCombinationID(bandCombo)))
@@ -271,7 +271,7 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 			imageRamp = GetColorRamp(ramp)
 		}
 
-		image, err := ImageFromBands(filePaths, imageRamp, bandCombo.Transform, imageScale, options...)
+		image, err := ImageFromBands(filePaths, imageRamp, bandCombo, imageScale, edges, options...)
 		if err != nil {
 			return nil, err
 		}
@@ -289,7 +289,7 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 // where the file names map to R,G,B in order.  The results are returned as a JPEG
 // encoded byte stream. If errors are encountered processing a band an attempt will
 // be made to create the image from the remaining bands, while logging an error.
-func ImageFromBands(paths []string, bandCombo *BandCombination, imageScale ImageScale, edges *OptramEdges, options ...Options) (*image.RGBA, error) {
+func ImageFromBands(paths []string, ramp []uint8, bandCombo *BandCombination, imageScale ImageScale, edges *OptramEdges, options ...Options) (*image.RGBA, error) {
 	bandImages := []*image.Gray16{}
 	maxXSize := 0
 	maxYSize := 0
@@ -323,7 +323,7 @@ func ImageFromBands(paths []string, bandCombo *BandCombination, imageScale Image
 		// Create an RGBA image from the resized bands
 		return createRGBAFromBands(maxXSize, maxYSize, bandImages, options...), nil
 	}
-	return createRGBAFromRamp(maxXSize, maxYSize, bandImages, bandCombo.Transform, bandCombo.Ramp, edges), nil
+	return createRGBAFromRamp(maxXSize, maxYSize, bandImages, bandCombo.Transform, ramp, edges), nil
 }
 
 // ScaleConfidenceMatrix scales confidence matrix to desired size using linear scaling

--- a/api/util/imagery/imagery_test.go
+++ b/api/util/imagery/imagery_test.go
@@ -59,7 +59,7 @@ func TestImageFromBandsTrueColor(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B03.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B02.tif",
-	}, nil, SentinelBandCombinations[NaturalColors], ImageScale{}, &OptramEdges{}, true)
+	}, nil, nil, ImageScale{}, &OptramEdges{}, true)
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -79,7 +79,7 @@ func TestImageFromBandsResize(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, SentinelBandCombinations[ShortwaveInfrared], ImageScale{}, &OptramEdges{}, true)
+	}, nil, nil, ImageScale{}, &OptramEdges{}, true)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
@@ -99,7 +99,7 @@ func TestImageFromRamp(t *testing.T) {
 	composedImage, err := ImageFromBands([]string{
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B11.tif",
-	}, BlueYellowBrownRamp, SentinelBandCombinations[NDMI], ImageScale{}, &OptramEdges{}, true)
+	}, BlueYellowBrownRamp, SentinelBandCombinations[NDMI].Transform, ImageScale{}, &OptramEdges{}, true)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
@@ -119,7 +119,7 @@ func TestImageFromRampClamped(t *testing.T) {
 	composedImage, err := ImageFromBands([]string{
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, RedYellowGreenRamp, SentinelBandCombinations[NDVI], ImageScale{}, &OptramEdges{}, true)
+	}, RedYellowGreenRamp, SentinelBandCombinations[NDVI].Transform, ImageScale{}, &OptramEdges{}, true)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
@@ -140,7 +140,7 @@ func TestImageFromBandsMissing(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, SentinelBandCombinations[ShortwaveInfrared], ImageScale{}, &OptramEdges{}, true)
+	}, nil, SentinelBandCombinations[ShortwaveInfrared].Transform, ImageScale{}, &OptramEdges{}, true)
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)

--- a/api/util/imagery/imagery_test.go
+++ b/api/util/imagery/imagery_test.go
@@ -38,7 +38,7 @@ func TestImageFromCombination(t *testing.T) {
 		"b11": "S2A_MSIL2A_20171121T112351_79_21_B11.tif",
 		"b12": "S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 	}
-	composedImage, err := ImageFromCombination("../test/bigearthnet", bandMap, NaturalColors, ImageScale{}, "")
+	composedImage, err := ImageFromCombination("../test/bigearthnet", bandMap, NaturalColors, ImageScale{}, &OptramEdges{}, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -57,7 +57,7 @@ func TestImageFromBandsTrueColor(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B03.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B02.tif",
-	}, nil, nil, ImageScale{})
+	}, nil, nil, ImageScale{}, &OptramEdges{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -77,7 +77,7 @@ func TestImageFromBandsResize(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil, ImageScale{})
+	}, nil, nil, ImageScale{}, &OptramEdges{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -96,7 +96,7 @@ func TestImageFromRamp(t *testing.T) {
 	composedImage, err := ImageFromBands([]string{
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B11.tif",
-	}, BlueYellowBrownRamp, NormalizingTransform, ImageScale{})
+	}, BlueYellowBrownRamp, SentinelBandCombinations[NDMI], ImageScale{}, &OptramEdges{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -115,7 +115,7 @@ func TestImageFromRampClamped(t *testing.T) {
 	composedImage, err := ImageFromBands([]string{
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, RedYellowGreenRamp, ClampedNormalizingTransform, ImageScale{})
+	}, RedYellowGreenRamp, SentinelBandCombinations[NDVI], ImageScale{}, &OptramEdges{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -135,7 +135,7 @@ func TestImageFromBandsMissing(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil, ImageScale{})
+	}, nil, nil, ImageScale{}, &OptramEdges{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)

--- a/api/util/imagery/imagery_test.go
+++ b/api/util/imagery/imagery_test.go
@@ -57,7 +57,7 @@ func TestImageFromBandsTrueColor(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B03.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B02.tif",
-	}, nil, nil, ImageScale{}, &OptramEdges{})
+	}, nil, SentinelBandCombinations[NaturalColors], ImageScale{}, &OptramEdges{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -77,7 +77,7 @@ func TestImageFromBandsResize(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil, ImageScale{}, &OptramEdges{})
+	}, nil, SentinelBandCombinations[ShortwaveInfrared], ImageScale{}, &OptramEdges{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -135,7 +135,7 @@ func TestImageFromBandsMissing(t *testing.T) {
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil, ImageScale{}, &OptramEdges{})
+	}, nil, SentinelBandCombinations[ShortwaveInfrared], ImageScale{}, &OptramEdges{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)

--- a/api/util/json/json.go
+++ b/api/util/json/json.go
@@ -17,6 +17,7 @@ package json
 
 import (
 	"encoding/json"
+	"io/ioutil"
 )
 
 // RawMessage is an alias for json.RawMessage
@@ -357,4 +358,13 @@ func Copy(j map[string]interface{}) (map[string]interface{}, error) {
 		return nil, err
 	}
 	return Unmarshal(bytes)
+}
+
+// ReadFile will read a json file into a byte array and unmarshal it to a map[string]interface
+func ReadFile(file string) (map[string]interface{}, error) {
+	buffer, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return Unmarshal(buffer)
 }

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1695,7 +1695,7 @@ export const actions = {
     try {
       const repsonse = await axios.post<BandCombinations>(
         `distil/index-data/bands`,
-        {}
+        { dataset: args.dataset }
       );
       const bands = repsonse.data.combinations;
       mutations.updateBands(context, bands);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25306965/139493922-1a29cf27-1164-48fc-887a-cd8b5d91e39e.png)
From distil with veridis color ramp
![image](https://user-images.githubusercontent.com/25306965/139493966-7d2ecfd6-2ad3-4908-9436-7cc7e7106adc.png)
From the python code

The optram_variables.json is required to be within the source folder. The classification, datasetDoc, importance files are also stored there. If the file is not found the OPTRAM band is not supplied to the client to prevent users from asking for it.

closes #2931 