### PR TITLE
Simple color model

### DIFF
--- a/api/util/imagery/color_correction.go
+++ b/api/util/imagery/color_correction.go
@@ -17,6 +17,8 @@ package imagery
 
 import "math"
 
+const basicGainLScale = 2.5
+
 // Options for ConvertS2ToRgb
 type Options struct {
 	Gain  float64 `json:"gain"`
@@ -29,7 +31,12 @@ type Options struct {
 // default options: gain=2.5, gamma=2.2, gainL=1.0
 func ConvertS2ToRgb(bands [3]float64, advancedColorModel bool, options ...Options) [3]float64 {
 	if !advancedColorModel {
-		return clamp([3]float64{bands[0] * 2.5, bands[1] * 2.5, bands[2] * 2.5})
+		// GainL comes in on a scale from 0 to 2.
+		gainScale := 1.0
+		if len(options) > 0 {
+			gainScale = options[0].GainL * basicGainLScale
+		}
+		return clamp([3]float64{bands[0] * gainScale, bands[1] * gainScale, bands[2] * gainScale})
 	}
 
 	t := [3][3]float64{{0.268, 0.362, 0.371},

--- a/api/util/imagery/color_correction.go
+++ b/api/util/imagery/color_correction.go
@@ -27,7 +27,11 @@ type Options struct {
 
 // ConvertS2ToRgb bands: [b02, b03, b04], Options gain amount, gamma correction amount, gainL light gain
 // default options: gain=2.5, gamma=2.2, gainL=1.0
-func ConvertS2ToRgb(bands [3]float64, options ...Options) [3]float64 {
+func ConvertS2ToRgb(bands [3]float64, advancedColorModel bool, options ...Options) [3]float64 {
+	if !advancedColorModel {
+		return clamp([3]float64{bands[0] * 2.5, bands[1] * 2.5, bands[2] * 2.5})
+	}
+
 	t := [3][3]float64{{0.268, 0.362, 0.371},
 		{0.240, 0.587, 0.174},
 		{1.463, -0.427, -0.043}} // magic matrix
@@ -128,4 +132,16 @@ func xyzToRGB(xyz [3]float64) [3]float64 {
 		sRGB[i] = math.Max(math.Min(adj(v), 1.0), 0)
 	}
 	return sRGB
+}
+
+func clamp(xyz [3]float64) [3]float64 {
+	result := [3]float64{0.0, 0.0, 0.0}
+	for i, v := range xyz {
+		if v > 1.0 {
+			result[i] = 1.0
+		} else {
+			result[i] = v
+		}
+	}
+	return result
 }

--- a/api/util/imagery/imagery.go
+++ b/api/util/imagery/imagery.go
@@ -142,8 +142,8 @@ var (
 func init() {
 	// initialize the band combination structures - needs to be done in init so that referenced color ramps are built
 	SentinelBandCombinations = map[string]*BandCombination{
-		NaturalColors1:          {NaturalColors, "Natural Colors", []string{"b04", "b03", "b02"}, nil, nil, false},
-        NaturalColors2:         {NaturalColors2, "Natural Colors 2", []string{"b04", "b03", "b02"}, nil, nil, true},
+		NaturalColors1:         {NaturalColors1, "Natural Colors", []string{"b04", "b03", "b02"}, nil, nil, false},
+		NaturalColors2:         {NaturalColors2, "Natural Colors 2", []string{"b04", "b03", "b02"}, nil, nil, true},
 		FalseColorInfrared:     {FalseColorInfrared, "False Color Infrared", []string{"b08", "b04", "b03"}, nil, nil, false},
 		FalseColorUrban:        {FalseColorUrban, "False Color Urban", []string{"b12", "b11", "b04"}, nil, nil, false},
 		Agriculture:            {Agriculture, "Agriculture", []string{"b11", "b08", "b02"}, nil, nil, false},
@@ -158,7 +158,7 @@ func init() {
 		NDWI:                   {NDWI, "Normalized Difference Water Index", []string{"b03", "b08"}, BlueYellowBrownRamp, NormalizingTransform, false},
 		NSMI:                   {NSMI, "Normalized Soil Moisture Index", []string{"b11", "b12"}, BlueYellowBrownRamp, NormalizingTransform, false},
 		MNDWI:                  {MNDWI, "Modified Normalized Difference Water Index", []string{"b03", "b11"}, BlueYellowBrownRamp, NormalizingTransform, false},
-		RSWIR:                  {RSWIR, "Red and Shortwave Infrared", []string{"b04", "b11"}, BlueYellowBrownRamp, NormalizingTransform, false},		
+		RSWIR:                  {RSWIR, "Red and Shortwave Infrared", []string{"b04", "b11"}, BlueYellowBrownRamp, NormalizingTransform, false},
 	}
 }
 
@@ -231,7 +231,7 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 			imageRamp = GetColorRamp(ramp)
 		}
 
-		image, err := ImageFromBands(filePaths, imageRamp, bandCombo.Transform, imageScale, bandCombo.AdvancedColorModel, options...)		
+		image, err := ImageFromBands(filePaths, imageRamp, bandCombo.Transform, imageScale, bandCombo.AdvancedColorModel, options...)
 		if err != nil {
 			return nil, err
 		}

--- a/api/util/imagery/imagery.go
+++ b/api/util/imagery/imagery.go
@@ -43,12 +43,11 @@ const (
 	// value.
 	Sentinel2Max = 10000
 
-	// Exponent is the exponent to apply to channel values during pre-processing.  A value of 1.0 will leave values
-	// unchanged.
-	Exponent = 0.3
+	// NaturalColors1 identifies a band mapping that displays an image in natural color.
+	NaturalColors1 = "natural_colors_1"
 
-	// NaturalColors identifies a band mapping that displays an image in natural color.
-	NaturalColors = "natural_colors"
+	// NaturalColors2 identifies a band mapping that displays an image in natural color.
+	NaturalColors2 = "natural_colors_2"
 
 	// FalseColorInfrared identifies a band mapping that displays an image in false color for visualizing vegatation.
 	FalseColorInfrared = "false_color_infrared"
@@ -107,11 +106,12 @@ type BandCombinationID string
 
 // BandCombination defines a mapping of satellite bands to image RGB channels.
 type BandCombination struct {
-	ID          BandCombinationID
-	DisplayName string
-	Mapping     []string
-	Ramp        []uint8
-	Transform   func(...uint16) float64
+	ID                 BandCombinationID
+	DisplayName        string
+	Mapping            []string
+	Ramp               []uint8
+	Transform          func(...uint16) float64
+	AdvancedColorModel bool
 }
 
 // ImageScale defines what to scale the image size to. If one property is defined aspect ratio will be kept. If nil for both the func will determine the size.
@@ -142,22 +142,23 @@ var (
 func init() {
 	// initialize the band combination structures - needs to be done in init so that referenced color ramps are built
 	SentinelBandCombinations = map[string]*BandCombination{
-		NaturalColors:          {NaturalColors, "Natural Colors", []string{"b04", "b03", "b02"}, nil, nil},
-		FalseColorInfrared:     {FalseColorInfrared, "False Color Infrared", []string{"b08", "b04", "b03"}, nil, nil},
-		FalseColorUrban:        {FalseColorUrban, "False Color Urban", []string{"b12", "b11", "b04"}, nil, nil},
-		Agriculture:            {Agriculture, "Agriculture", []string{"b11", "b08", "b02"}, nil, nil},
-		AtmosphericPenetration: {AtmosphericPenetration, "Atmospheric Penetration", []string{"b12", "b11", "b8a"}, nil, nil},
-		HealthyVegetation:      {HealthyVegetation, "Healthy Vegetation", []string{"b08", "b11", "b02"}, nil, nil},
-		LandWater:              {LandWater, "Land/Water", []string{"b08", "b11", "b04"}, nil, nil},
-		AtmosphericRemoval:     {AtmosphericRemoval, "Atmospheric Removal", []string{"b12", "b08", "b03"}, nil, nil},
-		ShortwaveInfrared:      {ShortwaveInfrared, "Shortwave Infrared", []string{"b12", "b08", "b04"}, nil, nil},
-		VegetationAnalysis:     {VegetationAnalysis, "Vegetation Analysis", []string{"b11", "b08", "b04"}, nil, nil},
-		NDVI:                   {NDVI, "Normalized Difference Vegetation Index", []string{"b08", "b04"}, RedYellowGreenRamp, ClampedNormalizingTransform},
-		NDMI:                   {NDMI, "Normalized Difference Moisture Index ", []string{"b08", "b11"}, BlueYellowBrownRamp, NormalizingTransform},
-		NDWI:                   {NDWI, "Normalized Difference Water Index", []string{"b03", "b08"}, BlueYellowBrownRamp, NormalizingTransform},
-		NSMI:                   {NSMI, "Normalized Soil Moisture Index", []string{"b11", "b12"}, BlueYellowBrownRamp, NormalizingTransform},
-		MNDWI:                  {MNDWI, "Modified Normalized Difference Water Index", []string{"b03", "b11"}, BlueYellowBrownRamp, NormalizingTransform},
-		RSWIR:                  {RSWIR, "Red and Shortwave Infrared", []string{"b04", "b11"}, BlueYellowBrownRamp, NormalizingTransform},
+		NaturalColors1:          {NaturalColors, "Natural Colors", []string{"b04", "b03", "b02"}, nil, nil, false},
+        NaturalColors2:         {NaturalColors2, "Natural Colors 2", []string{"b04", "b03", "b02"}, nil, nil, true},
+		FalseColorInfrared:     {FalseColorInfrared, "False Color Infrared", []string{"b08", "b04", "b03"}, nil, nil, false},
+		FalseColorUrban:        {FalseColorUrban, "False Color Urban", []string{"b12", "b11", "b04"}, nil, nil, false},
+		Agriculture:            {Agriculture, "Agriculture", []string{"b11", "b08", "b02"}, nil, nil, false},
+		AtmosphericPenetration: {AtmosphericPenetration, "Atmospheric Penetration", []string{"b12", "b11", "b8a"}, nil, nil, false},
+		HealthyVegetation:      {HealthyVegetation, "Healthy Vegetation", []string{"b08", "b11", "b02"}, nil, nil, false},
+		LandWater:              {LandWater, "Land/Water", []string{"b08", "b11", "b04"}, nil, nil, false},
+		AtmosphericRemoval:     {AtmosphericRemoval, "Atmospheric Removal", []string{"b12", "b08", "b03"}, nil, nil, false},
+		ShortwaveInfrared:      {ShortwaveInfrared, "Shortwave Infrared", []string{"b12", "b08", "b04"}, nil, nil, false},
+		VegetationAnalysis:     {VegetationAnalysis, "Vegetation Analysis", []string{"b11", "b08", "b04"}, nil, nil, false},
+		NDVI:                   {NDVI, "Normalized Difference Vegetation Index", []string{"b08", "b04"}, RedYellowGreenRamp, ClampedNormalizingTransform, false},
+		NDMI:                   {NDMI, "Normalized Difference Moisture Index ", []string{"b08", "b11"}, BlueYellowBrownRamp, NormalizingTransform, false},
+		NDWI:                   {NDWI, "Normalized Difference Water Index", []string{"b03", "b08"}, BlueYellowBrownRamp, NormalizingTransform, false},
+		NSMI:                   {NSMI, "Normalized Soil Moisture Index", []string{"b11", "b12"}, BlueYellowBrownRamp, NormalizingTransform, false},
+		MNDWI:                  {MNDWI, "Modified Normalized Difference Water Index", []string{"b03", "b11"}, BlueYellowBrownRamp, NormalizingTransform, false},
+		RSWIR:                  {RSWIR, "Red and Shortwave Infrared", []string{"b04", "b11"}, BlueYellowBrownRamp, NormalizingTransform, false},		
 	}
 }
 
@@ -223,6 +224,7 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 		for _, bandLabel := range bandCombo.Mapping {
 			filePaths = append(filePaths, path.Join(datasetDir, bandFileMapping[bandLabel]))
 		}
+<<<<<<< Updated upstream:api/util/imagery/imagery.go
 
 		imageRamp := bandCombo.Ramp
 
@@ -239,6 +241,9 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 		}
 
 		return image, nil
+=======
+		return ImageFromBands(filePaths, bandCombo.Ramp, bandCombo.Transform, imageScale, bandCombo.AdvancedColorModel, options...)
+>>>>>>> Stashed changes:api/util/imagery.go
 	}
 
 	return nil, errors.Errorf("unhandled band combination %s", bandCombination)
@@ -248,7 +253,7 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 // where the file names map to R,G,B in order.  The results are returned as a JPEG
 // encoded byte stream. If errors are encountered processing a band an attempt will
 // be made to create the image from the remaining bands, while logging an error.
-func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) float64, imageScale ImageScale, options ...Options) (*image.RGBA, error) {
+func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) float64, imageScale ImageScale, advancedColorModel bool, options ...Options) (*image.RGBA, error) {
 	bandImages := []*image.Gray16{}
 	maxXSize := 0
 	maxYSize := 0
@@ -280,7 +285,7 @@ func ImageFromBands(paths []string, ramp []uint8, transform func(...uint16) floa
 	// a transform and color lookup
 	if ramp == nil || transform == nil {
 		// Create an RGBA image from the resized bands
-		return createRGBAFromBands(maxXSize, maxYSize, bandImages, options...), nil
+		return createRGBAFromBands(maxXSize, maxYSize, bandImages, advancedColorModel, options...), nil
 	}
 	return createRGBAFromRamp(maxXSize, maxYSize, bandImages, transform, ramp), nil
 }
@@ -448,7 +453,7 @@ func loadAsGray16(filePath string) (*image.Gray16, error) {
 	return bandImage, nil
 }
 
-func createRGBAFromBands(xSize int, ySize int, bandImages []*image.Gray16, options ...Options) *image.RGBA {
+func createRGBAFromBands(xSize int, ySize int, bandImages []*image.Gray16, advancedColorModel bool, options ...Options) *image.RGBA {
 	// Create a new RGBA image to hold the collected bands
 	outputImage := image.NewRGBA(image.Rect(0, 0, xSize, ySize))
 
@@ -465,7 +470,7 @@ func createRGBAFromBands(xSize int, ySize int, bandImages []*image.Gray16, optio
 				bandBuffer[j] = 0.5
 			}
 		}
-		rgb := ConvertS2ToRgb(bandBuffer, options...)
+		rgb := ConvertS2ToRgb(bandBuffer, advancedColorModel, options...)
 		outputImage.Pix[outputIdx] = uint8(rgb[0] * 255)   // r
 		outputImage.Pix[outputIdx+1] = uint8(rgb[1] * 255) // g
 		outputImage.Pix[outputIdx+2] = uint8(rgb[2] * 255) // b

--- a/api/util/imagery/imagery.go
+++ b/api/util/imagery/imagery.go
@@ -224,7 +224,6 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 		for _, bandLabel := range bandCombo.Mapping {
 			filePaths = append(filePaths, path.Join(datasetDir, bandFileMapping[bandLabel]))
 		}
-<<<<<<< Updated upstream:api/util/imagery/imagery.go
 
 		imageRamp := bandCombo.Ramp
 
@@ -232,7 +231,7 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 			imageRamp = GetColorRamp(ramp)
 		}
 
-		image, err := ImageFromBands(filePaths, imageRamp, bandCombo.Transform, imageScale, options...)
+		image, err := ImageFromBands(filePaths, imageRamp, bandCombo.Transform, imageScale, bandCombo.AdvancedColorModel, options...)		
 		if err != nil {
 			return nil, err
 		}
@@ -241,9 +240,6 @@ func ImageFromCombination(datasetDir string, bandFileMapping map[string]string, 
 		}
 
 		return image, nil
-=======
-		return ImageFromBands(filePaths, bandCombo.Ramp, bandCombo.Transform, imageScale, bandCombo.AdvancedColorModel, options...)
->>>>>>> Stashed changes:api/util/imagery.go
 	}
 
 	return nil, errors.Errorf("unhandled band combination %s", bandCombination)

--- a/api/util/imagery/imagery_test.go
+++ b/api/util/imagery/imagery_test.go
@@ -38,7 +38,7 @@ func TestImageFromCombination(t *testing.T) {
 		"b11": "S2A_MSIL2A_20171121T112351_79_21_B11.tif",
 		"b12": "S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 	}
-	composedImage, err := ImageFromCombination("test/bigearthnet", bandMap, NaturalColors2, ImageScale{})
+	composedImage, err := ImageFromCombination("../test/bigearthnet", bandMap, NaturalColors2, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -54,17 +54,10 @@ func TestImageFromCombination(t *testing.T) {
 func TestImageFromBandsTrueColor(t *testing.T) {
 	// Test basic loading - all image sources are the same size.
 	composedImage, err := ImageFromBands([]string{
-<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B03.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B02.tif",
-	}, nil, nil, ImageScale{})
-=======
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B03.tif",
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B02.tif",
 	}, nil, nil, ImageScale{}, true)
->>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -81,17 +74,10 @@ func TestImageFromBandsResize(t *testing.T) {
 	// Tests loading data from sources that are 3 different sizes in terms
 	// of pixels.
 	composedImage, err := ImageFromBands([]string{
-<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil, ImageScale{})
-=======
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 	}, nil, nil, ImageScale{}, true)
->>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -108,15 +94,9 @@ func TestImageFromRamp(t *testing.T) {
 	// Tests loading data from sources that are 3 different sizes in terms
 	// of pixels.
 	composedImage, err := ImageFromBands([]string{
-<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B11.tif",
-	}, BlueYellowBrownRamp, NormalizingTransform, ImageScale{})
-=======
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B11.tif",
 	}, BlueYellowBrownRamp, NormalizingTransform, ImageScale{}, true)
->>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -133,15 +113,9 @@ func TestImageFromRampClamped(t *testing.T) {
 	// Tests loading data from sources that are 3 different sizes in terms
 	// of pixels.
 	composedImage, err := ImageFromBands([]string{
-<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, RedYellowGreenRamp, ClampedNormalizingTransform, ImageScale{})
-=======
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 	}, RedYellowGreenRamp, ClampedNormalizingTransform, ImageScale{}, true)
->>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -158,17 +132,10 @@ func TestImageFromBandsMissing(t *testing.T) {
 	// Tests handling the case where one of the bands contains bad data.  The missing
 	// band will be mapped to grey.
 	composedImage, err := ImageFromBands([]string{
-<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
-	}, nil, nil, ImageScale{})
-=======
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
-		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 	}, nil, nil, ImageScale{}, true)
->>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)

--- a/api/util/imagery/imagery_test.go
+++ b/api/util/imagery/imagery_test.go
@@ -38,7 +38,7 @@ func TestImageFromCombination(t *testing.T) {
 		"b11": "S2A_MSIL2A_20171121T112351_79_21_B11.tif",
 		"b12": "S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 	}
-	composedImage, err := ImageFromCombination("../test/bigearthnet", bandMap, NaturalColors, ImageScale{}, "")
+	composedImage, err := ImageFromCombination("test/bigearthnet", bandMap, NaturalColors2, ImageScale{})
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -54,10 +54,17 @@ func TestImageFromCombination(t *testing.T) {
 func TestImageFromBandsTrueColor(t *testing.T) {
 	// Test basic loading - all image sources are the same size.
 	composedImage, err := ImageFromBands([]string{
+<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B03.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B02.tif",
 	}, nil, nil, ImageScale{})
+=======
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B03.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B02.tif",
+	}, nil, nil, ImageScale{}, true)
+>>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -74,10 +81,17 @@ func TestImageFromBandsResize(t *testing.T) {
 	// Tests loading data from sources that are 3 different sizes in terms
 	// of pixels.
 	composedImage, err := ImageFromBands([]string{
+<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 	}, nil, nil, ImageScale{})
+=======
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
+	}, nil, nil, ImageScale{}, true)
+>>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -94,9 +108,15 @@ func TestImageFromRamp(t *testing.T) {
 	// Tests loading data from sources that are 3 different sizes in terms
 	// of pixels.
 	composedImage, err := ImageFromBands([]string{
+<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B11.tif",
 	}, BlueYellowBrownRamp, NormalizingTransform, ImageScale{})
+=======
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B11.tif",
+	}, BlueYellowBrownRamp, NormalizingTransform, ImageScale{}, true)
+>>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -113,9 +133,15 @@ func TestImageFromRampClamped(t *testing.T) {
 	// Tests loading data from sources that are 3 different sizes in terms
 	// of pixels.
 	composedImage, err := ImageFromBands([]string{
+<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 	}, RedYellowGreenRamp, ClampedNormalizingTransform, ImageScale{})
+=======
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
+	}, RedYellowGreenRamp, ClampedNormalizingTransform, ImageScale{}, true)
+>>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)
@@ -132,10 +158,17 @@ func TestImageFromBandsMissing(t *testing.T) {
 	// Tests handling the case where one of the bands contains bad data.  The missing
 	// band will be mapped to grey.
 	composedImage, err := ImageFromBands([]string{
+<<<<<<< Updated upstream:api/util/imagery/imagery_test.go
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
 		"../test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
 	}, nil, nil, ImageScale{})
+=======
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B12.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B08.tif",
+		"test/bigearthnet/S2A_MSIL2A_20171121T112351_79_21_B04.tif",
+	}, nil, nil, ImageScale{}, true)
+>>>>>>> Stashed changes:api/util/imagery_test.go
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)

--- a/api/util/imagery/imagery_test.go
+++ b/api/util/imagery/imagery_test.go
@@ -38,7 +38,7 @@ func TestImageFromCombination(t *testing.T) {
 		"b11": "S2A_MSIL2A_20171121T112351_79_21_B11.tif",
 		"b12": "S2A_MSIL2A_20171121T112351_79_21_B12.tif",
 	}
-	composedImage, err := ImageFromCombination("../test/bigearthnet", bandMap, NaturalColors2, ImageScale{})
+	composedImage, err := ImageFromCombination("../test/bigearthnet", bandMap, NaturalColors2, ImageScale{}, "")
 	assert.NoError(t, err)
 	assert.NotNil(t, composedImage)
 	assert.True(t, len(composedImage.Pix) > 0)

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1289,7 +1289,7 @@ export const actions = {
           return actions.fetchMultiBandImage(context, {
             dataset: args.dataset,
             imageId: url,
-            bandCombination: BandID.NATURAL_COLORS,
+            bandCombination: BandID.NATURAL_COLORS_1,
             isThumbnail: true,
           });
         }

--- a/public/store/dataset/index.ts
+++ b/public/store/dataset/index.ts
@@ -302,7 +302,8 @@ export enum TaskTypes {
 }
 
 export enum BandID {
-  NATURAL_COLORS = "natural_colors",
+  NATURAL_COLORS_1 = "natural_colors_1",
+  NATURAL_COLORS_2 = "natural_colors_2",
   FALSE_COLOR_INFRARED = "false_color_infrared",
   FALSE_COLOR_URBAN = "false_color_urban",
   AGRICULTURE = "agriculture",

--- a/public/store/route/getters.ts
+++ b/public/store/route/getters.ts
@@ -705,7 +705,7 @@ export const getters = {
 
   getBandCombinationId(state: Route): BandID {
     const bandCombo = state.query.bandCombinationId;
-    return _.isEmpty(bandCombo) ? BandID.NATURAL_COLORS : <BandID>bandCombo;
+    return _.isEmpty(bandCombo) ? BandID.NATURAL_COLORS_1 : <BandID>bandCombo;
   },
 
   getModelTimeLimit(state: Route): number {


### PR DESCRIPTION
Sentinel Hub has a (simple color model)[https://custom-scripts.sentinel-hub.com/sentinel-2/true_color/#] implemented as their default that is less accurate than our current model in terms of representing the visible spectrum, but makes colour more separable under a lot of lighting conditions.  The downside is that bright values end up pretty heavily saturated.  The model itself is just a multiplication of the normalized R, G and B channels by 2.5.
