### PR TITLE
Resize img drilldown

### DIFF
--- a/public/components/ImageDrilldown.vue
+++ b/public/components/ImageDrilldown.vue
@@ -415,13 +415,13 @@ export default Vue.extend({
       this.currentBrightness = 0.5; // reset brightness
       this.sliderPosition = 50; // reset slider position
     },
-    cycleImage(sideToCycleTo: EI.IMAGES.Side) {
+    async cycleImage(sideToCycleTo: EI.IMAGES.Side) {
       this.carouselPosition = Math.max(
         0,
         Math.min(this.carouselPosition + sideToCycleTo, this.items.length - 1)
       );
       this.resetDrillDownData();
-      this.requestImage({
+      await this.requestImage({
         gainL: 1.0,
         gamma: 2.2,
         gain: 2.5,


### PR DESCRIPTION
The width and height saving that is used to prevent the modal shrinking and expanding on image cycle was causing problems. The copying images was invoking another route call. Now the there is only 1 call to the backend and if vue resizes the component a redraw will be called (which was missing resulting in a lot of the issues).

closes #3058
closes #3055