### PR TITLE
Drop cols query pipeline

### DIFF
--- a/api/routes/add_field.go
+++ b/api/routes/add_field.go
@@ -94,8 +94,15 @@ func AddFieldHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataStorageC
 				displayName = name
 			}
 		}
+		distilRoles := []string{model.VarDistilRoleData}
+		if params["isLabel"] != nil {
+			isLabel, ok := params["isLabel"].(bool)
+			if ok && isLabel {
+				distilRoles = append(distilRoles, model.VarDistilRoleLabel)
+			}
+		}
 		// update elasticsearch
-		err = metaStorage.AddVariable(dataset, name, displayName, fieldType, []string{model.VarDistilRoleData})
+		err = metaStorage.AddVariable(dataset, name, displayName, fieldType, distilRoles)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/api/task/featurize.go
+++ b/api/task/featurize.go
@@ -133,7 +133,7 @@ func FeaturizeDataset(originalSchemaFile string, schemaFile string, dataset stri
 		} else {
 			v = model.NewVariable(index, field, field, field, field, model.RealType,
 				model.RealType, "featurized value", []string{model.RoleAttribute},
-				[]string{model.VarDistilRoleSystemData}, nil, mainDR.Variables, false)
+				[]string{model.VarDistilRoleSystemData, model.VarDistilRoleFeaturized}, nil, mainDR.Variables, false)
 		}
 		vars = append(vars, v)
 	}

--- a/api/task/query.go
+++ b/api/task/query.go
@@ -21,8 +21,10 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
+	metaData "github.com/uncharted-distil/distil-compute/metadata"
 	"github.com/uncharted-distil/distil-compute/model"
 	"github.com/uncharted-distil/distil-compute/primitive/compute"
 	"github.com/uncharted-distil/distil-compute/primitive/compute/description"
@@ -61,7 +63,12 @@ func Query(params QueryParams) (map[string]interface{}, error) {
 	if ds.LearningDataset == "" {
 		return nil, errors.Errorf("only prefeaturized datasets support querying")
 	}
-
+	metaDisk, err := metaData.LoadMetadataFromOriginalSchema(strings.Join([]string{ds.LearningDataset, compute.D3MDataSchema}, "/"), false)
+	if err != nil {
+		return nil, err
+	}
+	// drop columns that are not an Index or Featurized
+	columnsToDrop := dropUnwantedColumns(metaDisk)
 	// extract the dataset from the database
 	data, err := params.DataStorage.FetchDataset(params.Dataset, ds.StorageName, false, false, params.Filters)
 	if err != nil {
@@ -78,7 +85,7 @@ func Query(params QueryParams) (map[string]interface{}, error) {
 	}
 
 	// create the image retrieval pipeline
-	desc, err := description.CreateImageQueryPipeline("image query", "pipeline to retrieve pertinent images", getQueryCachePath(ds.ID))
+	desc, err := description.CreateImageQueryPipeline("image query", "pipeline to retrieve pertinent images", getQueryCachePath(ds.ID), columnsToDrop)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +114,15 @@ func Query(params QueryParams) (map[string]interface{}, error) {
 
 	return nil, nil
 }
-
+func dropUnwantedColumns(metaDisk *model.Metadata) []int {
+	result := []int{}
+	for _, variable := range metaDisk.DataResources[0].Variables {
+		if !variable.HasAnyRole([]string{model.VarDistilRoleFeaturized, model.VarDistilRoleIndex}) {
+			result = append(result, variable.Index)
+		}
+	}
+	return result
+}
 func convertResultToRanking(results *[][]string) error {
 	// index for result values
 	valueIdx := 1

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/russross/blackfriday v2.0.0+incompatible
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/uncharted-distil/distil-compute v0.0.0-20211109190438-72419276aa7b
+	github.com/uncharted-distil/distil-compute v0.0.0-20211111182155-5ec97a35a8cc
 	github.com/uncharted-distil/distil-image-upscale v0.0.0-20210923132226-8eaee866ebdb
 	github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a
 	github.com/unchartedsoftware/plog v0.0.0-20200807135627-83d59e50ced5

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/uncharted-distil/distil-compute v0.0.0-20211109190438-72419276aa7b h1:OwoabWLEOGXrlpGiUUZ6oRl4G7vFn2p5oq2iySevCS0=
-github.com/uncharted-distil/distil-compute v0.0.0-20211109190438-72419276aa7b/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
+github.com/uncharted-distil/distil-compute v0.0.0-20211111182155-5ec97a35a8cc h1:I0fgw+Tb2rqFzj37Ux5SM0KMf48HZ0RxTbH+QGXoy5w=
+github.com/uncharted-distil/distil-compute v0.0.0-20211111182155-5ec97a35a8cc/go.mod h1:iFA7B2kb+WJfkzukdwfZJVY3o/ZFEjHPsA8k2N6I+B8=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210923132226-8eaee866ebdb h1:wDsXsrF8qM34nLeQ9xW+zbEdRNATk5sgOwuwCTrZmvY=
 github.com/uncharted-distil/distil-image-upscale v0.0.0-20210923132226-8eaee866ebdb/go.mod h1:Xhb77n2q8yDvcVS3Mvw0XlpdNMiFsL+vOlvoe556ivc=
 github.com/uncharted-distil/gdal v0.0.0-20200504224203-25f2e6a0dc2a h1:BPJrlnjdhxMBrJWiU4/Gl3PVdCUlY9JspWFTJ9UVO0Y=

--- a/public/store/dataset/actions.ts
+++ b/public/store/dataset/actions.ts
@@ -1762,6 +1762,7 @@ export const actions = {
       fieldType: string;
       defaultValue?: T;
       displayName?: string;
+      isLabel?: boolean;
     }
   ) {
     // check for valid dataset
@@ -1774,6 +1775,7 @@ export const actions = {
         fieldType: args.fieldType,
         defaultValue: args.defaultValue.toString(),
         displayName: args.displayName,
+        isLabel: args.isLabel ?? false,
       });
       return response.data;
     } catch (error) {

--- a/public/util/explorer/functions/result.ts
+++ b/public/util/explorer/functions/result.ts
@@ -53,6 +53,9 @@ export const RESULT_COMPUTES = {
     const self = (this as unknown) as DataExplorerRef;
     return self.solution?.solutionId;
   },
+  /**
+   * fittedSolutionId returns the current solution's fittedSolutionId
+   */
   fittedSolutionId(): string | undefined {
     const self = (this as unknown) as DataExplorerRef;
     return self.solution?.fittedSolutionId;

--- a/public/util/types.ts
+++ b/public/util/types.ts
@@ -30,6 +30,7 @@ export enum DISTIL_ROLES {
   Meta = "metadata",
   Data = "data",
   SystemData = "system-data",
+  Label = "label",
 }
 
 export enum JoinTypes {

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -288,7 +288,7 @@
         {{ labelModalTitle }}
       </template>
       <b-form-group
-        v-if="!isClone"
+        v-if="!hasLabelRole"
         id="input-group-1"
         label="Label name:"
         label-for="label-input-field"
@@ -319,10 +319,10 @@
     </b-modal>
     <b-modal
       :id="unsaveModalId"
-      @ok="onConfirmRouteSave(nextRoute)"
-      @cancel="onCancelRouteSave(nextRoute)"
       ok-variant="danger"
       ok-title="Delete Cloned Dataset"
+      @ok="onConfirmRouteSave(nextRoute)"
+      @cancel="onCancelRouteSave(nextRoute)"
     >
       <template #modal-header> Unsaved dataset </template>
       <template>


### PR DESCRIPTION
- The label creation now add a "label" DistilRole to the variable for the client to parse
- The featurize step now adds the "featurize" DistilRole
- The "featurize" DistilRole is used to find only the feature vector columns and drops the rest for the image query pipeline
- Tested on a shire and shire_maize join, the input is always 2049 for the query primitive (2048 feature vector, 1 d3mIndex)
