### PR TITLE
The client keeps track of if the ds needs to be saved

### DIFF
--- a/public/App.vue
+++ b/public/App.vue
@@ -70,9 +70,7 @@ export default Vue.extend({
           ExplorerStateNames.LABEL_VIEW &&
         state !== ExplorerStateNames.LABEL_VIEW
       ) {
-        const isDatasetSaved = await dataExplorer.isCurrentDatasetSaved();
-
-        if (!isDatasetSaved) {
+        if (dataExplorer.shouldSaveDataset) {
           dataExplorer.$bvModal.show(dataExplorer.unsaveModalId);
         } else {
           await dataExplorer.changeStatesByName(state);

--- a/public/util/componentTypes.ts
+++ b/public/util/componentTypes.ts
@@ -87,6 +87,7 @@ export interface DataExplorerRef {
   metaTypes: string[];
   state: BaseState;
   unsaveModalId: string;
+  shouldSaveDataset: boolean;
 
   // methods
   bindEventHandlers: (eventHandlers: Record<string, Function>) => void;

--- a/public/util/explorer/functions/generic.ts
+++ b/public/util/explorer/functions/generic.ts
@@ -48,8 +48,7 @@ import { overlayRouteEntry, RouteArgs } from "../../routes";
 import { clearHighlight } from "../../highlights";
 import { datasetActions } from "../../../store";
 import { getters as datasetGetters } from "../../../store/dataset/module";
-import { downloadFile, LowShotLabels } from "../../data";
-import { LABEL_FEATURE_INSTANCE } from "../../../store/route";
+import { downloadFile } from "../../data";
 
 export const GENERIC_METHODS = {
   /**

--- a/public/views/DataExplorer.vue
+++ b/public/views/DataExplorer.vue
@@ -444,6 +444,7 @@ const DataExplorer = Vue.extend({
       instanceName: DATA_EXPLORER_VAR_INSTANCE, // component instance name
       isBusy: false, // controls spinners in label state when search similar or save is used
       labelModalId: "label-input-form", // modal id
+      shouldSaveDataset: false, // There is not a not a nice way of denoting saving currently for the label view
       unsaveModalId: "unsaved-modal",
       labelName: "", // labelName of the variable being annotated in the label view
       labelNameState: null,


### PR DESCRIPTION
For the label workflow if a dataset is already saved and no annotations have happened the user can leave the workflow without the delete modal popping up
closes #3099