### PR TITLE
Tabular outlier failure

### DIFF
--- a/api/routes/outlier_detecting.go
+++ b/api/routes/outlier_detecting.go
@@ -66,7 +66,7 @@ func OutlierDetectionHandler(metaCtor api.MetadataStorageCtor) func(http.Respons
 		}
 
 		// get the metadata
-		datasetMeta, err := metaStorage.FetchDataset(dataset, false, false, false)
+		datasetMeta, err := metaStorage.FetchDataset(dataset, true, false, false)
 		if err != nil {
 			handleError(w, err)
 			return
@@ -113,7 +113,7 @@ func OutlierResultsHandler(metaCtor api.MetadataStorageCtor, dataCtor api.DataSt
 		}
 
 		// get the metadata
-		datasetMeta, err := metaStorage.FetchDataset(dataset, false, false, false)
+		datasetMeta, err := metaStorage.FetchDataset(dataset, true, false, false)
 		if err != nil {
 			handleError(w, err)
 			return

--- a/public/components/GeoPlot.vue
+++ b/public/components/GeoPlot.vue
@@ -205,8 +205,11 @@ export default Vue.extend({
 
   props: {
     instanceName: String as () => string,
-    dataItems: { type: Array as () => any[], default: [] },
-    baselineItems: { type: Array as () => TableRow[], default: [] },
+    dataItems: { type: Array as () => any[], default: Array as () => any[] },
+    baselineItems: {
+      type: Array as () => TableRow[],
+      default: Array as () => TableRow[],
+    },
     baselineMap: { type: Object as () => Dictionary<number>, default: null },
     dataFields: Object as () => Dictionary<TableColumn>,
     summaries: {


### PR DESCRIPTION
fixes #3113

d3mIndex wasn't included in the set of variables passed to outlier detection, causing the pipeline to fail at the construct predictions stage. 
