### PR TITLE
Prediction display name

### DIFF
--- a/api/task/prediction.go
+++ b/api/task/prediction.go
@@ -742,7 +742,8 @@ func persistPredictionResults(datasetName string, params *PredictParams, meta *m
 	}
 	log.Infof("stored feature weights to the database")
 
-	createdTime := time.Now()
+	createdTime := time.Now().UTC()
+
 	err := params.SolutionStorage.PersistPrediction(predictionResult.ProduceRequestID, datasetName, params.Target.Key, params.FittedSolutionID, "PREDICT_COMPLETED", createdTime)
 	if err != nil {
 		return err

--- a/public/components/PredictionSummaries.vue
+++ b/public/components/PredictionSummaries.vue
@@ -44,9 +44,9 @@
           <div class="prediction-group-body">
             <!-- we need the new facets in here-->
             <prediction-group
-              :confidenceSummary="meta.confidence"
-              :predictedSummary="meta.summary"
-              :rankingSummary="meta.rank"
+              :confidence-summary="meta.confidence"
+              :predicted-summary="meta.summary"
+              :ranking-summary="meta.rank"
               :highlights="highlights"
               :prediction="meta.prediction"
               @categorical-click="onCategoricalClick"
@@ -86,9 +86,9 @@
 
     <b-button
       v-if="includeFooter"
+      v-b-modal.export
       variant="primary"
       class="float-right mt-3"
-      v-b-modal.export
     >
       Export Predictions
     </b-button>
@@ -130,9 +130,6 @@
 
 <script lang="ts">
 import Vue from "vue";
-import FileUploader from "../components/FileUploader.vue";
-import FacetNumerical from "../components/facets/FacetNumerical.vue";
-import FacetCategorical from "../components/facets/FacetCategorical.vue";
 import PredictionGroup from "./PredictionGroup.vue";
 import { getters as routeGetters } from "../store/route/module";
 import { getters as requestGetters } from "../store/requests/module";
@@ -164,12 +161,9 @@ import moment from "moment";
 import { EventList } from "../util/events";
 
 export default Vue.extend({
-  name: "prediction-summaries",
+  name: "PredictionSummaries",
 
   components: {
-    FacetNumerical,
-    FacetCategorical,
-    FileUploader,
     PredictionGroup,
   },
   props: {
@@ -186,16 +180,6 @@ export default Vue.extend({
       datasetModelNameState: false,
       datasetExportNameState: null,
     };
-  },
-
-  watch: {
-    newDatasetName() {
-      if (this.newDatasetName !== null && this.newDatasetName.length > 0) {
-        this.datasetModelNameState = true;
-      } else {
-        this.datasetModelNameState = false;
-      }
-    },
   },
 
   computed: {
@@ -252,12 +236,23 @@ export default Vue.extend({
     rowSelection(): RowSelection {
       return routeGetters.getDecodedRowSelection(this.$store);
     },
+
     openSolution(): Map<string, boolean> {
       return new Map(
         routeGetters.getRouteOpenSolutions(this.$store).map((s) => {
           return [s, true];
         })
       );
+    },
+  },
+
+  watch: {
+    newDatasetName() {
+      if (this.newDatasetName !== null && this.newDatasetName.length > 0) {
+        this.datasetModelNameState = true;
+      } else {
+        this.datasetModelNameState = false;
+      }
     },
   },
 

--- a/public/components/PredictionSummaries.vue
+++ b/public/components/PredictionSummaries.vue
@@ -41,6 +41,9 @@
               />
             </div>
           </header>
+          <div class="prediction-group-datetime">
+            {{ predictionTimestamp(meta.summary.dataset) }}
+          </div>
           <div class="prediction-group-body">
             <!-- we need the new facets in here-->
             <prediction-group
@@ -264,6 +267,7 @@ export default Vue.extend({
         this.$emit(EventList.SUMMARIES.FETCH_SUMMARY_PREDICTION, requestId);
       }
     },
+
     onClick(key: string) {
       // Note that the key is of the form <requestId>:predicted and so needs to be parsed.
       const requestId = getIDFromKey(key);
@@ -480,6 +484,23 @@ export default Vue.extend({
         toaster: location,
       });
     },
+
+    predictionTimestamp(datasetName: string): string {
+      const timestamp = requestGetters
+        .getRelevantPredictions(this.$store)
+        .find((p) => p.dataset === datasetName).timestamp;
+      return new Date(Date.parse(timestamp)).toLocaleString(
+        navigator.language,
+        {
+          day: "numeric",
+          month: "long",
+          weekday: "short",
+          hour: "numeric",
+          minute: "numeric",
+          timeZoneName: "short",
+        }
+      );
+    },
   },
 });
 </script>
@@ -533,5 +554,10 @@ export default Vue.extend({
 }
 .prediction-group-container {
   max-height: 87%;
+}
+
+.prediction-group-datetime {
+  font-size: 75%;
+  color: var(--color-text-second);
 }
 </style>

--- a/public/store/requests/index.ts
+++ b/public/store/requests/index.ts
@@ -55,7 +55,7 @@ export interface Request {
   dataset: string;
   feature: string;
   features: Feature[];
-  timestamp: number;
+  timestamp: string;
 }
 
 // A request to start the process of training, fitting and scoring a model


### PR DESCRIPTION
fixes #3114 

The dataset names have been left to include the generated ID, but a line has been added to the prediction dataset header to capture the date/time it was created:

![image](https://user-images.githubusercontent.com/8959554/142573517-0ddf7652-5901-4c2f-915d-e28872f7e993.png)
