### PR TITLE
emit event to trigger result fetch

### DIFF
--- a/public/components/ResultGroup.vue
+++ b/public/components/ResultGroup.vue
@@ -468,6 +468,9 @@ export default Vue.extend({
         !this.isOpenInRoute)
     ) {
       reviseOpenSolutions(this.requestId, this.$route, this.$router);
+      if (this.isOpenInRoute) {
+        this.$emit(EventList.SUMMARIES.FETCH_SUMMARY_SOLUTION, this.requestId);
+      }
     }
   },
   watch: {


### PR DESCRIPTION
fixes #3112 

There is no longer a watcher on the route, so we need to emit an event to trigger a fetch of the model results.