### PR TITLE
Label edit annotation mapping

### DIFF
--- a/api/task/query.go
+++ b/api/task/query.go
@@ -42,6 +42,18 @@ const (
 	queryCacheAppend = "query-cache"
 )
 
+// query annotation value map
+var valueMap map[string]int
+
+func init() {
+	valueMap = map[string]int{
+		"":          -1,
+		"unlabeled": -1,
+		"negative":  0,
+		"positive":  1,
+	}
+}
+
 // QueryParams helper struct to simplify query task calling.
 type QueryParams struct {
 	Dataset     string
@@ -181,7 +193,6 @@ func extractQueryDataset(targetName string, data [][]string) [][]string {
 	targetIndex, d3mIndex := getColumnIndices(targetName, data)
 
 	// need to reduce to 1 row / d3m index (labels should match across the whole group)
-	valueMap := map[string]int{"unlabeled": -1, "negative": 0, "positive": 1}
 	reducedData := map[string]string{}
 	dataToStore := [][]string{{model.D3MIndexFieldName, queryFieldName}}
 	for i := 1; i < len(data); i++ {


### PR DESCRIPTION
Annotations were being incorrectly mapped from loaded data values to the annotation values expected by the primitive (-1, 0, 1) in the case that the label was being updated.  When the dataset is saved we replace the `unlabeled` tag with an empty string for downstream compatibility, but the map that translated from the label values to the primitive annotation values only expected `unlabeled`.
